### PR TITLE
Install dcm2niix in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: bionic
 language: python
 python:
   - "3.7"
@@ -5,6 +7,8 @@ python:
 # command to install dependencies
 install:
   - echo "Installation of the repository"
+  - sudo apt-get update
+  - sudo apt-get install -y dcm2niix
   - pip install -e .[testing]
   - pip install python-coveralls  # Add me to install python-coveralls
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install -y dcm2niix
   - pip install -e .[testing]
-  - pip install python-coveralls  # Add me to install python-coveralls
+  - pip install python-coveralls
 # command to run tests
 script:
   - echo "Launch general integrity test"


### PR DESCRIPTION
Fixes #27

This upgrades the CI environment from Ubuntu 16.04 LTS (which is Very Old now) to 18.04 (which is Current Boring Mainline), because 16.04 is too old to have dcm2niix available, but 18.04 does and is probably closer to what most people are running anyway!