### PR TITLE
Read B1 maps

### DIFF
--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -156,18 +156,10 @@
         },
         {
             "dataType": "TB1map",
-            "modalityLabel": "TB1map_mag",
+            "modalityLabel": "TB1map",
             "criteria": {
                 "SeriesDescription": "standard",
                 "ImageComments": "flip_angle_map*"
-            }
-        },
-        {
-            "dataType": "TB1map",
-            "modalityLabel": "TB1map_phase",
-            "criteria": {
-                "SeriesDescription": "standard",
-                "ImageComments": "*phase*"
             }
         }
     ]

--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -155,16 +155,16 @@
             }
         },
         {
-            "dataType": "rfmap",
-            "modalityLabel": "rfmap_mag",
+            "dataType": "TB1map",
+            "modalityLabel": "TB1map_mag",
             "criteria": {
                 "SeriesDescription": "standard",
                 "ImageComments": "flip_angle_map*"
             }
         },
         {
-            "dataType": "rfmap",
-            "modalityLabel": "rfmap_phase",
+            "dataType": "TB1map",
+            "modalityLabel": "TB1map_phase",
             "criteria": {
                 "SeriesDescription": "standard",
                 "ImageComments": "*phase*"

--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -153,6 +153,22 @@
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "6"
             }
+        },
+        {
+            "dataType": "rfmap",
+            "modalityLabel": "rfmap_mag",
+            "criteria": {
+                "SeriesDescription": "standard",
+                "ImageComments": "flip_angle_map*"
+            }
+        },
+        {
+            "dataType": "rfmap",
+            "modalityLabel": "rfmap_phase",
+            "criteria": {
+                "SeriesDescription": "standard",
+                "ImageComments": "*phase*"
+            }
         }
     ]
 }

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -7,7 +7,7 @@ import click
 from shimmingtoolbox.download import install_data
 
 dict_url = {
-    "testing_data": ["https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"],
+    "testing_data": ["https://github.com/shimming-toolbox/data-testing/archive/r20200806.zip"],
     "prelude": ["https://github.com/shimming-toolbox/binaries/raw/master/prelude"]
 }
 

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -9,32 +9,41 @@ from shimmingtoolbox import __dir_config_dcm2bids__
 
 
 def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__,
-                   special_dicom = False):
+                   special_dicom=[]):
     """ Converts dicom files into nifti files by calling dcm2bids
 
     Args:
         path_dicom (str): path to the input dicom folder
         path_nifti (str): path to the output nifti folder
-
+        subject_id (str): ID of subject
+        path_config_dcm2bids (str): Path to dcm2bids.json file
+        special_dicom (:obj:`list` of :obj:`str`): List of modalities for which the output NIFTI from dcm2niix should
+        be half-split along the last dimension.
     """
-    # Case where the DICOM files have
-    if special_dicom:
-        with tempfile.TemporaryDirectory(prefix='st_mag_') as tmp_mag:
-            dicom_number = len(os.listdir(path_dicom))
-            dicom_list = os.listdir(path_dicom)
-            for i in range(int(dicom_number/2)):
-                shutil.copy(os.path.join(path_dicom, dicom_list[i]), tmp_mag)
-            cmd = f'dcm2bids -d {tmp_mag} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
-            subprocess.run(cmd.split(' '))
+    # # Case where the DICOM files have
+    # if special_dicom:
+    #     with tempfile.TemporaryDirectory(prefix='st_mag_') as tmp_mag:
+    #         dicom_number = len(os.listdir(path_dicom))
+    #         dicom_list = os.listdir(path_dicom)
+    #         for i in range(int(dicom_number/2)):
+    #             shutil.copy(os.path.join(path_dicom, dicom_list[i]), tmp_mag)
+    #         cmd = f'dcm2bids -d {tmp_mag} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
+    #         subprocess.run(cmd.split(' '))
+    #
+    #     with tempfile.TemporaryDirectory(prefix='st_mag_') as tmp_phase:
+    #         dicom_number = len(os.listdir(path_dicom))
+    #         dicom_list = os.listdir(path_dicom)
+    #         for i in range(int(dicom_number/2), int(dicom_number)):
+    #             shutil.copy(os.path.join(path_dicom, dicom_list[i]), tmp_phase)
+    #         cmd = f'dcm2bids -d {tmp_phase} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
+    #         subprocess.run(cmd.split(' '))
+    #
+    # else:
+    cmd = f'dcm2bids -d {path_dicom} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
+    subprocess.run(cmd.split(' '))
 
