### PR TITLE
Add a shimming scenario script under /examples

### DIFF
--- a/examples/volume_RT_shim_respiratory.py
+++ b/examples/volume_RT_shim_respiratory.py
@@ -1,18 +1,4 @@
-# Context: this is blablabla
-# Things to consider:
-# - with this large refactoring, we should try to accommodate Jason's current code
-# - log file should be created for each action.
-#   - should we use Matlab's diary()?
-#   - if so, is there a way to configure an output log file at the beginning of a process, and then pass the log handler across functions?
-# - when useful, plottings, etc. will appear.
-# - conventions:
-#   - variable: mixedCamelCase
-#     - images: start with "img", example: imgFieldmapMag
-#   - functions: snake_convention
-#     - use "action", then "what"
-# - use nifti-based software
-#   - ANTs: great for registration, interpolation (fast!)
-#
+# Context: That scripts covers a volume-wise realtime shimming with respiratory probe scenario 
 #
 # Sort unorganized images from DICOM socket transfer
 # dcm2bids is used to create folder structure and nifti conversion
@@ -27,32 +13,32 @@
 # > phase = load_niftis( niftiPath ) 5D array (x, y, z, nEcho, nAcq)
 #
 # Convert to complex
-# complexArray = mag.*exp( 1i.*phase ); 5D array (x, y, z, nEcho, nAcq)
+# > complexArray = mag.*exp( 1i.*phase ); 5D array (x, y, z, nEcho, nAcq)
 #
 # Compute B0 fieldmap
 # b0FieldMaps could be 2d, 3d or 4d. 4th dimension is the time in [s] (i.e. one B0 per timestamp).
 # JCA: OK for s as unit?
 # Note: the function should accommodate multiple fieldmap data (one per time point, in case of realtime shimming scenario)
-# unwrappedPhase = unwrap.unwrap_phase( complexArray, unwrapFunction )
-# b0FieldMaps = mapping( unwrappedPhase, echoTimes, mappingFunction )
+# > unwrappedPhase = unwrap.unwrap_phase( complexArray, unwrapFunction )
+# > b0FieldMaps = mapping( unwrappedPhase, echoTimes, mappingFunction )
 #
 # Load Siemens respiratory probe trace
 # JCA: it would be nice to have the file "acdc45/probe02.resp" copied in this folder automatically, so everything pertaining to this experiment is at the same location.
 # pmu is an object with useful properties.
-# pmu = load_probe_data(fullfile(pathNifti, 'probe02.resp'));
+# > pmu = load_probe_data(fullfile(pathNifti, 'probe02.resp'));
 #
 # Interpolate pmu to the image times
 # JCA: Do we want the function below to output an object pmuInterp or do we want to keep the current behaviour: include pmu information inside "Field" object?
 # pmuTrace is a vector
-# pmuTrace = match_probe_data_with_image(pmu, imgB0);
+# > pmuTrace = match_probe_data_with_image(pmu, imgB0);
 #
 # Load T2w magnitude image for segmentation
-# imgAnat = load_niftis(fullfile(pathNifti, '04-T2w.nii'));
+# > imgAnat = load_niftis(fullfile(pathNifti, '04-T2w.nii'));
 #
 # Segment ROI
-# paramSeg.betParamDummy = XX  some params for FSL BET function
-# paramSeg.sctDiameter = 30  in mm
-# roi = segment_image(imgAnat, method={'bet', 'sct', 'cylinder'}, paramSeg)
+# > paramSeg.betParamDummy = XX  # some params for FSL BET function
+# > paramSeg.sctDiameter = 30  # in mm
+# > roi = segment_image(imgAnat, method={'bet', 'sct', 'cylinder'}, paramSeg)
 #
 # Optimize shim currents
 # JCA: ShimOpt will use imgAnat as the destination target for regridding b0FieldMaps into the destination space. Also, if a segmentation exists in roi, it will use it to optimize shim currents.
@@ -61,10 +47,10 @@
 # another suggestion is to specify the algo type in the function itself
 # Coil sensitivity WIP
 # Output : (x y z channels)
