### PR TITLE
Create synthetic coil-profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ testing_data
 # Pycharm stuff
 *.pyc
 .idea
+venv
 
 # Sphinx stuff
 docs/build/

--- a/docs/source/6_api_reference/api.rst
+++ b/docs/source/6_api_reference/api.rst
@@ -1,8 +1,38 @@
-
 API Reference
 =============
 
 The following section outlines the API of shimming-toolbox.
+
+
+unwrap
+------
+
+.. automodule:: shimmingtoolbox.unwrap.prelude
+   :members:
+
+masking
+-------
+
+.. automodule:: shimmingtoolbox.masking.shapes
+    :members:
+
+coils
+_____
+
+.. automodule:: shimmingtoolbox.coils.siemens_basis
+    :members:
+
+.. automodule:: shimmingtoolbox.coils.spherical_harmonics
+    :members:
+
+numerical_model
+---------------
+
+.. automodule:: shimmingtoolbox.simulate.numerical_model
+   :members:
+
+misc
+____
 
 .. automodule:: shimmingtoolbox.download
    :members:
@@ -18,21 +48,3 @@ The following section outlines the API of shimming-toolbox.
 
 .. automodule:: shimmingtoolbox.cli.referencemaps
    :members:
-
-numerical_model
----------------
-
-.. automodule:: shimmingtoolbox.simulate.numerical_model
-   :members:
-
-unwrap
-------
-
-.. automodule:: shimmingtoolbox.unwrap.prelude
-   :members:
-
-masking
--------
-
-.. automodule:: shimmingtoolbox.masking.shapes
-    :members:

--- a/docs/source/6_api_reference/api.rst
+++ b/docs/source/6_api_reference/api.rst
@@ -19,9 +19,13 @@ masking
 coils
 -----
 
+siemens_basis
+_____________
 .. automodule:: shimmingtoolbox.coils.siemens_basis
     :members:
 
+spherical_harmonics
+___________________
 .. automodule:: shimmingtoolbox.coils.spherical_harmonics
     :members:
 

--- a/docs/source/6_api_reference/api.rst
+++ b/docs/source/6_api_reference/api.rst
@@ -17,7 +17,7 @@ masking
     :members:
 
 coils
-_____
+-----
 
 .. automodule:: shimmingtoolbox.coils.siemens_basis
     :members:
@@ -32,7 +32,7 @@ numerical_model
    :members:
 
 misc
-____
+----
 
 .. automodule:: shimmingtoolbox.download
    :members:

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -125,7 +125,8 @@ def siemens_basis(x, y, z):
 
         for i_ch in range(0, n_channels):
             field = sh[:, :, :, i_ch]
-            scaling_factors[i_ch] = 42.576 * ((r[i_ch] * 0.001) ** orders[i_ch]) / field[i_ref[i_ch]]
+            gyro_ratio = 42.576
+            scaling_factors[i_ch] = gyro_ratio * ((r[i_ch] * 0.001) ** orders[i_ch]) / field[i_ref[i_ch]]
 
         return scaling_factors
 

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -88,8 +88,7 @@ def siemens_basis(x, y, z):
 
         NOTE: The method has been worked out empirically and has only been tested for 2 Siemens Prisma systems.
         E.g.re: Y, Z, ZX, and XY terms, their polarity had to be flipped relative to the form given by
-        shimmingtoolbox.coils.spherical_harmonics. To adapt the code to other systems, arbitrary(?) changes along these
-        lines will likely be needed.
+        shimmingtoolbox.coils.spherical_harmonics.
         """
 
         [x_iso, y_iso, z_iso] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)),

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -7,8 +7,8 @@ from shimmingtoolbox.coils.spherical_harmonics import spherical_harmonics
 
 def siemens_basis(x, y, z):
     """
-    The function first wraps `shimmingtoolbox.coils.spherical_harmonics` to generate 1st and 2nd order spherical
-    harmonic `basis` fields at the grid positions given by arrays `X,Y,Z`. *Following Siemens convention*, `basis` is
+    The function first wraps ``shimmingtoolbox.coils.spherical_harmonics`` to generate 1st and 2nd order spherical
+    harmonic ``basis`` fields at the grid positions given by arrays ``X,Y,Z``. *Following Siemens convention*, ``basis`` is
     then:
 
         - Reordered along the 4th dimension as *X, Y, Z, Z2, ZX, ZY, X2-Y2, XY*
@@ -19,11 +19,11 @@ def siemens_basis(x, y, z):
             - 1 micro-T/m for *X,Y,Z* gradients (= 0.042576 Hz/mm)
             - 1 micro-T/m^2 for 2nd order terms (= 0.000042576 Hz/mm^2)
 
-    The returned `basis` is thereby in the form of ideal "shim reference maps", ready for optimization.
+    The returned ``basis`` is thereby in the form of ideal "shim reference maps", ready for optimization.
 
     Args:
-        orders (numpy.ndarray): *not yet implemented* Degrees of the desired terms in the series expansion, specified
-                                as a vector of non-negative integers (`[0:1:n]` yields harmonics up to n-th order)
+        orders (numpy.ndarray): **not yet implemented** Degrees of the desired terms in the series expansion, specified
+                                as a vector of non-negative integers (``[0:1:n]`` yields harmonics up to n-th order)
         x (numpy.ndarray): 3-D arrays of grid coordinates, "Right->Left" grid coordinates in the patient coordinate
                            system (i.e. DICOM reference, units of mm)
         y (numpy.ndarray): 3-D arrays of grid coordinates (same shape as x). "Anterior->Posterior" grid coordinates in
@@ -36,18 +36,18 @@ def siemens_basis(x, y, z):
         numpy.ndarray: 4-D array of spherical harmonic basis fields
 
     NOTES:
