### PR TITLE
Docstring fixes to address Sphinx build warnings

### DIFF
--- a/docs/source/6_api_reference/api.rst
+++ b/docs/source/6_api_reference/api.rst
@@ -31,8 +31,8 @@ unwrap
 .. automodule:: shimmingtoolbox.unwrap.prelude
    :members:
 
-mask
-----
+masking
+-------
 
 .. automodule:: shimmingtoolbox.masking.shapes
     :members:

--- a/docs/source/6_api_reference/api.rst
+++ b/docs/source/6_api_reference/api.rst
@@ -19,6 +19,9 @@ The following section outlines the API of shimming-toolbox.
 .. automodule:: shimmingtoolbox.cli.referencemaps
    :members:
 
+numerical_model
+---------------
+
 .. automodule:: shimmingtoolbox.simulate.numerical_model
    :members:
 

--- a/docs/source/6_api_reference/api.rst
+++ b/docs/source/6_api_reference/api.rst
@@ -34,5 +34,5 @@ unwrap
 mask
 ----
 
-.. automodule:: shimmingtoolbox.masking.shape
+.. automodule:: shimmingtoolbox.masking.shapes
     :members:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,7 +5,7 @@ build:
 
 sphinx:
   configuration: docs/source/conf.py
-  fail_on_warning: false
+  fail_on_warning: true
   builder: html
 
 python:

--- a/shimmingtoolbox/cli/b0map.py
+++ b/shimmingtoolbox/cli/b0map.py
@@ -6,7 +6,6 @@ import click
 
 from .. import b0map
 
-
 @click.command()
 @click.option("--verbose", is_flag=True, help="Be more verbose.")
 @click.option("--coilshims", help="Output hardware-shim calibration.")
@@ -19,11 +18,10 @@ def main(verbose, coilshims, pulseseq, input, output):
     """
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
-    logging.info(f"{coilshims}, {pulseseq}, {input}, {output}")
-    fieldmap, coilshims, pulseseq = b0map(input, coilshims=coilshims, pulseseq=pulseseq)
-    with open(output, "w") as out:
-        out.write(str(fieldmap))  # definitely not the right file format
+    logging.info(f'{coilshims}, {pulseseq}, {input}, {output}')
+    map, coilshims, pulseseq = b0map(input, coilshims=coilshims, pulseseq=pulseseq)
+    with open(output, 'w') as out:
+        out.write(str(map)) # definitely not the right file format
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/shimmingtoolbox/cli/b0map.py
+++ b/shimmingtoolbox/cli/b0map.py
@@ -6,6 +6,7 @@ import click
 
 from .. import b0map
 
+
 @click.command()
 @click.option("--verbose", is_flag=True, help="Be more verbose.")
 @click.option("--coilshims", help="Output hardware-shim calibration.")
@@ -18,10 +19,11 @@ def main(verbose, coilshims, pulseseq, input, output):
     """
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
-    logging.info(f'{coilshims}, {pulseseq}, {input}, {output}')
+    logging.info(f"{coilshims}, {pulseseq}, {input}, {output}")
     map, coilshims, pulseseq = b0map(input, coilshims=coilshims, pulseseq=pulseseq)
-    with open(output, 'w') as out:
-        out.write(str(map)) # definitely not the right file format
+    with open(output, "w") as out:
+        out.write(str(map))  # definitely not the right file format
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/shimmingtoolbox/cli/b0map.py
+++ b/shimmingtoolbox/cli/b0map.py
@@ -20,9 +20,9 @@ def main(verbose, coilshims, pulseseq, input, output):
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
     logging.info(f"{coilshims}, {pulseseq}, {input}, {output}")
-    map, coilshims, pulseseq = b0map(input, coilshims=coilshims, pulseseq=pulseseq)
+    fieldmap, coilshims, pulseseq = b0map(input, coilshims=coilshims, pulseseq=pulseseq)
     with open(output, "w") as out:
-        out.write(str(map))  # definitely not the right file format
+        out.write(str(fieldmap))  # definitely not the right file format
 
 
 if __name__ == "__main__":