-# coil = generate_coil(‘Nibardo’, [x y z])
+# > coil = generate_coil(‘Nibardo’, [x y z])
 #
 # WIP
-# shims = optimize_shim_algo(b0FieldMaps, coil, method=‘realtimeZShim’, roi (optional), PMU (optional), etc.)
+# > shims = optimize_shim_algo(b0FieldMaps, coil, method=‘realtimeZShim’, roi (optional), PMU (optional), etc.)
 #
 # Set shims to scanner or coil WIP
-# send_shim(shims, SyngoPath)
+# > send_shim(shims, SyngoPath)

--- a/examples/volume_RT_shim_respiratory.py
+++ b/examples/volume_RT_shim_respiratory.py
@@ -1,3 +1,4 @@
+# Context: this is blablabla
 # Things to consider:
 # - with this large refactoring, we should try to accommodate Jason's current code
 # - log file should be created for each action.
@@ -17,13 +18,13 @@
 # dcm2bids is used to create folder structure and nifti conversion
 # unsortedDicomDir: path to the folder containing the dicoms
 # niftiPath: path where we want dcm2bids to store the nifti files
-# dicom_to_nifti( unsortedDicomDir, niftiPath )
-#
+# 
+# > dicom_to_nifti( unsortedDicomDir, niftiPath )
 #
 # Load images from the path
 # Using niftiPath will prompt the user to select the appropriate acquisition. Alternatively, if the path to the acquisition is known, the path can be changed and the function won't prompt the user
-# mag = load_niftis( niftiPath ) 5D array (x, y, z, nEcho, nAcq)
-# phase = load_niftis( niftiPath ) 5D array (x, y, z, nEcho, nAcq)
+# > mag = load_niftis( niftiPath ) 5D array (x, y, z, nEcho, nAcq)
+# > phase = load_niftis( niftiPath ) 5D array (x, y, z, nEcho, nAcq)
 #
 # Convert to complex
 # complexArray = mag.*exp( 1i.*phase ); 5D array (x, y, z, nEcho, nAcq)

--- a/examples/volume_RT_shim_respiratory.py
+++ b/examples/volume_RT_shim_respiratory.py
@@ -2,42 +2,45 @@
 #
 # Sort unorganized images from DICOM socket transfer
 # dcm2bids is used to create folder structure and nifti conversion
-# unsortedDicomDir: path to the folder containing the dicoms
-# niftiPath: path where we want dcm2bids to store the nifti files
+# unsorted_dicom_dir: path to the folder containing the dicoms
+# nifti_path: path where we want dcm2bids to store the nifti files
 # 
-# > dicom_to_nifti( unsortedDicomDir, niftiPath )
+# > dicom_to_nifti( unsorted_dicom_dir, nifti_path )
 #
 # Load images from the path
-# Using niftiPath will prompt the user to select the appropriate acquisition. Alternatively, if the path to the acquisition is known, the path can be changed and the function won't prompt the user
-# > mag = load_niftis( niftiPath ) 5D array (x, y, z, nEcho, nAcq)
-# > phase = load_niftis( niftiPath ) 5D array (x, y, z, nEcho, nAcq)
+# Using nifti_path will prompt the user to select the appropriate acquisition. Alternatively, if the path to the acquisition is known, the path can be changed and the function won't prompt the user
+# > mag = load_niftis( nifti_path ) 
+# > phase = load_niftis( nifti_path )
+# 5D arrays (x, y, z, nEcho, nAcq)
 #
 # Convert to complex
-# > complexArray = mag.*exp( 1i.*phase ); 5D array (x, y, z, nEcho, nAcq)
+# > complex_array = mag.*exp( 1i.*phase ); 5D array (x, y, z, nEcho, nAcq)
 #