-        For now, `orders` is, in fact, ignored: fixed as [1:2]—which is suitable for the Prisma (presumably other
+        For now, ``orders`` is, in fact, ignored: fixed as [1:2]—which is suitable for the Prisma (presumably other
         Siemens systems as well) however, the 3rd-order shims of the Terra should ultimately be accommodated too.
         (Requires checking the Adjustments/Shim card to see what the corresponding terms and values actually are). So,
-        for now, `basis` will always be returned with 8 terms along the 4th dim.
+        for now, ``basis`` will always be returned with 8 terms along the 4th dim.
     """
 
     # Local functions
     def reorder_to_siemens(spher_harm):
         """
         Reorder 1st - 2nd order basis terms along 4th dim. From
-        1. Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2(output by shimmingtoolbox.coils.spherical_harmonics.spherical_harmonics), to
-        2. X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY( in line with Siemens shims)
+        1. Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2 (output by shimmingtoolbox.coils.spherical_harmonics.spherical_harmonics), to
+        2. X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY (in line with Siemens shims)
         """
 
         assert spher_harm.shape[3] == 8
@@ -65,7 +65,7 @@ def siemens_basis(x, y, z):
 
     def get_scaling_factors():
         """
-        Returns a vector of `scaling_factors` to apply to the(Siemens-reordered) 1st + 2nd order spherical harmonic fields
+        Returns a vector of ``scaling_factors`` to apply to the(Siemens-reordered) 1st + 2nd order spherical harmonic fields
         for rescaling field terms as "shim reference maps" in units of Hz/unit-shim:
 
         Gx, Gy, and Gz should yield 1 micro-T of field shift per metre: equivalently, 0.042576 Hz/mm
@@ -76,7 +76,7 @@ def siemens_basis(x, y, z):
         at which we know what the field *should* be, and use that to calculate the appropriate scaling factor.
 
         NOTE: The method has been worked out empirically and has only been tested for 2 Siemens Prisma systems.
-        E.g.re: Y, Z, ZX, and XY terms, it was noted that their polarity had to be flipped relative to the form given by
+        E.g.re: Y, Z, ZX, and XY terms, their polarity had to be flipped relative to the form given by
         shimmingtoolbox.coils.spherical_harmonics. To adapt the code to other systems, arbitrary(?) changes along these
         lines will likely be needed.
         """
@@ -120,10 +120,10 @@ def siemens_basis(x, y, z):
 
     # Check inputs
     if not (x.ndim == y.ndim == z.ndim == 3):
-        raise RuntimeError('Input arrays X, Y, and Z must be 3d')
+        raise RuntimeError("Input arrays X, Y, and Z must be 3d")
 
     if not (x.shape == y.shape == z.shape):
-        raise RuntimeError('Input arrays X, Y, and Z must be identically sized')
+        raise RuntimeError("Input arrays X, Y, and Z must be identically sized")
 
     # Create spherical harmonics from first to second order
     orders = np.array(range(1, 3))

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -1,0 +1,144 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+
+import numpy as np
+from shimmingtoolbox.coils.spherical_harmonics import spherical_harmonics
+
+
+def reorder_to_siemens(spher_harm):
+    """
+    Reorder 1st - 2nd order basis terms along 4th dim. From
+    1. Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2(output by shimmingtoolbox.coils.spherical_harmonics.sppherical_harmonics), to 
+    2. X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY( in line with Siemens shims)
+    """
+
+    assert spher_harm.shape[3] == 8
+    reordered = np.zeros(spher_harm.shape)
+    reordered[:, :, :, 0] = spher_harm[:, :, :, 2]
+    reordered[:, :, :, 1] = spher_harm[:, :, :, 0]
+    reordered[:, :, :, 2] = spher_harm[:, :, :, 1]
+    reordered[:, :, :, 3] = spher_harm[:, :, :, 5]
+    reordered[:, :, :, 4] = spher_harm[:, :, :, 6]
+    reordered[:, :, :, 5] = spher_harm[:, :, :, 4]
+    reordered[:, :, :, 6] = spher_harm[:, :, :, 7]
+    reordered[:, :, :, 7] = spher_harm[:, :, :, 3]
+
+    return reordered
+
+
+def scale(spher_harm):
+    """
+    Returns a vector of `scaling_factors` to apply to the(Siemens-reordered) 1st + 2nd order spherical harmonic fields
+    for rescaling field terms as "shim reference maps" in units of Hz/unit-shim:
+
+    Gx, Gy, and Gz should yield 1 micro-T of field shift per metre: equivalently, 0.042576 Hz/mm
+
+    2nd order terms should yield 1 micro-T of field shift per metre-squared: equivalently, 0.000042576 Hz/mm^2
+
+    Gist: given the stated nominal values, we can pick several arbitrary reference positions around the origin/isocenter
+    at which we know what the field *should* be, and use that to calculate the appropriate scaling factor.
+
+    NOTE: The method has been worked out empirically and has only been tested for 2 Siemens Prisma systems.
+    E.g.re: Y, Z, ZX, and XY terms, it was noted that their polarity had to be flipped relative to the form given by
+    shimmingtoolbox.coils.spherical_harmonics. To adapt the code to other systems, arbitrary(?) changes along these
+    lines will likely be needed.
+    """
+
+    [x_iso, y_iso, z_iso] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)),
+                                        indexing='xy')
+    orders = np.array(range(1, 3))
+    sh = spherical_harmonics(orders, x_iso, y_iso, z_iso)
+    sh = reorder_to_siemens(sh)
+
+    n_channels = sh.shape[3]
+    scaling_factors = np.zeros(n_channels)
+
+    # indices of reference positions for normalization:
+    i_x1 = np.nonzero((x_iso == 1) & (y_iso == 0) & (z_iso == 0))
+    i_y1 = np.nonzero((x_iso == 0) & (y_iso == 1) & (z_iso == 0))
+    i_z1 = np.nonzero((x_iso == 0) & (y_iso == 0) & (z_iso == 1))
+
+    i_x1z1 = np.nonzero((x_iso == 1) & (y_iso == 0) & (z_iso == 1))
+    i_y1z1 = np.nonzero((x_iso == 0) & (y_iso == 1) & (z_iso == 1))
+    i_x1y1 = np.nonzero((x_iso == 1) & (y_iso == 1) & (z_iso == 0))
+
+    # order the reference indices like the sh field terms
+    i_ref = [i_x1, i_y1, i_z1, i_z1, i_x1z1, i_y1z1, i_x1, i_x1y1]
+
+    # distance from iso/origin to adopted reference point[units: mm]
+    r = [1, 1, 1, 1, np.sqrt(2), np.sqrt(2), 1, np.sqrt(2)]
+
+    # invert polarity
+    # Y, Z, ZX, and XY terms only(determined empirically)
+    sh[:, :, :, [1, 2, 4, 7]] = -sh[:, :, :, [1, 2, 4, 7]]
+
+    # scaling:
+    orders = [1, 1, 1, 2, 2, 2, 2, 2]
+
+    for i_ch in range(0, n_channels):
+        field = sh[:, :, :, i_ch]
+        scaling_factors[i_ch] = 42.576 * ((r[i_ch] * 0.001) ** orders[i_ch]) / field[i_ref[i_ch]]
+
+    return scaling_factors
+
+
+def siemens_basis(x, y, z):
+    """
+    The function first wraps `shimmingtoolbox.coils.spherical_harmonics` to generate 1st and 2nd order spherical
+    harmonic `basis` fields at the grid positions given by arrays `X,Y,Z`. *Following Siemens convention*, `basis` is
+    then:
+
+    - Reordered along the 4th dimension as *X, Y, Z, Z2, ZX, ZY, X2-Y2, XY*
+
+    - Rescaled to Hz/unit-shim, where "unit-shim" refers to the measure displayed in the Adjustments card of the Syngo
+    console UI, namely:
+
+        - 1 micro-T/m for *X,Y,Z* gradients (= 0.042576 Hz/mm)
+        - 1 micro-T/m^2 for 2nd order terms (= 0.000042576 Hz/mm^2)
+
+    The returned `basis` is thereby in the form of ideal "shim reference maps", ready for optimization.
+
+    Args:
+        orders (numpy.ndarray): *not yet implemented* Degrees of the desired terms in the series expansion, specified
+                                as a vector of non-negative integers (`[0:1:n]` yields harmonics up to n-th order)
+        x (numpy.ndarray): 3-D arrays of grid coordinates, "Right->Left" grid coordinates in the patient coordinate
+                           system (i.e. DICOM reference, units of mm)
+        y (numpy.ndarray): 3-D arrays of grid coordinates (same shape as x). "Anterior->Posterior" grid coordinates in
+                           the patient coordinate system (i.e. DICOM reference, units of mm)
+
+        z (numpy.ndarray): 3-D arrays of grid coordinates (same shape as x). "Inferior->Superior" grid coordinates in
+                           the patient coordinate system (i.e. DICOM reference, units of mm)
+
+    Returns:
+        numpy.ndarray: 4-D array of spherical harmonic basis fields
+
+    NOTES:
+        For now, `orders` is, in fact, ignored: fixed as [1:2]—which is suitable for the Prisma (presumably other
+        Siemens systems as well) however, the 3rd-order shims of the Terra should ultimately be accommodated too.
+        (Requires checking the Adjustments/Shim card to see what the corresponding terms and values actually are). So,
+        for now, `basis` will always be returned with 8 terms along the 4th dim.
+    """
+
+    # Check inputs
+    if not (x.ndim == y.ndim == z.ndim == 3):
+        raise RuntimeError('Input arrays X, Y, and Z must be 3d')
+
+    if not (x.shape == y.shape == z.shape):
+        raise RuntimeError('Input arrays X, Y, and Z must be identically sized')
+
+    # Create spherical harmonics from first to second order
+    orders = np.array(range(1, 3))
+    spher_harm = spherical_harmonics(orders, x, y, z)
+
+    # Reorder according to siemens convention: X, Y, Z, Z2, ZX, ZY, X2-Y2, XY
+    reordered_spher = reorder_to_siemens(spher_harm)
+
+    # scale according to
+    # - 1 micro-T/m for *X,Y,Z* gradients (= 0.042576 Hz/mm)
+    # - 1 micro-T/m^2 for 2nd order terms (= 0.000042576 Hz/mm^2)
+    scaling_factors = scale(spher_harm)
+    scaled = np.zeros_like(reordered_spher)
+    for i_channel in range(0, spher_harm.shape[3]):
+        scaled[:, :, :, i_channel] = scaling_factors[i_channel] * reordered_spher[:, :, :, i_channel]
+
+    return scaled

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -5,96 +5,19 @@ import numpy as np
 from shimmingtoolbox.coils.spherical_harmonics import spherical_harmonics
 
 
-def reorder_to_siemens(spher_harm):
-    """
-    Reorder 1st - 2nd order basis terms along 4th dim. From
-    1. Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2(output by shimmingtoolbox.coils.spherical_harmonics.sppherical_harmonics), to 
-    2. X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY( in line with Siemens shims)
-    """
-
-    assert spher_harm.shape[3] == 8
-    reordered = np.zeros(spher_harm.shape)
-    reordered[:, :, :, 0] = spher_harm[:, :, :, 2]
-    reordered[:, :, :, 1] = spher_harm[:, :, :, 0]
-    reordered[:, :, :, 2] = spher_harm[:, :, :, 1]
-    reordered[:, :, :, 3] = spher_harm[:, :, :, 5]
-    reordered[:, :, :, 4] = spher_harm[:, :, :, 6]
-    reordered[:, :, :, 5] = spher_harm[:, :, :, 4]
-    reordered[:, :, :, 6] = spher_harm[:, :, :, 7]
-    reordered[:, :, :, 7] = spher_harm[:, :, :, 3]
-
-    return reordered
-
-
-def scale(spher_harm):
-    """
-    Returns a vector of `scaling_factors` to apply to the(Siemens-reordered) 1st + 2nd order spherical harmonic fields
-    for rescaling field terms as "shim reference maps" in units of Hz/unit-shim:
-
-    Gx, Gy, and Gz should yield 1 micro-T of field shift per metre: equivalently, 0.042576 Hz/mm
-
-    2nd order terms should yield 1 micro-T of field shift per metre-squared: equivalently, 0.000042576 Hz/mm^2
-
-    Gist: given the stated nominal values, we can pick several arbitrary reference positions around the origin/isocenter
-    at which we know what the field *should* be, and use that to calculate the appropriate scaling factor.
-
-    NOTE: The method has been worked out empirically and has only been tested for 2 Siemens Prisma systems.
-    E.g.re: Y, Z, ZX, and XY terms, it was noted that their polarity had to be flipped relative to the form given by
-    shimmingtoolbox.coils.spherical_harmonics. To adapt the code to other systems, arbitrary(?) changes along these
-    lines will likely be needed.
-    """
-
-    [x_iso, y_iso, z_iso] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)),
-                                        indexing='xy')
-    orders = np.array(range(1, 3))
-    sh = spherical_harmonics(orders, x_iso, y_iso, z_iso)
-    sh = reorder_to_siemens(sh)
-
-    n_channels = sh.shape[3]
-    scaling_factors = np.zeros(n_channels)
-
-    # indices of reference positions for normalization:
-    i_x1 = np.nonzero((x_iso == 1) & (y_iso == 0) & (z_iso == 0))
-    i_y1 = np.nonzero((x_iso == 0) & (y_iso == 1) & (z_iso == 0))
-    i_z1 = np.nonzero((x_iso == 0) & (y_iso == 0) & (z_iso == 1))
-
-    i_x1z1 = np.nonzero((x_iso == 1) & (y_iso == 0) & (z_iso == 1))
-    i_y1z1 = np.nonzero((x_iso == 0) & (y_iso == 1) & (z_iso == 1))
-    i_x1y1 = np.nonzero((x_iso == 1) & (y_iso == 1) & (z_iso == 0))
-
-    # order the reference indices like the sh field terms
-    i_ref = [i_x1, i_y1, i_z1, i_z1, i_x1z1, i_y1z1, i_x1, i_x1y1]
-
-    # distance from iso/origin to adopted reference point[units: mm]
-    r = [1, 1, 1, 1, np.sqrt(2), np.sqrt(2), 1, np.sqrt(2)]
-
-    # invert polarity
-    # Y, Z, ZX, and XY terms only(determined empirically)
-    sh[:, :, :, [1, 2, 4, 7]] = -sh[:, :, :, [1, 2, 4, 7]]
-
-    # scaling:
-    orders = [1, 1, 1, 2, 2, 2, 2, 2]
-
-    for i_ch in range(0, n_channels):
-        field = sh[:, :, :, i_ch]
-        scaling_factors[i_ch] = 42.576 * ((r[i_ch] * 0.001) ** orders[i_ch]) / field[i_ref[i_ch]]
-
-    return scaling_factors
-
-
 def siemens_basis(x, y, z):
     """
     The function first wraps `shimmingtoolbox.coils.spherical_harmonics` to generate 1st and 2nd order spherical
     harmonic `basis` fields at the grid positions given by arrays `X,Y,Z`. *Following Siemens convention*, `basis` is
     then:
 
-    - Reordered along the 4th dimension as *X, Y, Z, Z2, ZX, ZY, X2-Y2, XY*
+        - Reordered along the 4th dimension as *X, Y, Z, Z2, ZX, ZY, X2-Y2, XY*
 
-    - Rescaled to Hz/unit-shim, where "unit-shim" refers to the measure displayed in the Adjustments card of the Syngo
-    console UI, namely:
+        - Rescaled to Hz/unit-shim, where "unit-shim" refers to the measure displayed in the Adjustments card of the
+          Syngo console UI, namely:
 
-        - 1 micro-T/m for *X,Y,Z* gradients (= 0.042576 Hz/mm)
-        - 1 micro-T/m^2 for 2nd order terms (= 0.000042576 Hz/mm^2)
+            - 1 micro-T/m for *X,Y,Z* gradients (= 0.042576 Hz/mm)
+            - 1 micro-T/m^2 for 2nd order terms (= 0.000042576 Hz/mm^2)
 
     The returned `basis` is thereby in the form of ideal "shim reference maps", ready for optimization.
 
@@ -119,6 +42,82 @@ def siemens_basis(x, y, z):
         for now, `basis` will always be returned with 8 terms along the 4th dim.
     """
 
+    # Local functions
+    def reorder_to_siemens(spher_harm):
+        """
+        Reorder 1st - 2nd order basis terms along 4th dim. From
+        1. Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2(output by shimmingtoolbox.coils.spherical_harmonics.spherical_harmonics), to
+        2. X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY( in line with Siemens shims)
+        """
+
+        assert spher_harm.shape[3] == 8
+        reordered = np.zeros(spher_harm.shape)
+        reordered[:, :, :, 0] = spher_harm[:, :, :, 2]
+        reordered[:, :, :, 1] = spher_harm[:, :, :, 0]
+        reordered[:, :, :, 2] = spher_harm[:, :, :, 1]
+        reordered[:, :, :, 3] = spher_harm[:, :, :, 5]
+        reordered[:, :, :, 4] = spher_harm[:, :, :, 6]
+        reordered[:, :, :, 5] = spher_harm[:, :, :, 4]
+        reordered[:, :, :, 6] = spher_harm[:, :, :, 7]
+        reordered[:, :, :, 7] = spher_harm[:, :, :, 3]
+
+        return reordered
+
+    def get_scaling_factors():
+        """
+        Returns a vector of `scaling_factors` to apply to the(Siemens-reordered) 1st + 2nd order spherical harmonic fields
+        for rescaling field terms as "shim reference maps" in units of Hz/unit-shim:
+
+        Gx, Gy, and Gz should yield 1 micro-T of field shift per metre: equivalently, 0.042576 Hz/mm
+
+        2nd order terms should yield 1 micro-T of field shift per metre-squared: equivalently, 0.000042576 Hz/mm^2
+
+        Gist: given the stated nominal values, we can pick several arbitrary reference positions around the origin/isocenter
+        at which we know what the field *should* be, and use that to calculate the appropriate scaling factor.
+
+        NOTE: The method has been worked out empirically and has only been tested for 2 Siemens Prisma systems.
+        E.g.re: Y, Z, ZX, and XY terms, it was noted that their polarity had to be flipped relative to the form given by
+        shimmingtoolbox.coils.spherical_harmonics. To adapt the code to other systems, arbitrary(?) changes along these
+        lines will likely be needed.
+        """
+
+        [x_iso, y_iso, z_iso] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)),
+                                            indexing='xy')
+        orders = np.array(range(1, 3))
+        sh = spherical_harmonics(orders, x_iso, y_iso, z_iso)
+        sh = reorder_to_siemens(sh)
+
+        n_channels = sh.shape[3]
+        scaling_factors = np.zeros(n_channels)
+
+        # indices of reference positions for normalization:
+        i_x1 = np.nonzero((x_iso == 1) & (y_iso == 0) & (z_iso == 0))
+        i_y1 = np.nonzero((x_iso == 0) & (y_iso == 1) & (z_iso == 0))
+        i_z1 = np.nonzero((x_iso == 0) & (y_iso == 0) & (z_iso == 1))
+
+        i_x1z1 = np.nonzero((x_iso == 1) & (y_iso == 0) & (z_iso == 1))
+        i_y1z1 = np.nonzero((x_iso == 0) & (y_iso == 1) & (z_iso == 1))
+        i_x1y1 = np.nonzero((x_iso == 1) & (y_iso == 1) & (z_iso == 0))
+
+        # order the reference indices like the sh field terms
+        i_ref = [i_x1, i_y1, i_z1, i_z1, i_x1z1, i_y1z1, i_x1, i_x1y1]
+
+        # distance from iso/origin to adopted reference point[units: mm]
+        r = [1, 1, 1, 1, np.sqrt(2), np.sqrt(2), 1, np.sqrt(2)]
+
+        # invert polarity
+        # Y, Z, ZX, and XY terms only(determined empirically)
+        sh[:, :, :, [1, 2, 4, 7]] = -sh[:, :, :, [1, 2, 4, 7]]
+
+        # scaling:
+        orders = [1, 1, 1, 2, 2, 2, 2, 2]
+
+        for i_ch in range(0, n_channels):
+            field = sh[:, :, :, i_ch]
+            scaling_factors[i_ch] = 42.576 * ((r[i_ch] * 0.001) ** orders[i_ch]) / field[i_ref[i_ch]]
+
+        return scaling_factors
+
     # Check inputs
     if not (x.ndim == y.ndim == z.ndim == 3):
         raise RuntimeError('Input arrays X, Y, and Z must be 3d')
@@ -136,7 +135,7 @@ def siemens_basis(x, y, z):
     # scale according to
     # - 1 micro-T/m for *X,Y,Z* gradients (= 0.042576 Hz/mm)
     # - 1 micro-T/m^2 for 2nd order terms (= 0.000042576 Hz/mm^2)
-    scaling_factors = scale(spher_harm)
+    scaling_factors = get_scaling_factors()
     scaled = np.zeros_like(reordered_spher)
     for i_channel in range(0, spher_harm.shape[3]):
         scaled[:, :, :, i_channel] = scaling_factors[i_channel] * reordered_spher[:, :, :, i_channel]

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -67,7 +67,6 @@ def siemens_basis(x, y, z):
         if spher_harm.shape[3] != 8:
             raise RuntimeError("Input arrays should have 4th dimension's shape equal to 8")
 
-        reordered = np.zeros(spher_harm.shape)
         reordered = spher_harm[:, :, :, [2, 0, 1, 5, 6, 4, 7, 3]]
 
         return reordered

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -20,7 +20,7 @@ def reorder_to_siemens(spher_harm):
 
     Args:
         spher_harm (numpy.ndarray): 4d basis set of spherical harmonics with order/degree ordered along 4th
-                                    dimension. ``spher_harm.shape[3]` must equal 8.
+                                    dimension. ``spher_harm.shape[3]`` must equal 8.
 
     Returns:
         numpy.ndarray: 4d basis set of spherical harmonics ordered following siemens convention

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -48,6 +48,13 @@ def siemens_basis(x, y, z):
         Reorder 1st - 2nd order basis terms along 4th dim. From
         1. Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2 (output by shimmingtoolbox.coils.spherical_harmonics.spherical_harmonics), to
         2. X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY (in line with Siemens shims)
+
+        Args:
+            spher_harm (numpy.ndarray): 4d basis set of spherical harmonics with order/degree ordered along 4th
+                                        dimension. ``spher_harm.shape[3]` must equal 8.
+
+        Returns:
+            numpy.ndarray: 4d basis set of spherical harmonics ordered following siemens convention
         """
 
         assert spher_harm.shape[3] == 8
@@ -65,15 +72,19 @@ def siemens_basis(x, y, z):
 
     def get_scaling_factors():
         """
-        Returns a vector of ``scaling_factors`` to apply to the(Siemens-reordered) 1st + 2nd order spherical harmonic fields
-        for rescaling field terms as "shim reference maps" in units of Hz/unit-shim:
+        Get scaling factors for the 8 terms to apply to the (Siemens-reordered) 1st + 2nd order spherical harmonic
+        fields for rescaling field terms as "shim reference maps" in units of Hz/unit-shim:
 
         Gx, Gy, and Gz should yield 1 micro-T of field shift per metre: equivalently, 0.042576 Hz/mm
 
         2nd order terms should yield 1 micro-T of field shift per metre-squared: equivalently, 0.000042576 Hz/mm^2
 
-        Gist: given the stated nominal values, we can pick several arbitrary reference positions around the origin/isocenter
-        at which we know what the field *should* be, and use that to calculate the appropriate scaling factor.
+        Gist: given the stated nominal values, we can pick several arbitrary reference positions around the
+        origin/isocenter at which we know what the field *should* be, and use that to calculate the appropriate scaling
+        factor.
+
+        Returns:
+             numpy.ndarray:  1D vector of ``scaling_factors``
 
         NOTE: The method has been worked out empirically and has only been tested for 2 Siemens Prisma systems.
         E.g.re: Y, Z, ZX, and XY terms, their polarity had to be flipped relative to the form given by

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -88,7 +88,7 @@ def siemens_basis(x, y, z):
 
         NOTE: The method has been worked out empirically and has only been tested for 2 Siemens Prisma systems.
         E.g.re: Y, Z, ZX, and XY terms, their polarity had to be flipped relative to the form given by
-        shimmingtoolbox.coils.spherical_harmonics.
+        ``shimmingtoolbox.coils.spherical_harmonics``.
         """
 
         [x_iso, y_iso, z_iso] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)),

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -12,7 +12,7 @@ XY = 7
 GYROMAGNETIC_RATIO = 42.576
 
 
