### PR TITLE
[docs][API reference] Replace Autodoc with Napoleon

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,10 +32,10 @@ author = "NeuroPoly Lab, Polytechnique Montreal"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.githubpages", "sphinx.ext.autodoc"]
+extensions = ["sphinx.ext.githubpages", "sphinx.ext.napoleon"]
 
 # Autodoc configuration
-autodoc_mock_imports=[
+autodoc_mock_imports = [
     "click",
     "importlib-metadata",
     "numpy",
@@ -43,7 +43,7 @@ autodoc_mock_imports=[
     "nibabel",
     "requests",
     "scipy",
-    "tqdm"
+    "tqdm",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
**Why this change was necessary**
Sphinx's default Autodoc does not recognize Google style docstrings
and throws warnings when autogenerating API documentation.

**What this change does**
Replaces Sphinx's default Autodoc extension with Napoleon.

**Additional context/notes/links**

Resolves: #55
Related to: #53 (partially resolves), #54 (partially resolves)

See also:
https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
https://github.com/shimming-toolbox/shimming-toolbox-py/pull/56#issuecomment-667320630