-        with tempfile.TemporaryDirectory(prefix='st_mag_') as tmp_phase:
-            dicom_number = len(os.listdir(path_dicom))
-            dicom_list = os.listdir(path_dicom)
-            for i in range(int(dicom_number/2), int(dicom_number)):
-                shutil.copy(os.path.join(path_dicom, dicom_list[i]), tmp_phase)
-            cmd = f'dcm2bids -d {tmp_phase} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
-            subprocess.run(cmd.split(' '))
-
-    else:
-        cmd = f'dcm2bids -d {path_dicom} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
-        subprocess.run(cmd.split(' '))
+    # If output nifti needs to be split along the last dimension. This could happen if there is not enough information
+    # in the input dicom data.
+    # TODO: assert input special_dicom
+    if special_dicom is not []:
+        a=1

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -1,15 +1,17 @@
 # coding: utf-8
 
+import json
+import nibabel as nib
+import numpy as np
 import os
 import subprocess
 import shutil
-import tempfile
 
 from shimmingtoolbox import __dir_config_dcm2bids__
 
 
 def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__,
-                   special_dicom=[]):
+                   special_dicom=''):
     """ Converts dicom files into nifti files by calling dcm2bids
 
     Args:
@@ -17,33 +19,40 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
         path_nifti (str): path to the output nifti folder
         subject_id (str): ID of subject
         path_config_dcm2bids (str): Path to dcm2bids.json file
-        special_dicom (:obj:`list` of :obj:`str`): List of modalities for which the output NIFTI from dcm2niix should
-        be half-split along the last dimension.
+        special_dicom (str): Name of the modality for which the output NIFTI from dcm2niix should
+        be half-split along the last dimension. Available values: 'TB1map'.
     """
-    # # Case where the DICOM files have
-    # if special_dicom:
-    #     with tempfile.TemporaryDirectory(prefix='st_mag_') as tmp_mag:
-    #         dicom_number = len(os.listdir(path_dicom))
-    #         dicom_list = os.listdir(path_dicom)
-    #         for i in range(int(dicom_number/2)):
-    #             shutil.copy(os.path.join(path_dicom, dicom_list[i]), tmp_mag)
-    #         cmd = f'dcm2bids -d {tmp_mag} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
-    #         subprocess.run(cmd.split(' '))
-    #
-    #     with tempfile.TemporaryDirectory(prefix='st_mag_') as tmp_phase:
-    #         dicom_number = len(os.listdir(path_dicom))
-    #         dicom_list = os.listdir(path_dicom)
-    #         for i in range(int(dicom_number/2), int(dicom_number)):
-    #             shutil.copy(os.path.join(path_dicom, dicom_list[i]), tmp_phase)
-    #         cmd = f'dcm2bids -d {tmp_phase} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
-    #         subprocess.run(cmd.split(' '))
-    #
-    # else:
+
     cmd = f'dcm2bids -d {path_dicom} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
     subprocess.run(cmd.split(' '))
 
     # If output nifti needs to be split along the last dimension. This could happen if there is not enough information
     # in the input dicom data.