-def reorder_to_siemens(spher_harm):
+def _reorder_to_siemens(spher_harm):
     """
     Reorder 1st - 2nd order basis terms along 4th dim. From
     1. Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2 (output by shimmingtoolbox.coils.spherical_harmonics.spherical_harmonics), to
@@ -20,7 +20,7 @@ def reorder_to_siemens(spher_harm):
 
     Args:
         spher_harm (numpy.ndarray): 4d basis set of spherical harmonics with order/degree ordered along 4th
-                                    dimension. ``spher_harm.shape[3]`` must equal 8.
+                                    dimension. ``spher_harm.shape[3]`` must qual 8.
 
     Returns:
         numpy.ndarray: 4d basis set of spherical harmonics ordered following siemens convention
@@ -34,7 +34,7 @@ def reorder_to_siemens(spher_harm):
     return reordered
 
 
-def get_scaling_factors():
+def _get_scaling_factors():
     """
     Get scaling factors for the 8 terms to apply to the (Siemens-reordered) 1st + 2nd order spherical harmonic
     fields for rescaling field terms as "shim reference maps" in units of Hz/unit-shim:
@@ -59,7 +59,7 @@ def get_scaling_factors():
                                         indexing='xy')
     orders = np.array(range(1, 3))
     sh = spherical_harmonics(orders, x_iso, y_iso, z_iso)