-# Compute B0 fieldmap
-# b0FieldMaps could be 2d, 3d or 4d. 4th dimension is the time in [s] (i.e. one B0 per timestamp).
+# Compute B0 fieldmaps
+# b0_field_maps could be 2d, 3d or 4d. 4th dimension is the time in [s] (i.e. one B0 per timestamp).
 # JCA: OK for s as unit?
 # Note: the function should accommodate multiple fieldmap data (one per time point, in case of realtime shimming scenario)
-# > unwrappedPhase = unwrap.unwrap_phase( complexArray, unwrapFunction )
-# > b0FieldMaps = mapping( unwrappedPhase, echoTimes, mappingFunction )
+# > unwrapped_phase = unwrap_phase( complex_array, unwrapping_function )
+# > b0_field_maps = mapping( unwrappedPhase, echoTimes, mapping_function )
 #
 # Load Siemens respiratory probe trace
 # JCA: it would be nice to have the file "acdc45/probe02.resp" copied in this folder automatically, so everything pertaining to this experiment is at the same location.
 # pmu is an object with useful properties.
-# > pmu = load_probe_data(fullfile(pathNifti, 'probe02.resp'));
+# > pmu = load_probe_data(fullfile(nifti_path, 'probe02.resp'));
 #
 # Interpolate pmu to the image times
 # JCA: Do we want the function below to output an object pmuInterp or do we want to keep the current behaviour: include pmu information inside "Field" object?
 # pmuTrace is a vector
-# > pmuTrace = match_probe_data_with_image(pmu, imgB0);
+# > pmu_trace = match_probe_data_with_image(pmu, imgB0);
 #
 # Load T2w magnitude image for segmentation
-# > imgAnat = load_niftis(fullfile(pathNifti, '04-T2w.nii'));
+# > imgAnat = load_niftis(fullfile(nifti_path, '04-T2w.nii'));
 #
 # Segment ROI
-# > paramSeg.betParamDummy = XX  # some params for FSL BET function
-# > paramSeg.sctDiameter = 30  # in mm
+# > param_seg.bet_param_dummy = XX
+# some params for FSL BET function
+# > param_seg.sct_diameter = 30
+# in mm
 # > roi = segment_image(imgAnat, method={'bet', 'sct', 'cylinder'}, paramSeg)
 #
 # Optimize shim currents
@@ -50,7 +53,7 @@
 # > coil = generate_coil(‘Nibardo’, [x y z])
 #
 # WIP
-# > shims = optimize_shim_algo(b0FieldMaps, coil, method=‘realtimeZShim’, roi (optional), PMU (optional), etc.)
+# > shims = optimize_shim_algo(b0_field_maps, coil, method=‘realtimeZShim’, roi (optional), PMU (optional), etc.)
 #
 # Set shims to scanner or coil WIP
-# > send_shim(shims, SyngoPath)
+# > send_shim(shims, syngo_path)

--- a/examples/volume_RT_shim_respiratory.py
+++ b/examples/volume_RT_shim_respiratory.py
@@ -1,60 +1,65 @@
 # Context: That scripts covers a volume-wise realtime shimming with respiratory probe scenario 
 #
-# Sort unorganized images from DICOM socket transfer
-# dcm2bids is used to create folder structure and nifti conversion
-# unsorted_dicom_dir: path to the folder containing the dicoms
-# nifti_path: path to the directory where we want dcm2bids to store the nifti files corresponding to the different acquisition
-# 
+# Sort unorganized images from DICOM socket transfer (this is how they are returned by the scanner)
+# dcm2bids is used to convert the dicoms into niftis following the BIDS convension and organize them into a folder structure (separating magnitude and phase)
+# unsorted_dicom_dir: path to the folder containing the unsorted dicoms
+# nifti_path: path to the directory where we want dcm2bids to store the nifti files corresponding to the different acquisitions
 # > dicom_to_nifti( unsorted_dicom_dir, nifti_path )
 #
-# Load images from the path
-# Using nifti_path will prompt the user to select the appropriate acquisition (stored in nifti_path)
+# Load nifti images from nifti_path
+# Using nifti_path will prompt the user to select the appropriate acquisition (by displaying the different acquisitions stored in nifti_path)
 # Alternatively, if the direct path to the acquisition is known, it can be directly use as an input and the function won't prompt the user
