### PR TITLE
Avoid double-building CI on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: python
 python:
   - "3.7"
+  
+# limit tested branches
+# branches with PRs will only be tested once via https://docs.travis-ci.com/user/pull-requests,
+#  instead of twice: https://docs.travis-ci.com/user/pull-requests#double-builds-on-pull-requests
+# and master will be tested after merges as a double-check
+branches:
+  only:
+  - master
 
 # command to install dependencies
 install:


### PR DESCRIPTION
This integrates @Drulex's idea from https://github.com/neuropoly/spinalcordtoolbox/issues/2674#issuecomment-659622200

If you watch this PR's test run, you'll see it only has 1 check instead of 2, which makes more sense because both checks are running identical code. The only time they're different is if the merge with `master` a. is not a simple linear rebase (#14) and b. the merge is complicated enough that git's heuristics get the merge wrong somehow, but without detecting a conflict.

I think this setting should be the Travis default.