-    sh = reorder_to_siemens(sh)
+    sh = _reorder_to_siemens(sh)
 
     n_channels = sh.shape[3]
     scaling_factors = np.zeros(n_channels)
@@ -141,12 +141,12 @@ def siemens_basis(x, y, z):
     spher_harm = spherical_harmonics(orders, x, y, z)
 
     # Reorder according to siemens convention: X, Y, Z, Z2, ZX, ZY, X2-Y2, XY
-    reordered_spher = reorder_to_siemens(spher_harm)
+    reordered_spher = _reorder_to_siemens(spher_harm)
 
     # scale according to
     # - 1 micro-T/m for *X,Y,Z* gradients (= 0.042576 Hz/mm)
     # - 1 micro-T/m^2 for 2nd order terms (= 0.000042576 Hz/mm^2)
-    scaling_factors = get_scaling_factors()
+    scaling_factors = _get_scaling_factors()
     scaled = np.zeros_like(reordered_spher)
     for i_channel in range(0, spher_harm.shape[3]):
         scaled[:, :, :, i_channel] = scaling_factors[i_channel] * reordered_spher[:, :, :, i_channel]

--- a/shimmingtoolbox/coils/siemens_basis.py
+++ b/shimmingtoolbox/coils/siemens_basis.py
@@ -64,7 +64,7 @@ def siemens_basis(x, y, z):
             numpy.ndarray: 4d basis set of spherical harmonics ordered following siemens convention
         """
 
-        if not (spher_harm.shape[3] != 8):
+        if spher_harm.shape[3] != 8:
             raise RuntimeError("Input arrays should have 4th dimension's shape equal to 8")
 
         reordered = np.zeros(spher_harm.shape)

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -72,7 +72,6 @@ def spherical_harmonics(orders, x, y, z):
         r = np.sqrt(r2)
         phi = np.arctan2(pos_y, pos_x)
         cos_theta = np.cos(np.arctan2(np.sqrt(pos_x ** 2 + pos_y ** 2), pos_z))
-        # cos_theta = pos_z / r
 
         if m >= 0:
             c = 1
@@ -80,7 +79,6 @@ def spherical_harmonics(orders, x, y, z):
             c = 0
             m = -m
 
-        # y_mn = leg_rec(n, m, cos_theta)  # Does the same as lpmv function (Will remove after more tests)
         y_mn = lpmv(m, n, cos_theta)
 
         rri_norm = math.factorial(n + m + 1) / math.factorial(n - m) / factorial2(2 * m)

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -53,14 +53,6 @@ def spherical_harmonics(orders, x, y, z):
             - calc_spherical_harmonics_arb_points_cz.m by jaystock@nmr.mgh.harvard.edu
     """
 