-# > mag = load_niftis( nifti_path ) 
-# > phase = load_niftis( nifti_path )
-# 5D arrays (x, y, z, nEcho, nAcq)
-#
-# Convert to complex
-# > complex_array = mag.*exp( 1i.*phase ); 5D array (x, y, z, nEcho, nAcq)
-#
-# Compute B0 fieldmaps
-# b0_field_maps could be 2d, 3d or 4d. 4th dimension is the time in [s] (i.e. one B0 per timestamp).
-# JCA: OK for s as unit?
-# Note: the function should accommodate multiple fieldmap data (one per time point, in case of realtime shimming scenario)
-# > unwrapped_phase = unwrap_phase( complex_array, unwrapping_function )
-# > b0_field_maps = mapping( unwrappedPhase, echoTimes, mapping_function )
-#
-# Load Siemens respiratory probe trace
-# JCA: it would be nice to have the file "acdc45/probe02.resp" copied in this folder automatically, so everything pertaining to this experiment is at the same location.
-# pmu is an object with useful properties.
-# > pmu = load_probe_data(fullfile(nifti_path, 'probe02.resp'));
-#
-# Interpolate pmu to the image times
-# JCA: Do we want the function below to output an object pmuInterp or do we want to keep the current behaviour: include pmu information inside "Field" object?
-# pmuTrace is a vector
-# > pmu_trace = match_probe_data_with_image(pmu, imgB0);
+# mag & phase : 5D arrays (x y z nEcho nAcq)
+# > mag = load_nii( nifti_path ) 
+# > phase = load_nii( nifti_path )
+# 
+# Convert into a complex 5D array (x y z nEcho nAcq)
+# > complex_array = np.multiply( mag, exp( phase*1j ) )
 #
 # Load T2w magnitude image for segmentation
-# > imgAnat = load_niftis(fullfile(nifti_path, '04-T2w.nii'));
+# > img_anat = load_niftis(os.path.join(nifti_path, '04-T2w.nii'))
 #
-# Segment ROI
-# > param_seg.bet_param_dummy = XX
-# some params for FSL BET function
-# > param_seg.sct_diameter = 30
-# in mm
-# > roi = segment_image(imgAnat, method={'bet', 'sct', 'cylinder'}, paramSeg)
+# Define the binary mask/ROI to shim
+# Note: get_masking_image might call segment_spinal_canal (automatic) or define_mask (manual)
+# masking_algo = defines what method will be used for ROI selection (manual selection, SCT, bet, cylinder...)
+# > shim_VOI = get_mask( img_anat, masking_algo )
 #
-# Optimize shim currents
-# JCA: ShimOpt will use imgAnat as the destination target for regridding b0FieldMaps into the destination space. Also, if a segmentation exists in roi, it will use it to optimize shim currents.
-# JCA: unclear to me "what" shims should be here (struct? object?).
-# Nick's suggestion is to explicit all parameters as function input (instead of using a structure of parameters)
-# another suggestion is to specify the algo type in the function itself
-# Coil sensitivity WIP
-# Output : (x y z channels)
+# Compute B0 fieldmaps
+# b0_fieldmap could be 2d, 3d or 4d. The 4th dimension being the time in [s] (i.e. one B0 per timestamp).
+# Note: the function should accommodate multiple fieldmap data (one per time point, in case of realtime shimming scenario)
+# Note: map_field calls b0_mappers and might call unwrap_phase if needed
+# threshold: sets the maximum frequency (Hz) value returned by map_field. If not defined, a default value is applied 
+# > b0_fieldmap = map_field( complex_array, mapping_algo, unwrapping_algo, mask (optional), threshold (optional) )
+#
+# Load Siemens respiratory probe trace
+# JCA: It would be nice to have the file "acdc45/probe02.resp" copied in this folder automatically, so everything pertaining to this experiment is at the same location.
+# pmu_data: object with properties corresponding to the pressure measurements vs time
+# > pmu_data = read_PMU( os.path.join( nifti_path, 'probe02.resp' ) )
+#
+# Interpolate pmu_data to the image times
+# JCA: Do we want the function below to output an object pmu_interp or do we want to keep the current behaviour: include pmu information inside "Field" object?
+# pmu_trace: vector
+# Note: interp_PMU will call get_acq_times that will read the json files in the nifti_path to fetch the different acquisition times
+# > pmu_trace = interp_PMU( pmu_data, nifti_path )
+#
+# Compute the respiration induced resonance offset
+# > riro = get_riro( pmu_trace, b0_fieldmap )
+#
+# Returns the optimised field image that will be used for the shim coefficients computation
+# > model_field( b0_fieldmap, riro )
+#
+# Coil sensitivity (WIP)
+# Output : (x, y, z, channels)
 # > coil = generate_coil(‘Nibardo’, [x y z])
 #