--- a/shimmingtoolbox/cli/b0map.py
+++ b/shimmingtoolbox/cli/b0map.py
@@ -15,7 +15,7 @@ from .. import b0map
 @click.argument("output", type=click.Path(exists=False))
 def main(verbose, coilshims, pulseseq, input, output):
     """
-    Compute b0 fieldmap OUTPUT from a folder of dicom files INPUT.
+    Compute b0 fieldmap ``OUTPUT`` from a folder of dicom files ``INPUT/``.
     """
     if verbose:
         logging.getLogger().setLevel(logging.INFO)

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -7,19 +7,15 @@ import click
 from shimmingtoolbox.download import install_data
 
 dict_url = {
-    "testing_data": [
-        "https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"
-    ],
-    "prelude": ["https://github.com/shimming-toolbox/binaries/raw/master/prelude"],
+    "testing_data": ["https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"],
+    "prelude": ["https://github.com/shimming-toolbox/binaries/raw/master/prelude"]
 }
 
 
 # TODO: display automatically the list of data available from the dict above
 # TODO: wrap the help properly
-@click.command(
-    help="Download data from the internet. The available datasets are:"
-    "- testing_data: Light-weighted dataset for testing purpose."
-)
+@click.command(help="Download data from the internet. The available datasets are:"
+                    "- testing_data: Light-weighted dataset for testing purpose.")
 @click.option("--verbose", is_flag=True, help="Be more verbose.")
 @click.option("--output", help="Output folder.")
 @click.argument("data")