-    def number_of_coef(orders):
-        n_coef = 0
-        for n in orders:
-            m = 2 * n + 1
-            n_coef += m
-
-        return n_coef
-
     def leg_rec_harmonic_cz(n, m, pos_x, pos_y, pos_z):
         """
         Returns harmonic field for the required solid harmonic addressed by n, m based on the Legendre
@@ -102,7 +94,7 @@ def spherical_harmonics(orders, x, y, z):
     # Initialize variables
     n_voxels = x.size
     n_orders = orders.size
-    n_basis = number_of_coef(orders)
+    n_basis = sum(2*orders+1)
     harm_all = np.zeros([n_voxels, n_basis])
 
     ii = 0

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -1,23 +1,149 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*
 
-from scipy.special import sph_harm
 import numpy as np
+import math
+from scipy.special import factorial2
+from scipy.special import lpmv
+from matplotlib.figure import Figure
+import os
 
 
-# def spherical_harmonics(order, X,Y,Z):
+def number_of_coef(orders):
+    out = 0
+    for n in orders:
+        m = 2 * n + 1
+        out += m
 
-phi = np.linspace(0, np.pi, 100)
-theta = np.linspace(0, 2 * np.pi, 100)
-phi, theta = np.meshgrid(phi, theta)
-
-x = np.sin(phi) * np.cos(theta)
-y = np.sin(phi) * np.sin(theta)
-z = np.cos(phi)
-
-m, n = 1, 1
-
-basis = sph_harm(m, n, theta, phi)
+    return out
 
 
+# Removed as it seems to be the same as scipy's lpmv function
+# def leg_rec(n, m, u):
+#     # compute legendre polynomial values for dat using recursive relations
+#
+#     if m > 0:
+#         p_mm = (-1) ** m * factorial2(2 * m - 1) * (1 - u ** 2) ** (m / 2)
+#     else:
+#         p_mm = 1
+#
+#     if n == m:
+#         out = p_mm
+#     else:
+#         p_mm1 = (2 * m + 1) * u * p_mm
+#
+#         if n == m + 1:
+#             out = p_mm1
+#         else:
+#             # recursive calculation needed
+#             a = m + 2
+#             p_ma_2 = p_mm
+#             p_ma_1 = p_mm1
+#
+#             while True:
+#                 p_ma = ((2 * a - 1) * u * p_ma_1 - (a + m - 1) * p_ma_2) / (a - m)
+#
+#                 if a == n:
+#                     break
+#
+#                 # prepare next iteration
+#                 p_ma_2 = p_ma_1
+#                 p_ma_1 = p_ma
+#                 a = a + 1
+#
+#             out = p_ma
+#
+#     return out
 
+
+def leg_rec_harmonic_cz(n, m, pos_x, pos_y, pos_z):
+    # returns harmonic field for the required solid harmonic addressed by n, m based on the  iterative Legendre
+    # polynomial calculation. Positive m values correspond to the cosine component, negative to the sine. Returned
+    # fields will eventually follow RRI 's convention pos_...can be both value and vector / matrix
+
+    r2 = pos_x ** 2 + pos_y ** 2 + pos_z ** 2
+    r = np.sqrt(r2)
+    phi = np.arctan2(pos_y, pos_x)
+    cos_theta = np.cos(np.arctan2(np.sqrt(pos_x ** 2 + pos_y ** 2), pos_z))
+    # cos_theta = pos_z / r
+
+    if m >= 0:
+        c = 1
+    else:
+        c = 0
+        m = -m
+
+    # y_mn = leg_rec(n, m, cos_theta)  # Does the same as lpmv function (Will remove after more tests)
+    y_mn = lpmv(m, n, cos_theta)
+
+    rri_norm = math.factorial(n + m + 1) / math.factorial(n - m) / factorial2(2 * m)
+
+    out = (n + m + 1) * (r ** n) * (np.cos(m * phi) * c + np.sin(m * phi) * (1 - c)) * y_mn / rri_norm
+
+    return out
+
+
+def spherical_harmonics(orders, x, y, z):
+
+    # Check inputs
+    if not (x.ndim == y.ndim == z.ndim):
+        raise RuntimeError('Input arrays X, Y, and Z must be identically sized')
+
+    if x.ndim == 2:
+        grid_size = [x.shape, 1]
+    elif x.ndim == 3:
+        grid_size = x.shape
+    else:
+        raise RuntimeError('Input arrays X, Y, and Z must have 2 or 3 dimensions')
+
+    # Initialize variables
+    n_voxels = x.size
+    n_orders = orders.size
+    n_basis = number_of_coef(orders)
+    harm_all = np.zeros([n_voxels, n_basis])
+
+    ii = 0
+
+    # Compute basis
+    for iOrder in range(0, n_orders):
+
+        n = orders[iOrder]
+        if n == 0:
+            m = np.zeros([1], dtype=int)
+        else:
+            m = np.array(range(-orders[iOrder], orders[iOrder] + 1, 1))
+
+        for mm in range(0, m.size):
+
+            # The first 2 * n(1) + 1 columns of the output correspond to harmonics of order n(1), and the next
+            # 2 * n(2) + 1 columns correspond to harmonics of order n(2), etc.
+            harm_all[:, ii] = leg_rec_harmonic_cz(n, m[mm], np.reshape(x, [n_voxels]), np.reshape(y, [n_voxels]),
+                                                  np.reshape(z, [n_voxels]))
+
+            ii += 1
+
+    # Reshape to initial grid_size
+    basis = np.zeros([grid_size[0], grid_size[1], grid_size[2], n_basis])
+
+    for i_basis in range(0, n_basis):
+        basis[:, :, :, i_basis] = np.reshape(harm_all[:, i_basis], grid_size)
+
+    return basis
+
+
+[x, y, z] = np.meshgrid(np.array(range(-10, 11)), np.array(range(-10, 11)), np.array(range(-10, 11)),
+                        indexing='ij')
+orders = np.array(range(0, 3))
+basis = spherical_harmonics(orders, x, y, z)
+
+# Plot results
+fig = Figure(figsize=(10, 10))
+
+for iBasis in range(0, number_of_coef(orders)):
+    ax = fig.add_subplot(3, 3, iBasis + 1)
+    im = ax.imshow(basis[:, :, 11, iBasis])
+    fig.colorbar(im)
+    ax.set_title(f'basis {iBasis + 1}')
+
+fname_figure = os.path.join(os.path.curdir, 'basis_plot.png')
+fig.savefig(fname_figure)

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -63,8 +63,6 @@ def leg_rec_harmonic_cz(n, m, pos_x, pos_y, pos_z):
     fields will eventually follow RRI 's convention pos_... can be both value and vector/matrix
     """
 