-# WIP
-# > shims = optimize_shim_algo(b0_field_maps, coil, method=‘realtimeZShim’, roi (optional), PMU (optional), etc.)
+# Optimize shim coefficients
+# JCA: Shim_opt will use img_anat as the destination target for regridding b0_fieldmap into the destination space. Also, if a segmentation exists in roi, it will use it to optimize shim currents.
+# Nick's suggestion is to explicit all parameters as function input (instead of using a structure of parameters). Another suggestion is to specify the algo type in the function itself
+# Note: b0_fieldmap must be resliced to match img_anat's x, y and z dimensions.
+# shims: need to define the variable type (matrix, text file...)
+# > b0_resliced = reslice( b0_fieldmap, img_anat)
+# > shims = shim_opt( b0_resliced, coil, method=‘realtimeZShim’, shim_VOI (optional), pmu_trace (optional), etc. )
 #
-# Set shims to scanner or coil WIP
-# > send_shim(shims, syngo_path)
+# Send the shimming coefficient to scanner or coil (WIP)
+# syngo_path: path to the folder where syngo reads the setting files
+# > send_shim( shims, syngo_path )

--- a/examples/volume_RT_shim_respiratory.py
+++ b/examples/volume_RT_shim_respiratory.py
@@ -1,0 +1,69 @@
+# Things to consider:
+# - with this large refactoring, we should try to accommodate Jason's current code
+# - log file should be created for each action.
+#   - should we use Matlab's diary()?
+#   - if so, is there a way to configure an output log file at the beginning of a process, and then pass the log handler across functions?
+# - when useful, plottings, etc. will appear.
+# - conventions:
+#   - variable: mixedCamelCase
+#     - images: start with "img", example: imgFieldmapMag
+#   - functions: snake_convention
+#     - use "action", then "what"
+# - use nifti-based software
+#   - ANTs: great for registration, interpolation (fast!)
+#
+#
+# Sort unorganized images from DICOM socket transfer
+# dcm2bids is used to create folder structure and nifti conversion
+# unsortedDicomDir: path to the folder containing the dicoms
+# niftiPath: path where we want dcm2bids to store the nifti files
+# dicom_to_nifti( unsortedDicomDir, niftiPath )
+#
+#
+# Load images from the path
+# Using niftiPath will prompt the user to select the appropriate acquisition. Alternatively, if the path to the acquisition is known, the path can be changed and the function won't prompt the user
+# mag = load_niftis( niftiPath ) 5D array (x, y, z, nEcho, nAcq)
+# phase = load_niftis( niftiPath ) 5D array (x, y, z, nEcho, nAcq)
+#
+# Convert to complex
+# complexArray = mag.*exp( 1i.*phase ); 5D array (x, y, z, nEcho, nAcq)
+#
+# Compute B0 fieldmap
+# b0FieldMaps could be 2d, 3d or 4d. 4th dimension is the time in [s] (i.e. one B0 per timestamp).
+# JCA: OK for s as unit?
+# Note: the function should accommodate multiple fieldmap data (one per time point, in case of realtime shimming scenario)
+# unwrappedPhase = unwrap.unwrap_phase( complexArray, unwrapFunction )
+# b0FieldMaps = mapping( unwrappedPhase, echoTimes, mappingFunction )
+#
+# Load Siemens respiratory probe trace
+# JCA: it would be nice to have the file "acdc45/probe02.resp" copied in this folder automatically, so everything pertaining to this experiment is at the same location.
+# pmu is an object with useful properties.
+# pmu = load_probe_data(fullfile(pathNifti, 'probe02.resp'));
+#
+# Interpolate pmu to the image times
+# JCA: Do we want the function below to output an object pmuInterp or do we want to keep the current behaviour: include pmu information inside "Field" object?
+# pmuTrace is a vector
+# pmuTrace = match_probe_data_with_image(pmu, imgB0);
+#
+# Load T2w magnitude image for segmentation
+# imgAnat = load_niftis(fullfile(pathNifti, '04-T2w.nii'));
+#
+# Segment ROI
+# paramSeg.betParamDummy = XX  some params for FSL BET function
+# paramSeg.sctDiameter = 30  in mm
+# roi = segment_image(imgAnat, method={'bet', 'sct', 'cylinder'}, paramSeg)
+#
+# Optimize shim currents
+# JCA: ShimOpt will use imgAnat as the destination target for regridding b0FieldMaps into the destination space. Also, if a segmentation exists in roi, it will use it to optimize shim currents.
+# JCA: unclear to me "what" shims should be here (struct? object?).
+# Nick's suggestion is to explicit all parameters as function input (instead of using a structure of parameters)
+# another suggestion is to specify the algo type in the function itself
+# Coil sensitivity WIP
+# Output : (x y z channels)
+# coil = generate_coil(‘Nibardo’, [x y z])
+#
+# WIP
+# shims = optimize_shim_algo(b0FieldMaps, coil, method=‘realtimeZShim’, roi (optional), PMU (optional), etc.)
+#
+# Set shims to scanner or coil WIP
+# send_shim(shims, SyngoPath)