-    # TODO: assert input special_dicom
-    if special_dicom is not []:
-        a=1
+    if special_dicom != '':
+        list_special_dicom = ['TB1map']
+        assert special_dicom in list_special_dicom, f'The specified special_dicom name is invalid.' \
+                                                    f' Available names: {list_special_dicom}'
+        path_complete = os.path.join(path_nifti, subject_id, special_dicom, f'{subject_id}_{special_dicom}')
+        nifti = nib.load(path_complete + '.nii.gz')
+        nifti_image = nifti.get_fdata()
+        n_coils = nifti_image.shape[3]
+        image_mag = nib.Nifti2Image(nifti_image[:, :, :, :int(n_coils/2)], np.eye(4))
+        image_phase = nib.Nifti2Image(nifti_image[:, :, :, int(n_coils/2):], np.eye(4))
+        with open(path_complete + '.json') as json_file:
+            json_mag = json_phase = json.load(json_file)
+        json_mag['ImageComments'] = 'magnitude'
+        json_phase['ImageComments'] = 'phase'
+        # Create the magnitude NIfTI
+        nib.save(image_mag, path_complete + '_mag.nii.gz')
+        # Create json sidecar for the magnitude NIfTI
+        with open(path_complete + '_mag.json', 'w') as json_mag_file:
+            json.dump(json_mag, json_mag_file, indent=4, sort_keys=True)
+        # Create the phase NIfTI
+        nib.save(image_phase, path_complete + '_phase.nii.gz')
+        # Create json sidecar for the phase NIfTI
+        with open(path_complete + '_phase.json', 'w') as json_phase_file:
+            json.dump(json_phase, json_phase_file, indent=4, sort_keys=True)
+        # Delete original json file
+        os.remove(path_complete + '.json')
+        # Delete original nifti file
+        os.remove(path_complete + '.nii.gz')

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -1,13 +1,15 @@
 # coding: utf-8
 
-# TODO: check in unit test if dcm2bids_scaffold is installed, and also check for the required version.
-
+import os
 import subprocess
+import shutil
+import tempfile
 
 from shimmingtoolbox import __dir_config_dcm2bids__
 
 
-def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__):
+def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__,
+                   special_dicom = False):
     """ Converts dicom files into nifti files by calling dcm2bids
 
     Args:
@@ -15,6 +17,26 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
         path_nifti (str): path to the output nifti folder
 
     """