-
-
     r2 = pos_x ** 2 + pos_y ** 2 + pos_z ** 2
     r = np.sqrt(r2)
     phi = np.arctan2(pos_y, pos_x)

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -128,7 +128,7 @@ def spherical_harmonics(orders, x, y, z):
             - calc_spherical_harmonics_arb_points_cz.m by jaystock@nmr.mgh.harvard.edu
     """
     # Check inputs
-    if not (x.ndim == y.ndim == z.ndim):
+    if not (x.shape == y.shape == z.shape):
         raise RuntimeError('Input arrays X, Y, and Z must be identically sized')
 
     if x.ndim == 3:

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -92,7 +92,8 @@ def spherical_harmonics(orders, x, y, z):
 
     Args:
         orders (numpy.ndarray):  Degrees of the desired terms in the series expansion, specified as a vector of
-                                 non-negative integers (`[0:1:n]` yields harmonics up to n-th order)
+                                 non-negative integers (`np.array(range(0, 3))` yields harmonics up to (n-1)-th order).
+                                 Must be non negative.
         x (numpy.ndarray): 3-D arrays of grid coordinates
         y (numpy.ndarray): 3-D arrays of grid coordinates (same shape as x)
         z (numpy.ndarray): 3-D arrays of grid coordinates (same shape as x)
@@ -134,6 +135,9 @@ def spherical_harmonics(orders, x, y, z):
         grid_size = x.shape
     else:
         raise RuntimeError('Input arrays X, Y, and Z must have 3 dimensions')
+
+    if not np.all(orders >= 0):
+        raise RuntimeError('Orders must be positive')
 
     # Initialize variables
     n_voxels = x.size

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -57,9 +57,13 @@ def number_of_coef(orders):
 
 
 def leg_rec_harmonic_cz(n, m, pos_x, pos_y, pos_z):
-    # returns harmonic field for the required solid harmonic addressed by n, m based on the  iterative Legendre
-    # polynomial calculation. Positive m values correspond to the cosine component, negative to the sine. Returned
-    # fields will eventually follow RRI 's convention pos_...can be both value and vector / matrix
+    """
+    Returns harmonic field for the required solid harmonic addressed by n, m based on the Legendre
+    polynomial calculation. Positive m values correspond to the cosine component, negative to the sine. Returned
+    fields will eventually follow RRI 's convention pos_... can be both value and vector/matrix
+    """
+
+
 
     r2 = pos_x ** 2 + pos_y ** 2 + pos_z ** 2
     r = np.sqrt(r2)

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -13,7 +13,7 @@ def spherical_harmonics(orders, x, y, z):
 
     Args:
         orders (numpy.ndarray):  Degrees of the desired terms in the series expansion, specified as a vector of
-                                 non-negative integers (`np.array(range(0, 3))` yields harmonics up to (n-1)-th order).
+                                 non-negative integers (``np.array(range(0, 3))`` yields harmonics up to (n-1)-th order).
                                  Must be non negative.
         x (numpy.ndarray): 3-D arrays of grid coordinates
         y (numpy.ndarray): 3-D arrays of grid coordinates (same shape as x)
@@ -54,12 +54,12 @@ def spherical_harmonics(orders, x, y, z):
     """
 
     def number_of_coef(orders):
-        out = 0
+        n_coef = 0
         for n in orders:
             m = 2 * n + 1
-            out += m
+            n_coef += m
 
-        return out
+        return n_coef
 
     def leg_rec_harmonic_cz(n, m, pos_x, pos_y, pos_z):
         """
@@ -85,9 +85,9 @@ def spherical_harmonics(orders, x, y, z):
 
         rri_norm = math.factorial(n + m + 1) / math.factorial(n - m) / factorial2(2 * m)
 
-        out = (n + m + 1) * (r ** n) * (np.cos(m * phi) * c + np.sin(m * phi) * (1 - c)) * y_mn / rri_norm
+        harmonic_field = (n + m + 1) * (r ** n) * (np.cos(m * phi) * c + np.sin(m * phi) * (1 - c)) * y_mn / rri_norm
 
-        return out
+        return harmonic_field
 
     # Check inputs
     if not (x.shape == y.shape == z.shape):

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+
+from scipy.special import sph_harm
+import numpy as np
+
+
+# def spherical_harmonics(order, X,Y,Z):
+
+phi = np.linspace(0, np.pi, 100)
+theta = np.linspace(0, 2 * np.pi, 100)
+phi, theta = np.meshgrid(phi, theta)
+
+x = np.sin(phi) * np.cos(theta)
+y = np.sin(phi) * np.sin(theta)
+z = np.cos(phi)
+
+m, n = 1, 1
+
+basis = sph_harm(m, n, theta, phi)
+
+
+

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -84,17 +84,54 @@ def leg_rec_harmonic_cz(n, m, pos_x, pos_y, pos_z):
 
 
 def spherical_harmonics(orders, x, y, z):
+    """Return orthonormal spherical harmonic basis set
 
