### PR TITLE
Source package version from setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup, find_packages
 from os import path
 
-import shimmingtoolbox
-
 # Get the directory where this current file is saved
 here = path.abspath(path.dirname(__file__))
 
@@ -12,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 setup(
     name="shimmingtoolbox",
     python_requires=">=3.6",
-    version=shimmingtoolbox.__version__,
+    version="0.1.0",
     description="Code for performing real-time shimming using external MRI shim coils",
     long_description=long_description,
     url="https://github.com/shimming-toolbox/shimming-toolbox-py",
@@ -22,6 +20,7 @@ setup(
     packages=find_packages(exclude=["contrib", "docs", "tests"]),
     install_requires=[
         #"numpy~=1.16.0",
+        'importlib-metadata ~= 1.0 ; python_version < "3.8"',
     ],
     extras_require={
         'testing': ["pytest~=4.6.3", "pytest-cov~=2.5.1"]

--- a/shimmingtoolbox/__init__.py
+++ b/shimmingtoolbox/__init__.py
@@ -1,1 +1,9 @@
-__version__ = "0.1"
+
+# https://packaging.python.org/guides/single-sourcing-package-version/
+try:
+    from importlib import metadata
+except ImportError:
+    # Running on pre-3.8 Python; use importlib-metadata package
+    import importlib_metadata as metadata
+__version__ = metadata.version(__name__)
+del metadata


### PR DESCRIPTION
This avoids a tricky chicken-or-egg problem:
as soon as `shimmingtoolbox/__init__.py` starts loading up
submodules, which are going to load up libraries,
installation will fail because setup.py was doing

> import shimmingtoolbox

at the top, just to get at

> shimmingtoolbox.__version__

and of course when setup.py is run, none of the
libraries we need will be installed yet.

This is mentioned on https://packaging.python.org/guides/single-sourcing-package-version/

> Warning
>
> Although this technique is common, beware that it will fail if sample/__init__.py
> imports packages from install_requires dependencies, which will very likely not
> be installed yet when setup.py is run.

and after looking through that page, I decided that using importlib.metadata
is the future-proofed option.

(Editorializing: I really wish PyPA would stick to the Zen of Python's admonishment
to "There should be one obvious way to do it."; but the first thing this page says is
"There are many techniques" and the best is buried as #5)