@@ -35,12 +31,12 @@ def main(verbose, output, data):
     # TODO: logging does not seem to output on the terminal
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
-    logging.info(f"{output}, {data}")
+    logging.info(f'{output}, {data}')
     url = dict_url[data]
     if output is None:
         output = os.path.join(os.path.abspath(os.curdir), data)
     install_data(url, output, keep=True)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -26,6 +26,11 @@ dict_url = {
 def main(verbose, output, data):
     """
     Download data from the internet.
+
+    Args:
+        verbose: If true, increases output verbosity.
+        output: Output folder.
+        data: The data to be downloaded.
     """
     # TODO: logging does not seem to output on the terminal
     if verbose:

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -7,15 +7,19 @@ import click
 from shimmingtoolbox.download import install_data
 
 dict_url = {
-    "testing_data": ["https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"],
-    "prelude": ["https://github.com/shimming-toolbox/binaries/raw/master/prelude"]
+    "testing_data": [
+        "https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"
+    ],
+    "prelude": ["https://github.com/shimming-toolbox/binaries/raw/master/prelude"],
 }
 
 
 # TODO: display automatically the list of data available from the dict above
 # TODO: wrap the help properly
-@click.command(help="Download data from the internet. The available datasets are:"
-                    "- testing_data: Light-weighted dataset for testing purpose.")
+@click.command(
+    help="Download data from the internet. The available datasets are:"
+    "- testing_data: Light-weighted dataset for testing purpose."
+)
 @click.option("--verbose", is_flag=True, help="Be more verbose.")
 @click.option("--output", help="Output folder.")
 @click.argument("data")
@@ -26,12 +30,12 @@ def main(verbose, output, data):
     # TODO: logging does not seem to output on the terminal
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
-    logging.info(f'{output}, {data}')
+    logging.info(f"{output}, {data}")
     url = dict_url[data]
     if output is None:
         output = os.path.join(os.path.abspath(os.curdir), data)
     install_data(url, output, keep=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/shimmingtoolbox/download.py
+++ b/shimmingtoolbox/download.py
@@ -37,16 +37,16 @@ def download_data(urls):
     exceptions = []
     for url in urls:
         try:
-            logger.info("Trying URL: %s" % url)
+            logger.info('Trying URL: %s' % url)
             retry = Retry(total=3, backoff_factor=0.5, status_forcelist=[500, 503, 504])
             session = requests.Session()
-            session.mount("https://", HTTPAdapter(max_retries=retry))
+            session.mount('https://', HTTPAdapter(max_retries=retry))
             response = session.get(url, stream=True)
             response.raise_for_status()
 
             filename = os.path.basename(urllib.parse.urlparse(url).path)
             if "Content-Disposition" in response.headers:
-                _, content = cgi.parse_header(response.headers["Content-Disposition"])
+                _, content = cgi.parse_header(response.headers['Content-Disposition'])
                 filename = content["filename"]
 
             # protect against directory traversal
@@ -54,24 +54,15 @@ def download_data(urls):
             if not filename:
                 # this handles cases where you're loading something like an index page
                 # instead of a specific file. e.g. https://osf.io/ugscu/?action=view.
-                raise ValueError(
-                    "Unable to determine target filename for URL: %s" % (url,)
-                )
+                raise ValueError("Unable to determine target filename for URL: %s" % (url,))
 
             tmp_path = os.path.join(tempfile.mkdtemp(), filename)
 
-            logger.info("Downloading: %s" % filename)
+            logger.info('Downloading: %s' % filename)
 
-            with open(tmp_path, "wb") as tmp_file:
-                total = int(response.headers.get("content-length", 1))
-                progress_bar = st_progress_bar(
-                    total=total,
-                    unit="B",
-                    unit_scale=True,
-                    desc="Status",
-                    ascii=False,
-                    position=0,
-                )
+            with open(tmp_path, 'wb') as tmp_file:
+                total = int(response.headers.get('content-length', 1))
+                progress_bar = st_progress_bar(total=total, unit='B', unit_scale=True, desc="Status", ascii=False, position=0)
 
                 for chunk in response.iter_content(chunk_size=8192):
                     if chunk:
@@ -83,12 +74,10 @@ def download_data(urls):
             return tmp_path
 
         except Exception as e:
-            logger.warning(
-                "Link download error, trying next mirror (error was: %s)" % e
-            )
+            logger.warning("Link download error, trying next mirror (error was: %s)" % e)
             exceptions.append(e)
     else:
-        raise Exception("Download error", exceptions)
+        raise Exception('Download error', exceptions)
 
 
 def unzip(compressed, dest_folder):
@@ -100,21 +89,23 @@ def unzip(compressed, dest_folder):
         compressed: the compressed ``.zip`` or ``.tar.gz`` file
         dest_folder: the destination dir that expanded files are written to
     """
-    logger.info("Unzip data to: %s" % dest_folder)
+    logger.info('Unzip data to: %s' % dest_folder)
 
-    formats = {".zip": zipfile.ZipFile, ".tar.gz": tarfile.open, ".tgz": tarfile.open}
+    formats = {'.zip': zipfile.ZipFile,
+               '.tar.gz': tarfile.open,
+               '.tgz': tarfile.open}
     for format, open in formats.items():
         if compressed.lower().endswith(format):
             break
     else:
-        logger.info("File extension is not included in {}".format(formats.keys()))
+        logger.info('File extension is not included in {}'.format(formats.keys()))
         shutil.copy(compressed, dest_folder)
         return
 
     try:
         open(compressed).extractall(dest_folder)
     except:
-        logger.error("ZIP package corrupted. Please try downloading again.")
+        logger.error('ZIP package corrupted. Please try downloading again.')
         raise
 
 
@@ -156,7 +147,7 @@ def install_data(url, dest_folder, keep=False):
 
     tmp_file = download_data(url)
 
-    extraction_folder = tempfile.mkdtemp(prefix="st_download_")
+    extraction_folder = tempfile.mkdtemp(prefix='st_download_')
 
     unzip(tmp_file, extraction_folder)
 
@@ -186,7 +177,7 @@ def install_data(url, dest_folder, keep=False):
     for cwd, ds, fs in os.walk(bundle_folder):
         ds.sort()
         fs.sort()
-        ds[:] = [d for d in ds if d not in ("__MACOSX",)]
+        ds[:] = [ d for d in ds if d not in ("__MACOSX",) ]
         for d in ds:
             srcpath = os.path.join(cwd, d)
             relpath = os.path.relpath(srcpath, bundle_folder)

--- a/shimmingtoolbox/download.py
+++ b/shimmingtoolbox/download.py
@@ -35,16 +35,16 @@ def download_data(urls):
     exceptions = []
     for url in urls:
         try:
-            logger.info('Trying URL: %s' % url)
+            logger.info("Trying URL: %s" % url)
             retry = Retry(total=3, backoff_factor=0.5, status_forcelist=[500, 503, 504])
             session = requests.Session()
-            session.mount('https://', HTTPAdapter(max_retries=retry))
+            session.mount("https://", HTTPAdapter(max_retries=retry))
             response = session.get(url, stream=True)
             response.raise_for_status()
 
             filename = os.path.basename(urllib.parse.urlparse(url).path)
             if "Content-Disposition" in response.headers:
-                _, content = cgi.parse_header(response.headers['Content-Disposition'])
+                _, content = cgi.parse_header(response.headers["Content-Disposition"])
                 filename = content["filename"]
 
             # protect against directory traversal
@@ -52,15 +52,24 @@ def download_data(urls):
             if not filename:
                 # this handles cases where you're loading something like an index page
                 # instead of a specific file. e.g. https://osf.io/ugscu/?action=view.
-                raise ValueError("Unable to determine target filename for URL: %s" % (url,))
+                raise ValueError(
+                    "Unable to determine target filename for URL: %s" % (url,)
+                )
 
             tmp_path = os.path.join(tempfile.mkdtemp(), filename)
 
-            logger.info('Downloading: %s' % filename)
+            logger.info("Downloading: %s" % filename)
 
-            with open(tmp_path, 'wb') as tmp_file:
-                total = int(response.headers.get('content-length', 1))
-                progress_bar = st_progress_bar(total=total, unit='B', unit_scale=True, desc="Status", ascii=False, position=0)
+            with open(tmp_path, "wb") as tmp_file:
+                total = int(response.headers.get("content-length", 1))
+                progress_bar = st_progress_bar(
+                    total=total,
+                    unit="B",
+                    unit_scale=True,
+                    desc="Status",
+                    ascii=False,
+                    position=0,
+                )
 
                 for chunk in response.iter_content(chunk_size=8192):
                     if chunk:
@@ -72,10 +81,12 @@ def download_data(urls):
             return tmp_path
 
         except Exception as e:
-            logger.warning("Link download error, trying next mirror (error was: %s)" % e)
+            logger.warning(
+                "Link download error, trying next mirror (error was: %s)" % e
+            )
             exceptions.append(e)
     else:
-        raise Exception('Download error', exceptions)
+        raise Exception("Download error", exceptions)
 
 
 def unzip(compressed, dest_folder):
@@ -83,23 +94,21 @@ def unzip(compressed, dest_folder):
     Extract compressed file to the dest_folder. Can handle .zip, .tar.gz. If none of this extension is found, simply
     copy the file in dest_folder.
     """
-    logger.info('Unzip data to: %s' % dest_folder)
+    logger.info("Unzip data to: %s" % dest_folder)
 
-    formats = {'.zip': zipfile.ZipFile,
-               '.tar.gz': tarfile.open,
-               '.tgz': tarfile.open}
+    formats = {".zip": zipfile.ZipFile, ".tar.gz": tarfile.open, ".tgz": tarfile.open}
     for format, open in formats.items():
         if compressed.lower().endswith(format):
             break
     else:
-        logger.info('File extension is not included in {}'.format(formats.keys()))
+        logger.info("File extension is not included in {}".format(formats.keys()))
         shutil.copy(compressed, dest_folder)
         return
 
     try:
         open(compressed).extractall(dest_folder)
     except:
-        logger.error('ZIP package corrupted. Please try downloading again.')
+        logger.error("ZIP package corrupted. Please try downloading again.")
         raise
 
 
@@ -136,7 +145,7 @@ def install_data(url, dest_folder, keep=False):
 
     tmp_file = download_data(url)
 
-    extraction_folder = tempfile.mkdtemp(prefix='st_download_')
+    extraction_folder = tempfile.mkdtemp(prefix="st_download_")
 
     unzip(tmp_file, extraction_folder)
 
@@ -166,7 +175,7 @@ def install_data(url, dest_folder, keep=False):
     for cwd, ds, fs in os.walk(bundle_folder):
         ds.sort()
         fs.sort()
-        ds[:] = [ d for d in ds if d not in ("__MACOSX",) ]
+        ds[:] = [d for d in ds if d not in ("__MACOSX",)]
         for d in ds:
             srcpath = os.path.join(cwd, d)
             relpath = os.path.relpath(srcpath, bundle_folder)

--- a/shimmingtoolbox/download.py
+++ b/shimmingtoolbox/download.py
@@ -93,8 +93,12 @@ def download_data(urls):
 
 def unzip(compressed, dest_folder):
     """
-    Extract compressed file to the dest_folder. Can handle .zip, .tar.gz. If none of this extension is found, simply
-    copy the file in dest_folder.
+    Extract compressed file to the ``dest_folder``. Can handle ``.zip``, ``.tar.gz``. If none of this extension is found, simply
+    copy the file in ``dest_folder``.
+
+    Args:
+        compressed: the compressed ``.zip`` or ``.tar.gz`` file
+        dest_folder: the destination dir that expanded files are written to
     """
     logger.info("Unzip data to: %s" % dest_folder)
 

--- a/shimmingtoolbox/download.py
+++ b/shimmingtoolbox/download.py
@@ -24,7 +24,9 @@ def download_data(urls):
     """Download the binaries from a URL and return the destination filename
     Retry downloading if either server or connection errors occur on a SSL
     connection
-    urls: list of several urls (mirror servers) or single url (string)
+
+    Args:
+        urls: list of several urls (mirror servers) or single url (string)
     """
 
     # make sure urls becomes a list, in case user inputs a str

--- a/shimmingtoolbox/download.py
+++ b/shimmingtoolbox/download.py
@@ -113,29 +113,34 @@ def unzip(compressed, dest_folder):
 
 
 def install_data(url, dest_folder, keep=False):
-    """
-    Download a data bundle from a URL and install in the destination folder.
-    :param url: URL or sequence thereof (if mirrors).
-    :param dest_folder: destination directory for the data (to be created).
-    :param keep: whether to keep existing data in the destination folder.
-    :return: None
+    """Download a data bundle from a URL and install in the destination folder.
+
+    Args:
+        url: URL or sequence thereof (if mirrors).
+        dest_folder: destination directory for the data (to be created).
+        keep: whether to keep existing data in the destination folder.
+    Returns:
+        ``NoneType``
     .. note::
         The function tries to be smart about the data contents.
+
         Examples:
-        a. If the archive only contains a `README.md`, and the destination folder is `${dst}`,
-            `${dst}/README.md` will be created.
-            Note: an archive not containing a single folder is commonly known as a "bomb" because
+
+            If the archive only contains a ``README.md``, and the destination folder is ``${dst}``,
+            ``${dst}/README.md`` will be created.
+            Note: an archive not containing a single folder is commonly known as a "tarbomb" because
             it puts files anywhere in the current working directory.
-            https://en.wikipedia.org/wiki/Tar_(computing)#Tarbomb
-        b. If the archive contains a `${dir}/README.md`, and the destination folder is `${dst}`,
-            `${dst}/README.md` will be created.
-            Note: typically the package will be called `${basename}-${revision}.zip` and contain
-            a root folder named `${basename}-${revision}/` under which all the other files will
+
+            If the archive contains a ``${dir}/README.md``, and the destination folder is ``${dst}``,
+            ``${dst}/README.md`` will be created.
+            Note: typically the package will be called ``${basename}-${revision}.zip`` and contain
+            a root folder named ``${basename}-${revision}/`` under which all the other files will
             be located.
             The right thing to do in this case is to take the files from there and install them
-            in `${dst}`.
-        - Uses `download_data()` to retrieve the data.
-        - Uses `unzip()` to extract the bundle.
+            in ``${dst}``.
+
+        - Uses ``download_data()`` to retrieve the data.
+        - Uses ``unzip()`` to extract the bundle.
     """
 
     if not keep and os.path.exists(dest_folder):

--- a/shimmingtoolbox/simulate/numerical_model.py
+++ b/shimmingtoolbox/simulate/numerical_model.py
@@ -44,13 +44,12 @@ class NumericalModel:
 
     Simulate multi-echo B0 field mapping data in the presence of a B0 field. 
     Can simulate data under ideal conditions or with noise. Export simulations 
-    in a NIfTI or .mat file formats.
+    in a NIfTI or ``.mat`` file formats.
 
     Attributes:
-        gamma: Gyromagnetic ratio in rad*Hz/Tesla.
-        field_strength: Static field strength in Tesla.
-        handedness: Orientation of the cross-product for the Larmor equation.
-            The value of this attribute is MRI vendor-dependent.
+        gamma (float): Gyromagnetic ratio in rad * Hz / Tesla.
+        field_strength (float): Static field strength in Tesla.
+        handedness: Orientation of the cross-product for the Larmor equation. The value of this attribute is MRI vendor-dependent.
         measurement: Simulated measurement data array.
         proton_density: Default assumed brain proton density in %.
         T2_star: Default assumed brain T2* values in seconds at 3T.

--- a/shimmingtoolbox/simulate/numerical_model.py
+++ b/shimmingtoolbox/simulate/numerical_model.py
@@ -4,24 +4,26 @@
 This module is for numerically simulating multi-echo B0 field mapping data. It
 considers features like: background B0 field, flip angle, echo time, and noise.
 
-  Typical usage example:
+Typical usage example:
 
-  from shimmingtoolbox.simulate import *
+::
 
-  b0_sim = NumericalModel(model="shepp-logan")
-  
-  # Generate a background B0
-  b0_field = 13 # (Hz)
-  b0_sim.generate_deltaB0("linear", [0.0, b0_field])
+    from shimmingtoolbox.simulate import *
 
-  # Simulate the signal data
-  FA = 15 # (degrees)
-  TE = [0.003, 0.015] # (seconds)
-  SNR = 50
-  b0_sim.simulate_measurement(FA, TE, SNR)
+    b0_sim = NumericalModel(model="shepp-logan")
 
-  # Save simulation as NIfTI file (JSON sidecar also exported with parameters)
-  b0_sim.save('Phase', 'b0_mapping_data.nii', format='nifti')
+    # Generate a background B0
+    b0_field = 13 # (Hz)
+    b0_sim.generate_deltaB0("linear", [0.0, b0_field])
+
+    # Simulate the signal data
+    FA = 15 # (degrees)
+    TE = [0.003, 0.015] # (seconds)
+    SNR = 50
+    b0_sim.simulate_measurement(FA, TE, SNR)
+
+    # Save simulation as NIfTI file (JSON sidecar also exported with parameters)
+    b0_sim.save('Phase', 'b0_mapping_data.nii', format='nifti')
 """
 
 import os, json

--- a/shimmingtoolbox/simulate/numerical_model.py
+++ b/shimmingtoolbox/simulate/numerical_model.py
@@ -107,11 +107,11 @@ class NumericalModel:
         Defines the starting volume. Sets the background B0 field to zeros.
 
         Args:
-            field_type: Type of field to be generated. Available implementations 
-                are: 'linear'.
-            params: Parameters defining the field for the selected field type.
-                field_type = 'linear': [m b] where m (Hz/pixel) is the slope and b
-                    is the floor field (Hz).
+            field_type: Type of field to be generated. Available implementations are: ``'linear'``.
+            params: List of parameters defining the field for the selected
+                field type. If ``field_type = 'linear'``, then ``params`` are
+                ``[m b]`` where m (Hz/pixel) is the slope and b is the floor
+                field (Hz).
         """
 
         if field_type == "linear":

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -14,8 +14,8 @@ def run_subprocess(cmd):
     Args:
         cmd (string): full command to be run on the command line
     """
-    logging.debug('{}'.format(cmd))
-    subprocess.run(cmd.split(' '), stdout=subprocess.PIPE, text=True, check=True)
+    logging.debug("{}".format(cmd))
+    subprocess.run(cmd.split(" "), stdout=subprocess.PIPE, text=True, check=True)
 
 
 def add_suffix(fname, suffix):
@@ -42,9 +42,9 @@ def add_suffix(fname, suffix):
         (``os.path.splitext()`` would want to do the latter, hence the special case).
         """
         dir, filename = os.path.split(fname)
-        for special_ext in ['.nii.gz', '.tar.gz']:
+        for special_ext in [".nii.gz", ".tar.gz"]:
             if filename.endswith(special_ext):
-                stem, ext = filename[:-len(special_ext)], special_ext
+                stem, ext = filename[: -len(special_ext)], special_ext
                 return os.path.join(dir, stem), ext
         # If no special case, behaves like the regular splitext
         stem, ext = os.path.splitext(filename)
@@ -57,8 +57,8 @@ def add_suffix(fname, suffix):
 def st_progress_bar(*args, **kwargs):
     """Thin wrapper around `tqdm.tqdm` which checks `SCT_PROGRESS_BAR` muffling the progress
        bar if the user sets it to `no`, `off`, or `false` (case insensitive)."""
-    do_pb = os.environ.get('SCT_PROGRESS_BAR', 'yes')
-    if do_pb.lower() in ['off', 'no', 'false']:
-        kwargs['disable'] = True
+    do_pb = os.environ.get("SCT_PROGRESS_BAR", "yes")
+    if do_pb.lower() in ["off", "no", "false"]:
+        kwargs["disable"] = True
 
     return tqdm.tqdm(*args, **kwargs)

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -23,15 +23,15 @@ def add_suffix(fname, suffix):
     Add suffix between end of file name and extension.
 
     Args:
-        fname: absolute or relative file name. Example: t2.nii
-        suffix: suffix. Example: _mean
+        fname: absolute or relative file name. Example: ``t2.nii``
+        suffix: suffix. Example: ``_mean``
 
-    :Return: file name with suffix. Example: t2_mean.nii
+    :Return: file name string with suffix. Example: ``t2_mean.nii``
 
     Examples:
 
-    - add_suffix(t2.nii, _mean) -> t2_mean.nii
-    - add_suffix(t2.nii.gz, a) -> t2a.nii.gz
+    - ``add_suffix(t2.nii, _mean)`` -> ``t2_mean.nii``
+    - ``add_suffix(t2.nii.gz, a)`` -> ``t2a.nii.gz``
     """
 
     def _splitext(fname):

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -15,8 +15,8 @@ def run_subprocess(cmd):
     Args:
         cmd (string): full command to be run on the command line
     """
-    logging.debug("{}".format(cmd))
-    subprocess.run(cmd.split(" "), stdout=subprocess.PIPE, text=True, check=True)
+    logging.debug('{}'.format(cmd))
+    subprocess.run(cmd.split(' '), stdout=subprocess.PIPE, text=True, check=True)
 
 
 def add_suffix(fname, suffix):
@@ -43,9 +43,9 @@ def add_suffix(fname, suffix):
         (``os.path.splitext()`` would want to do the latter, hence the special case).
         """
         dir, filename = os.path.split(fname)
-        for special_ext in [".nii.gz", ".tar.gz"]:
+        for special_ext in ['.nii.gz', '.tar.gz']:
             if filename.endswith(special_ext):
-                stem, ext = filename[: -len(special_ext)], special_ext
+                stem, ext = filename[:-len(special_ext)], special_ext
                 return os.path.join(dir, stem), ext
         # If no special case, behaves like the regular splitext
         stem, ext = os.path.splitext(filename)
@@ -56,10 +56,10 @@ def add_suffix(fname, suffix):
 
 
 def st_progress_bar(*args, **kwargs):
-    """Thin wrapper around ``tqdm.tqdm`` which checks ``SCT_PROGRESS_BAR``, muffling the progress
-       bar if the user sets it to ``no``, ``off``, or ``false`` (case insensitive)."""
-    do_pb = os.environ.get("SCT_PROGRESS_BAR", "yes")
-    if do_pb.lower() in ["off", "no", "false"]:
-        kwargs["disable"] = True
+    """Thin wrapper around `tqdm.tqdm` which checks `SCT_PROGRESS_BAR` muffling the progress
+       bar if the user sets it to `no`, `off`, or `false` (case insensitive)."""
+    do_pb = os.environ.get('SCT_PROGRESS_BAR', 'yes')
+    if do_pb.lower() in ['off', 'no', 'false']:
+        kwargs['disable'] = True
 
     return tqdm.tqdm(*args, **kwargs)

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -10,7 +10,8 @@ import logging
 
 def run_subprocess(cmd):
     """
-    Wrapper for subprocess.run() that enables to input cmd as a full string (easier for debugging).
+    Wrapper for ``subprocess.run()`` that enables to input ``cmd`` as a full string (easier for debugging).
+
     Args:
         cmd (string): full command to be run on the command line
     """

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -56,8 +56,8 @@ def add_suffix(fname, suffix):
 
 
 def st_progress_bar(*args, **kwargs):
-    """Thin wrapper around `tqdm.tqdm` which checks `SCT_PROGRESS_BAR` muffling the progress
-       bar if the user sets it to `no`, `off`, or `false` (case insensitive)."""
+    """Thin wrapper around ``tqdm.tqdm`` which checks ``SCT_PROGRESS_BAR``, muffling the progress
+       bar if the user sets it to ``no``, ``off``, or ``false`` (case insensitive)."""
     do_pb = os.environ.get("SCT_PROGRESS_BAR", "yes")
     if do_pb.lower() in ["off", "no", "false"]:
         kwargs["disable"] = True


### PR DESCRIPTION
This PR addresses various Sphinx warnings that were indicating poor docstring formatting.

Now that the doc build is warning-free, the RTD build is reconfigured to fail on warning. This is done to help ensure that any new feature added to the package is also well-documented, at least with Sphinx formatting.

➤ **Built doc on RTD: https://shimming-toolbox.org/en/ji-docstring-fix/**