+    Returns an array of spherical harmonic basis fields with the order/degree index along the 4th dimension.
+
+    Args:
+        orders (numpy.ndarray):  Degrees of the desired terms in the series expansion, specified as a vector of
+                                 non-negative integers (`[0:1:n]` yields harmonics up to n-th order)
+        x (numpy.ndarray): 3-D arrays of grid coordinates
+        y (numpy.ndarray): 3-D arrays of grid coordinates (same shape as x)
+        z (numpy.ndarray): 3-D arrays of grid coordinates (same shape as x)
+
+    Returns:
+        numpy.ndarray: 4d basis set of spherical harmonics with order/degree ordered along 4th dimension
+
+    Examples:
+        Initialize grid positions
+        >>> [x, y, z] = np.meshgrid(np.array(range(-10, 11)), np.array(range(-10, 11)), np.array(range(-10, 11)),
+                        indexing='ij')
+        0th-to-2nd order terms inclusive
+        >>> orders = np.array(range(0, 3))
+        >>> basis = spherical_harmonics(orders, x, y, z)
+
+    Note:
+        - basis[:,:,:,1] corresponds to the 0th-order constant term (globally=unity)
+
+        - basis[:,:,:,2:4] to 1st-order linear terms
+            - 2: *y*
+            - 3: *z*
+            - 4: *x*
+        - basis[:,:,:,5:9] to 2nd-order terms
+            - 5: *xy*
+            - 6: *zy*
+            - 7: *z2*
+            - 8: *zx*
+            - 9: *x2y2*
+
+        Based on
+            - spherical_harmonics.m by topfer@ualberta.ca
+            - calc_spherical_harmonics_arb_points_cz.m by jaystock@nmr.mgh.harvard.edu
+    """
     # Check inputs
     if not (x.ndim == y.ndim == z.ndim):
         raise RuntimeError('Input arrays X, Y, and Z must be identically sized')
 
-    if x.ndim == 2:
-        grid_size = [x.shape, 1]
-    elif x.ndim == 3:
+    if x.ndim == 3:
         grid_size = x.shape
     else:
-        raise RuntimeError('Input arrays X, Y, and Z must have 2 or 3 dimensions')
+        raise RuntimeError('Input arrays X, Y, and Z must have 3 dimensions')
 
     # Initialize variables
     n_voxels = x.size

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -5,51 +5,10 @@ import numpy as np
 import math
 from scipy.special import factorial2
 from scipy.special import lpmv
-from matplotlib.figure import Figure
-import os
-
-
-def number_of_coef(orders):
-    out = 0
-    for n in orders:
-        m = 2 * n + 1
-        out += m
-
-    return out
-
-
-def leg_rec_harmonic_cz(n, m, pos_x, pos_y, pos_z):
-    """
-    Returns harmonic field for the required solid harmonic addressed by n, m based on the Legendre
-    polynomial calculation. Positive m values correspond to the cosine component, negative to the sine. Returned
-    fields will eventually follow RRI 's convention pos_... can be both value and vector/matrix
-    """
-
-    r2 = pos_x ** 2 + pos_y ** 2 + pos_z ** 2
-    r = np.sqrt(r2)
-    phi = np.arctan2(pos_y, pos_x)
-    cos_theta = np.cos(np.arctan2(np.sqrt(pos_x ** 2 + pos_y ** 2), pos_z))
-    # cos_theta = pos_z / r
-
-    if m >= 0:
-        c = 1
-    else:
-        c = 0
-        m = -m
-
-    # y_mn = leg_rec(n, m, cos_theta)  # Does the same as lpmv function (Will remove after more tests)
-    y_mn = lpmv(m, n, cos_theta)
-
-    rri_norm = math.factorial(n + m + 1) / math.factorial(n - m) / factorial2(2 * m)
-
-    out = (n + m + 1) * (r ** n) * (np.cos(m * phi) * c + np.sin(m * phi) * (1 - c)) * y_mn / rri_norm
-
-    return out
 
 
 def spherical_harmonics(orders, x, y, z):
-    """Return orthonormal spherical harmonic basis set
-
+    """
     Returns an array of spherical harmonic basis fields with the order/degree index along the 4th dimension.
 
     Args:
@@ -65,30 +24,71 @@ def spherical_harmonics(orders, x, y, z):
 
     Examples:
         Initialize grid positions
-        >>> [x, y, z] = np.meshgrid(np.array(range(-10, 11)), np.array(range(-10, 11)), np.array(range(-10, 11)),
-                        indexing='ij')
+
+        >>> [x, y, z] = np.meshgrid(np.array(range(-10, 11)), np.array(range(-10, 11)), np.array(range(-10, 11)), indexing='ij')
+
         0th-to-2nd order terms inclusive
+
         >>> orders = np.array(range(0, 3))
         >>> basis = spherical_harmonics(orders, x, y, z)
 
-    Note:
-        - basis[:,:,:,1] corresponds to the 0th-order constant term (globally=unity)
+    Notes:
+        - basis[:, :, :,0] corresponds to the 0th-order constant term (globally=unity)
+            - 0: *c*
 
-        - basis[:,:,:,2:4] to 1st-order linear terms
-            - 2: *y*
-            - 3: *z*
-            - 4: *x*
-        - basis[:,:,:,5:9] to 2nd-order terms
-            - 5: *xy*
-            - 6: *zy*
-            - 7: *z2*
-            - 8: *zx*
-            - 9: *x2y2*
+        - basis[:, :, :, 1:3] to 1st-order linear terms
+            - 1: *y*
+            - 2: *z*
+            - 3: *x*
+
+        - basis[:, :, :, 4:8] to 2nd-order terms
+            - 4: *xy*
+            - 5: *zy*
+            - 6: *z2*
+            - 7: *zx*
+            - 8: *x2y2*
 
         Based on
             - spherical_harmonics.m by topfer@ualberta.ca
             - calc_spherical_harmonics_arb_points_cz.m by jaystock@nmr.mgh.harvard.edu
     """
+
+    def number_of_coef(orders):
+        out = 0
+        for n in orders:
+            m = 2 * n + 1
+            out += m
+
+        return out
+
+    def leg_rec_harmonic_cz(n, m, pos_x, pos_y, pos_z):
+        """
+        Returns harmonic field for the required solid harmonic addressed by n, m based on the Legendre
+        polynomial calculation. Positive m values correspond to the cosine component, negative to the sine. Returned
+        fields will eventually follow RRI s convention
+        """
+
+        r2 = pos_x ** 2 + pos_y ** 2 + pos_z ** 2
+        r = np.sqrt(r2)
+        phi = np.arctan2(pos_y, pos_x)
+        cos_theta = np.cos(np.arctan2(np.sqrt(pos_x ** 2 + pos_y ** 2), pos_z))
+        # cos_theta = pos_z / r
+
+        if m >= 0:
+            c = 1
+        else:
+            c = 0
+            m = -m
+
+        # y_mn = leg_rec(n, m, cos_theta)  # Does the same as lpmv function (Will remove after more tests)
+        y_mn = lpmv(m, n, cos_theta)
+
+        rri_norm = math.factorial(n + m + 1) / math.factorial(n - m) / factorial2(2 * m)
+
+        out = (n + m + 1) * (r ** n) * (np.cos(m * phi) * c + np.sin(m * phi) * (1 - c)) * y_mn / rri_norm
+
+        return out
+
     # Check inputs
     if not (x.shape == y.shape == z.shape):
         raise RuntimeError('Input arrays X, Y, and Z must be identically sized')

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -18,44 +18,6 @@ def number_of_coef(orders):
     return out
 
 