--- a/examples/volume_RT_shim_respiratory.py
+++ b/examples/volume_RT_shim_respiratory.py
@@ -3,12 +3,13 @@
 # Sort unorganized images from DICOM socket transfer
 # dcm2bids is used to create folder structure and nifti conversion
 # unsorted_dicom_dir: path to the folder containing the dicoms
-# nifti_path: path where we want dcm2bids to store the nifti files
+# nifti_path: path to the directory where we want dcm2bids to store the nifti files corresponding to the different acquisition
 # 
 # > dicom_to_nifti( unsorted_dicom_dir, nifti_path )
 #
 # Load images from the path
-# Using nifti_path will prompt the user to select the appropriate acquisition. Alternatively, if the path to the acquisition is known, the path can be changed and the function won't prompt the user
+# Using nifti_path will prompt the user to select the appropriate acquisition (stored in nifti_path)
+# Alternatively, if the direct path to the acquisition is known, it can be directly use as an input and the function won't prompt the user
 # > mag = load_niftis( nifti_path ) 
 # > phase = load_niftis( nifti_path )
 # 5D arrays (x, y, z, nEcho, nAcq)


### PR DESCRIPTION
## Context
The 'shimming-toolbox' is designed to be used in different shimming scenarios (Slice-wise or Volume-wise, realtime or dynamic, with or without respiratory probe, with or without RF shimming...). 

These scenarios must describe all the different steps and functions required in each specific case. That will provide us a general overview of the project, help us organize our work and make the workflow easier to understand and to adapt. 

## Goal
Here we want to provide a [fully commented script](https://github.com/shimming-toolbox/shimming-toolbox-py/blob/gc/scenarios/examples/volume_RT_shim_respiratory.py) containing all the  different steps of a scenario. That file will allow us to keep track of the different functions we need to create/update to complete that scenario. 

Once these different functions will be implemented, we will be able to just uncomment them in the file (thus turning it into a functional script). This will be covered in subsequent pull requests.

Fixes #8 