### PR TITLE
[docs][fix] Add documentation dependency installation steps

### DIFF
--- a/docs/source/2_getting_started/1_installation.rst
+++ b/docs/source/2_getting_started/1_installation.rst
@@ -159,7 +159,7 @@ that you followed the ``git clone`` instruction above:
 .. code:: bash
 
    cd shimming-toolbox
-   pip install -e ".[testing]"
+   pip install -e ".[testing,docs]"
 
 .. NOTE ::
    If you downloaded shimming-toolbox using the link above
@@ -178,7 +178,7 @@ version of the project from GitHub and reinstall the application:
 
    cd shimming-toolbox
    git pull
-   pip install -e ".[testing]"
+   pip install -e ".[testing,docs]"
 
 Testing the installation
 ------------------------


### PR DESCRIPTION
**Why this change was necessary**
The develop installation instructions did not include the
documentation dependencies.

**What this change does**
Adds `docs` to the `pip` installation instructions.

**Any side-effects?**
None

**Additional context/notes/links**

Resolves: #61