-# Removed as it seems to be the same as scipy's lpmv function
-# def leg_rec(n, m, u):
-#     # compute legendre polynomial values for dat using recursive relations
-#
-#     if m > 0:
-#         p_mm = (-1) ** m * factorial2(2 * m - 1) * (1 - u ** 2) ** (m / 2)
-#     else:
-#         p_mm = 1
-#
-#     if n == m:
-#         out = p_mm
-#     else:
-#         p_mm1 = (2 * m + 1) * u * p_mm
-#
-#         if n == m + 1:
-#             out = p_mm1
-#         else:
-#             # recursive calculation needed
-#             a = m + 2
-#             p_ma_2 = p_mm
-#             p_ma_1 = p_mm1
-#
-#             while True:
-#                 p_ma = ((2 * a - 1) * u * p_ma_1 - (a + m - 1) * p_ma_2) / (a - m)
-#
-#                 if a == n:
-#                     break
-#
-#                 # prepare next iteration
-#                 p_ma_2 = p_ma_1
-#                 p_ma_1 = p_ma
-#                 a = a + 1
-#
-#             out = p_ma
-#
-#     return out
-
-
 def leg_rec_harmonic_cz(n, m, pos_x, pos_y, pos_z):
     """
     Returns harmonic field for the required solid harmonic addressed by n, m based on the Legendre
@@ -172,21 +134,3 @@ def spherical_harmonics(orders, x, y, z):
         basis[:, :, :, i_basis] = np.reshape(harm_all[:, i_basis], grid_size)
 
     return basis
-
-
-[x, y, z] = np.meshgrid(np.array(range(-10, 11)), np.array(range(-10, 11)), np.array(range(-10, 11)),
-                        indexing='ij')
-orders = np.array(range(0, 3))
-basis = spherical_harmonics(orders, x, y, z)
-
-# Plot results
-fig = Figure(figsize=(10, 10))
-
-for iBasis in range(0, number_of_coef(orders)):
-    ax = fig.add_subplot(3, 3, iBasis + 1)
-    im = ax.imshow(basis[:, :, 11, iBasis])
-    fig.colorbar(im)
-    ax.set_title(f'basis {iBasis + 1}')
-
-fname_figure = os.path.join(os.path.curdir, 'basis_plot.png')
-fig.savefig(fname_figure)

--- a/shimmingtoolbox/coils/spherical_harmonics.py
+++ b/shimmingtoolbox/coils/spherical_harmonics.py
@@ -89,15 +89,15 @@ def spherical_harmonics(orders, x, y, z):
 
     # Check inputs
     if not (x.shape == y.shape == z.shape):
-        raise RuntimeError('Input arrays X, Y, and Z must be identically sized')
+        raise RuntimeError("Input arrays X, Y, and Z must be identically sized")
 
     if x.ndim == 3:
         grid_size = x.shape
     else:
-        raise RuntimeError('Input arrays X, Y, and Z must have 3 dimensions')
+        raise RuntimeError("Input arrays X, Y, and Z must have 3 dimensions")
 
     if not np.all(orders >= 0):
-        raise RuntimeError('Orders must be positive')
+        raise RuntimeError("Orders must be positive")
 
     # Initialize variables
     n_voxels = x.size

--- a/test/test_siemens_basis.py
+++ b/test/test_siemens_basis.py
@@ -19,5 +19,8 @@ def test_normal_siemens_basis(x, y, z):
 
     # Test for shape
     assert(np.all(basis.shape == (x.shape[0], x.shape[1], x.shape[2], 8)))
-    # Test for first value
+
+    # Test for a value, arbitrarily chose basis[0, 0, 0, 0].
+    # The full matrix could be checked to be more thorough but would require explicitly defining the matrix which is
+    # 2x2x2x8. -4.25760000e-02 was worked out to be the value that should be in basis[0, 0, 0, 0].
     assert(math.isclose(basis[0, 0, 0, 0], -4.25760000e-02, rel_tol=1e-09))

--- a/test/test_siemens_basis.py
+++ b/test/test_siemens_basis.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+
+import numpy as np
+import pytest
+import math
+
+from shimmingtoolbox.coils.siemens_basis import siemens_basis
+
+dummy_data = [
+    np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)), indexing='ij'),
+]
+
+
+@pytest.mark.parametrize('x,y,z', dummy_data)
+def test_normal_siemens_basis(x, y, z):
+
+    basis = siemens_basis(x, y, z)
+
+    # Test for shape
+    assert(np.all(basis.shape == (x.shape[0], x.shape[1], x.shape[2], 8)))
+    # Test for first value
+    assert(math.isclose(basis[0, 0, 0, 0], -4.25760000e-02, rel_tol=1e-09))

--- a/test/test_spherical_harmonics.py
+++ b/test/test_spherical_harmonics.py
@@ -1,14 +1,18 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*
 
-
 import numpy as np
+import pytest
 
 from shimmingtoolbox.coils.spherical_harmonics import spherical_harmonics
 
+dummy_data = [
+    np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)), indexing='ij'),
+]
 
-def test_normal_use():
-    [x, y, z] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)), indexing='ij')
+
+@pytest.mark.parametrize('x,y,z', dummy_data)
+def test_normal_use(x, y, z):
     orders = np.array(range(0, 2, 1))
     basis = spherical_harmonics(orders, x, y, z)
 
@@ -16,8 +20,8 @@ def test_normal_use():
     assert(basis[:, :, :, 0].shape == x.shape)
 
 
-def test_wrong_input_dimension():
-    [x, y, z] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)), indexing='ij')
+@pytest.mark.parametrize('x,y,z', dummy_data)
+def test_wrong_input_dimension(x, y, z):
     orders = np.array(range(0, 2, 1))
 
     # Call spherical harmonics with wrong dimension
@@ -32,8 +36,8 @@ def test_wrong_input_dimension():
     assert False
 
 
-def test_negative_order():
-    [x, y, z] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)), indexing='ij')
+@pytest.mark.parametrize('x,y,z', dummy_data)
+def test_negative_order(x, y, z):
     orders = np.array(range(-1, 2, 1))
 
     # Call spherical harmonics with negative order

--- a/test/test_spherical_harmonics.py
+++ b/test/test_spherical_harmonics.py
@@ -32,7 +32,7 @@ def test_wrong_input_dimension(x, y, z):
         return 0
 
     # If there isn't an error, then there is a problem
-    print('\nWrong dimensions for input x does not throw an error')
+    print("\nWrong dimensions for input x does not throw an error")
     assert False
 
 
@@ -48,5 +48,5 @@ def test_negative_order(x, y, z):
         return 0
 
     # If there isn't an error, then there is a problem
-    print('\nNegative order does not throw an error')
+    print("\nNegative order does not throw an error")
     assert False

--- a/test/test_spherical_harmonics.py
+++ b/test/test_spherical_harmonics.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+
+
+import numpy as np
+
+from shimmingtoolbox.coils.spherical_harmonics import spherical_harmonics
+
+
+def test_normal_use():
+    [x, y, z] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)), indexing='ij')
+    orders = np.array(range(0, 2, 1))
+    basis = spherical_harmonics(orders, x, y, z)
+
+    assert(basis.ndim == 4)
+    assert(basis[:, :, :, 0].shape == x.shape)
+
+
+def test_wrong_input_dimension():
+    [x, y, z] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)), indexing='ij')
+    orders = np.array(range(0, 2, 1))
+
+    # Call spherical harmonics with wrong dimension
+    try:
+        spherical_harmonics(orders, x[:, :, 0], y, z)
+    except RuntimeError:
+        # If an exception occurs, this is the desired behaviour
+        return 0
+
+    # If there isn't an error, then there is a problem
+    print('\nWrong dimensions for input x does not throw an error')
+    assert False
+
+
+def test_negative_order():
+    [x, y, z] = np.meshgrid(np.array(range(-1, 2)), np.array(range(-1, 2)), np.array(range(-1, 2)), indexing='ij')
+    orders = np.array(range(-1, 2, 1))
+
+    # Call spherical harmonics with negative order
+    try:
+        spherical_harmonics(orders, x, y, z)
+    except RuntimeError:
+        # If an exception occurs, this is the desired behaviour
+        return 0
+
+    # If there isn't an error, then there is a problem
+    print('\nNegative order does not throw an error')
+    assert False


### PR DESCRIPTION
## Context

Coil profiles are required for shimming to know how the field will change when current is applied to a channel. Siemens coils are designed to generate SH fields. Using spherical harmonics generation can be used to create synthetic coil profiles as they simulate the Siemens' shimming coils.

## Proposed changes

This PR introduces a function that creates spherical harmonics and reorders/scales them to siemens specifications (X, Y, Z, Z2, ZX, ZY, X2-Y2, XY). 

- [x] siemens_basis(x, y, z) (1st to 2nd order)
  - [x] spherical_harmonics(orders, x, y, z)


Future PRs
siemens_basis(orders, x, y, z) (3rd order) #76 

## Rendered documentation

➤ https://shimming-toolbox.org/en/ad-coil-profiles/