-    cmd = 'dcm2bids -d {} -p {} -o {} -l DEBUG -c {}'.format(
-        path_dicom, subject_id, path_nifti, path_config_dcm2bids)
-    subprocess.run(cmd.split(' '))
+    if special_dicom:
+        with tempfile.TemporaryDirectory(prefix='st_mag_') as tmp_mag:
+            dicom_number = len(os.listdir(path_dicom))
+            dicom_list = os.listdir(path_dicom)
+            for i in range(int(dicom_number/2)):
+                shutil.copy(os.path.join(path_dicom, dicom_list[i]), tmp_mag)
+            cmd = 'dcm2bids -d {} -p {} -o {} -l DEBUG -c {}'.format(
+                tmp_mag, subject_id, path_nifti, path_config_dcm2bids)
+            subprocess.run(cmd.split(' '))
+
+        with tempfile.TemporaryDirectory(prefix='st_mag_') as tmp_phase:
+            dicom_number = len(os.listdir(path_dicom))
+            dicom_list = os.listdir(path_dicom)
+            for i in range(int(dicom_number/2), int(dicom_number)):
+                shutil.copy(os.path.join(path_dicom, dicom_list[i]), tmp_phase)
+            cmd = 'dcm2bids -d {} -p {} -o {} -l DEBUG -c {}'.format(
+                tmp_phase, subject_id, path_nifti, path_config_dcm2bids)
+            subprocess.run(cmd.split(' '))
+
+    else:
+        cmd = 'dcm2bids -d {} -p {} -o {} -l DEBUG -c {}'.format(
+            path_dicom, subject_id, path_nifti, path_config_dcm2bids)
+        subprocess.run(cmd.split(' '))

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -17,14 +17,14 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
         path_nifti (str): path to the output nifti folder
 
     """
+    # Case where the DICOM files have
     if special_dicom:
         with tempfile.TemporaryDirectory(prefix='st_mag_') as tmp_mag:
             dicom_number = len(os.listdir(path_dicom))
             dicom_list = os.listdir(path_dicom)
             for i in range(int(dicom_number/2)):
                 shutil.copy(os.path.join(path_dicom, dicom_list[i]), tmp_mag)
-            cmd = 'dcm2bids -d {} -p {} -o {} -l DEBUG -c {}'.format(
-                tmp_mag, subject_id, path_nifti, path_config_dcm2bids)
+            cmd = f'dcm2bids -d {tmp_mag} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
             subprocess.run(cmd.split(' '))
 
         with tempfile.TemporaryDirectory(prefix='st_mag_') as tmp_phase:
@@ -32,11 +32,9 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
             dicom_list = os.listdir(path_dicom)
             for i in range(int(dicom_number/2), int(dicom_number)):
                 shutil.copy(os.path.join(path_dicom, dicom_list[i]), tmp_phase)
-            cmd = 'dcm2bids -d {} -p {} -o {} -l DEBUG -c {}'.format(
-                tmp_phase, subject_id, path_nifti, path_config_dcm2bids)
+            cmd = f'dcm2bids -d {tmp_phase} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
             subprocess.run(cmd.split(' '))
 
     else:
-        cmd = 'dcm2bids -d {} -p {} -o {} -l DEBUG -c {}'.format(
-            path_dicom, subject_id, path_nifti, path_config_dcm2bids)
+        cmd = f'dcm2bids -d {path_dicom} -p {subject_id} -o {path_nifti} -l DEBUG -c {path_config_dcm2bids}'
         subprocess.run(cmd.split(' '))

--- a/shimmingtoolbox/download.py
+++ b/shimmingtoolbox/download.py
@@ -92,7 +92,7 @@ def unzip(compressed, dest_folder):
         if compressed.lower().endswith(format):
             break
     else:
-        logger.info('File extension is not included in {}'.format(formats.keys()))
+        logger.info(f'File extension is not included in {formats.keys()}')
         shutil.copy(compressed, dest_folder)
         return
 

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -13,7 +13,9 @@ def test_dicom_to_nifti():
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        dicom_to_nifti(__dir_testing__, path_nifti, subject_id=subject_id)
+        # Conversion of the B0 mapping dicoms
+        dicom_to_nifti(os.path.join(__dir_testing__, 'dicom_unsorted'), path_nifti, subject_id=subject_id)
+
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.
         for i in range(1, 7):
@@ -21,3 +23,10 @@ def test_dicom_to_nifti():
                 for ext in ['nii.gz', 'json']:
                     assert os.path.exists(os.path.join(path_nifti, subject_id, 'fmap', subject_id + '_{}{}.{}'.format(
                         modality, i, ext)))
+
+        # Conversion of the RF maps
+        dicom_to_nifti(os.path.join(__dir_testing__, 'b1_maps'), path_nifti, subject_id=subject_id, special_dicom=True)
+        for modality in ['phase', 'mag']:
+            for ext in ['nii.gz', 'json']:
+                assert os.path.exists(os.path.join(path_nifti, subject_id, 'rfmap',
+                                                   subject_id + '_rfmap_{}.{}'.format(modality, ext)))

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -35,8 +35,8 @@ def test_dicom_to_nifti_b1map():
         subject_id = 'sub-test'
 
         # Conversion of the RF maps
-        dicom_to_nifti(os.path.join(__dir_testing__, 'b1_maps'), path_nifti, subject_id=subject_id, special_dicom=['TB1map'])
+        dicom_to_nifti(os.path.join(__dir_testing__, 'b1_maps'), path_nifti, subject_id=subject_id, special_dicom='TB1map')
         for modality in ['phase', 'mag']:
             for ext in ['nii.gz', 'json']:
-                assert os.path.exists(os.path.join(path_nifti, subject_id, 'rfmap',
-                                                   subject_id + f'_rfmap_{modality}.{ext}'))
+                assert os.path.exists(os.path.join(path_nifti, subject_id, 'TB1map',
+                                                   subject_id + f'_TB1map_{modality}.{ext}'))

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -21,12 +21,12 @@ def test_dicom_to_nifti():
         for i in range(1, 7):
             for modality in ['phase', 'magnitude']:
                 for ext in ['nii.gz', 'json']:
-                    assert os.path.exists(os.path.join(path_nifti, subject_id, 'fmap', subject_id + '_{}{}.{}'.format(
-                        modality, i, ext)))
+                    assert os.path.exists(os.path.join(path_nifti, subject_id, 'fmap',
+                                                       subject_id + f'_{modality}{i}.{ext}'))
 
         # Conversion of the RF maps
         dicom_to_nifti(os.path.join(__dir_testing__, 'b1_maps'), path_nifti, subject_id=subject_id, special_dicom=True)
         for modality in ['phase', 'mag']:
             for ext in ['nii.gz', 'json']:
                 assert os.path.exists(os.path.join(path_nifti, subject_id, 'rfmap',
-                                                   subject_id + '_rfmap_{}.{}'.format(modality, ext)))
+                                                   subject_id + f'_rfmap_{modality}.{ext}'))

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -8,7 +8,7 @@ from shimmingtoolbox.dicom_to_nifti import dicom_to_nifti
 from shimmingtoolbox import __dir_testing__
 
 
-def test_dicom_to_nifti():
+def test_dicom_to_nifti_unsorted():
     # TODO: put as decorator
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
@@ -24,8 +24,18 @@ def test_dicom_to_nifti():
                     assert os.path.exists(os.path.join(path_nifti, subject_id, 'fmap',
                                                        subject_id + f'_{modality}{i}.{ext}'))
 
+
+def test_dicom_to_nifti_b1map():
+    """"
+    Test special cases of DICOM files that don't have enough information to be properly converted by dcm2niix.
+    More details at: https://github.com/shimming-toolbox/shimming-toolbox-py/issues/58
+    """
+    with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
+        path_nifti = os.path.join(tmp, 'nifti')
+        subject_id = 'sub-test'
+
         # Conversion of the RF maps
-        dicom_to_nifti(os.path.join(__dir_testing__, 'b1_maps'), path_nifti, subject_id=subject_id, special_dicom=True)
+        dicom_to_nifti(os.path.join(__dir_testing__, 'b1_maps'), path_nifti, subject_id=subject_id, special_dicom=['TB1map'])
         for modality in ['phase', 'mag']:
             for ext in ['nii.gz', 'json']:
                 assert os.path.exists(os.path.join(path_nifti, subject_id, 'rfmap',


### PR DESCRIPTION
## Context
The RF maps are here directly measured by the scanner that returns them as `DICOM` files. We then want to convert these `DICOM` files to the `NIfTI` format with respect of the BIDS conventions. 

That conversion is thus the first step of our B1 mapping process.

## How to test this PR

The test `test_dicom_to_nifti.py` downloads data and has a test sensitive to the related issue.

More details about the data: The DICOM files I use are standard RF maps from the MNI measurements:
[RF_dicoms.zip](https://github.com/shimming-toolbox/shimming-toolbox-py/files/5018048/RF_dicoms.zip)

The easiest way to call the function from the command prompt is to go in the folder where the data have been extracted and type: `dcm2niix RF_dicoms`

## Problem encountered with our dataset
See #58 for more details.
When running [dcm2niix](https://github.com/rordenlab/dcm2niix) with B1 mapping `DICOM` files, it only outputs one `NIfTI` file (and its corresponding `json` file) that gather magnitude and phase. 

That is be related to the fact that these `DICOM` files don't have the exact same fields as the others we play with (e.g. no `ImageType` field). By default, the phase and magnitudes are thus stored in the same `NIfTI` file. 

Here the field that could be used to separate phase and magnitude images is `ImageComments` that has the value `'flip angle map, TraRefAmpl: 400.0 V'` for the magnitude and `'relative phase map'` for the phase but it seems to be filled by the user during the scan --> that might not be a good option as it is sensitive to human errors.

## Proposed changes

- After calling `dcm2bids`, separate the phase and magnitude files into 2 different nifti files, if modality is listed in `special_dicom` argument.
- Delete original nifti once phase and magnitude niftis are created
- Updated URL in download_data to include `b1_maps` in the downloaded release
- Updated `config/dcm2bids.json` to add the T1map case, as per [BIDS convention](https://bep001.readthedocs.io/en/dev/04-modality-specific-files/01-magnetic-resonance-imaging-data.html)
