### PR TITLE
Repair dicom_to_nifti missing calls [bug]

### DIFF
--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -7,7 +7,10 @@ from distutils.dir_util import copy_tree
 import json
 import numpy as np
 import os
+import sys
 import subprocess
+import dcm2bids
+from dcm2bids.scaffold import scaffold
 
 from shimmingtoolbox import __dir_config_dcm2bids__
 
@@ -30,9 +33,11 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
         raise FileNotFoundError("No dcm2bids config file found")
     if not os.path.exists(path_nifti):
         os.makedirs(path_nifti)
+
+    # dcm2bids is broken for windows as a python package so using CLI
     # Create bids structure for data
-    # TODO; use dcm2bids as python package (no system call)
     subprocess.run(['dcm2bids_scaffold', '-o', path_nifti], check=True)
+
     #
     # # Copy original dicom files into nifti_path/sourcedata
     copy_tree(path_dicom, os.path.join(path_nifti, 'sourcedata'))
@@ -50,39 +55,44 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     if not helper_file_list:
         raise ValueError('No data to process')
 
-    # # Create list of acquisitions
-    # acquisition_names = []
-    # acquisition_numbers = []
-    # modality = []
+    subprocess.run(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', path_config_dcm2bids],
+                   check=True)
+
+    # if 'win' in sys.platform:
+    #     # dcm2bids is broken for windows as a python package so using CLI
+    #     # Create bids structure for data
+    #     subprocess.run(['dcm2bids_scaffold', '-o', path_nifti], check=True)
     #
-    # # Create lists containing all acquisition names and numbers
-    # for file in [file for file in helper_file_list if file.endswith(".json")]:
-    #     name, ext = os.path.splitext(file)
-    #     # Check for both.gz and .nii
-    #     niftis = [name + ext for ext in [".nii", ".nii.gz"] if (name + ext) in helper_file_list]
-    #     nifti = str(niftis[0])
+    #     #
+    #     # # Copy original dicom files into nifti_path/sourcedata
+    #     copy_tree(path_dicom, os.path.join(path_nifti, 'sourcedata'))
+    #     #
+    #     # # Call the dcm2bids_helper
+    #     subprocess.run(['dcm2bids_helper', '-d', path_dicom, '-o', path_nifti], check=True)
+    #     #
+    #     # Check if the helper folder has been created
+    #     helper_path = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
+    #     if not os.path.isdir(helper_path):
+    #         raise ValueError('dcm2bids_helper could not create directory helper')
     #
-    #     # Read json file
-    #     _, json_data = read_nii(os.path.join(helper_path, nifti))
+    #     # Make sure there is data in nifti_path / tmp_dcm2bids / helper
+    #     helper_file_list = os.listdir(helper_path)
+    #     if not helper_file_list:
+    #         raise ValueError('No data to process')
     #
-    #     # Create future folder name
-    #     acquisition_numbers.append(json_data['SeriesNumber'])
-    #     acquisition_names.append(json_data['SeriesDescription'])
-    #     # Modality could be used as acquisition name
-    #     modality.append(json_data['Modality'])
+    #     subprocess.run(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', path_config_dcm2bids], check=True)
+    # else:
+    #     bids_info = dcm2bids.Dcm2bids([path_dicom], subject_id, path_config_dcm2bids, path_nifti)
+    #     scaffold()
     #
-    # # Remove duplicates
-    # acquisition_numbers, ia = np.unique(acquisition_numbers, return_index=True)
-    # acquisition_names_short = []
-    # modality_short = []
-    # for iAcq in ia:
-    #     acquisition_names_short.append(acquisition_names[iAcq])
-    #     modality_short.append(modality[iAcq])
+    #     helper_path = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
+    #     if not os.path.isdir(helper_path):
+    #         raise ValueError('dcm2bids_helper could not create directory helper')
+    #     helper_file_list = os.listdir(helper_path)
+    #     if not helper_file_list:
+    #         raise ValueError('No data to process')
     #
-    # # Folder where the different nifti acquisitions will be stored
-    # output_dir = os.path.join(path_nifti, 'code')
-    #
-    subprocess.run(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', path_config_dcm2bids], check=True)
+    #     bids_info.run()
 
     if remove_tmp:
         os.removedirs(os.path.join(path_dicom, 'tmp_dcm2bids'))

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -1,8 +1,6 @@
 #!usr/bin/env python3
 # -*- coding: utf-8
 
-# TODO: check in unit test if dcm2bids_scaffold is installed, and also check for the required version.
-
 from distutils.dir_util import copy_tree
 import json
 import numpy as np

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -46,12 +46,12 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     subprocess.run(['dcm2bids_helper', '-d', path_dicom, '-o', path_nifti], check=True)
     #
     # Check if the helper folder has been created
-    helper_path = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
-    if not os.path.isdir(helper_path):
+    path_helper = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
+    if not os.path.isdir(path_helper):
         raise ValueError('dcm2bids_helper could not create directory helper')
 
     # Make sure there is data in nifti_path / tmp_dcm2bids / helper
-    helper_file_list = os.listdir(helper_path)
+    helper_file_list = os.listdir(path_helper)
     if not helper_file_list:
         raise ValueError('No data to process')
 
@@ -71,12 +71,12 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     #     subprocess.run(['dcm2bids_helper', '-d', path_dicom, '-o', path_nifti], check=True)
     #     #
     #     # Check if the helper folder has been created
-    #     helper_path = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
-    #     if not os.path.isdir(helper_path):
+    #     path_helper = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
+    #     if not os.path.isdir(path_helper):
     #         raise ValueError('dcm2bids_helper could not create directory helper')
     #
     #     # Make sure there is data in nifti_path / tmp_dcm2bids / helper
-    #     helper_file_list = os.listdir(helper_path)
+    #     helper_file_list = os.listdir(path_helper)
     #     if not helper_file_list:
     #         raise ValueError('No data to process')
     #
@@ -85,10 +85,10 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     #     bids_info = dcm2bids.Dcm2bids([path_dicom], subject_id, path_config_dcm2bids, path_nifti)
     #     scaffold()
     #
-    #     helper_path = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
-    #     if not os.path.isdir(helper_path):
+    #     path_helper = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
+    #     if not os.path.isdir(path_helper):
     #         raise ValueError('dcm2bids_helper could not create directory helper')
-    #     helper_file_list = os.listdir(helper_path)
+    #     helper_file_list = os.listdir(path_helper)
     #     if not helper_file_list:
     #         raise ValueError('No data to process')
     #

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -14,9 +14,6 @@ import dcm2bids
 
 from shimmingtoolbox import __dir_config_dcm2bids__
 
-# TODO: check in unit test if dcm2bids_scaffold is installed, and also check for the required version.
-
-
 def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__, remove_tmp=False):
     """ Converts dicom files into nifti files by calling dcm2bids
 

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -25,7 +25,11 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     # TODO: remove temp tmp_dcm2bids (if user wants to)
 
     # Create the folder where the nifti files will be stored
-    if not os.exists(path_nifti):
+    if not os.path.exists(path_dicom):
+        raise(FileNotFoundError, "No dicom path found")
+    if not os.path.exists(path_config_dcm2bids):
+        raise(FileNotFoundError, "No dcm2bids config file found")
+    if not os.path.exists(path_nifti):
         os.makedirs(path_nifti)
     # Create bids structure for data
     # TODO; use dcm2bids as python package (no system call)

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -14,7 +14,7 @@ from shimmingtoolbox import __dir_config_dcm2bids__
 # TODO: check in unit test if dcm2bids_scaffold is installed, and also check for the required version.
 
 
-def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__):
+def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__, remove_tmp=False):
     """ Converts dicom files into nifti files by calling dcm2bids
 
     Args:
@@ -22,13 +22,12 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
         path_nifti (str): path to the output nifti folder
 
     """
-    # TODO: remove temp tmp_dcm2bids (if user wants to)
 
     # Create the folder where the nifti files will be stored
     if not os.path.exists(path_dicom):
-        raise(FileNotFoundError, "No dicom path found")
+        raise FileNotFoundError("No dicom path found")
     if not os.path.exists(path_config_dcm2bids):
-        raise(FileNotFoundError, "No dcm2bids config file found")
+        raise FileNotFoundError("No dcm2bids config file found")
     if not os.path.exists(path_nifti):
         os.makedirs(path_nifti)
     # Create bids structure for data
@@ -41,16 +40,16 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     # # Call the dcm2bids_helper
     subprocess.run(['dcm2bids_helper', '-d', path_dicom, '-o', path_nifti], check=True)
     #
-    # # Check if the helper folder has been created
-    # helper_path = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
-    # if not os.path.isdir(helper_path):
-    #     raise ValueError('dcm2bids_helper could not create directory helper')
-    #
-    # # Make sure there is data in nifti_path / tmp_dcm2bids / helper
-    # helper_file_list = os.listdir(helper_path)
-    # if not helper_file_list:
-    #     raise ValueError('No data to process')
-    #
+    # Check if the helper folder has been created
+    helper_path = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
+    if not os.path.isdir(helper_path):
+        raise ValueError('dcm2bids_helper could not create directory helper')
+
+    # Make sure there is data in nifti_path / tmp_dcm2bids / helper
+    helper_file_list = os.listdir(helper_path)
+    if not helper_file_list:
+        raise ValueError('No data to process')
+
     # # Create list of acquisitions
     # acquisition_names = []
     # acquisition_numbers = []
@@ -84,3 +83,6 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     # output_dir = os.path.join(path_nifti, 'code')
     #
     subprocess.run(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', path_config_dcm2bids], check=True)
+
+    if remove_tmp:
+        os.removedirs(os.path.join(path_dicom, 'tmp_dcm2bids'))

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -1,10 +1,17 @@
-# coding: utf-8
+#!usr/bin/env python3
+# -*- coding: utf-8
 
 # TODO: check in unit test if dcm2bids_scaffold is installed, and also check for the required version.
 
+from distutils.dir_util import copy_tree
+import json
+import numpy as np
+import os
 import subprocess
 
 from shimmingtoolbox import __dir_config_dcm2bids__
+
+# TODO: check in unit test if dcm2bids_scaffold is installed, and also check for the required version.
 
 
 def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__):
@@ -15,6 +22,110 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
         path_nifti (str): path to the output nifti folder
 
     """
-    cmd = 'dcm2bids -d {} -p {} -o {} -l DEBUG -c {}'.format(
-        path_dicom, subject_id, path_nifti, path_config_dcm2bids)
-    subprocess.run(cmd.split(' '))
+    # TODO: remove temp tmp_dcm2bids (if user wants to)
+
+    # # Create the folder where the nifti files will be stored
+    # # TODO: might crash if folder already exists
+    # os.makedirs(path_nifti)
+    #
+    # # Create bids structure for data
+    # # TODO; use dcm2bids as python package (no system call)
+    subprocess.run(['dcm2bids_scaffold', '-o', path_nifti], check=True)
+    #
+    # # Copy original dicom files into nifti_path/sourcedata
+    copy_tree(path_dicom, os.path.join(path_nifti, 'sourcedata'))
+    #
+    # # Call the dcm2bids_helper
+    subprocess.run(['dcm2bids_helper', '-d', path_dicom, '-o', path_nifti], check=True)
+    #
+    # # Check if the helper folder has been created
+    # helper_path = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
+    # if not os.path.isdir(helper_path):
+    #     raise ValueError('dcm2bids_helper could not create directory helper')
+    #
+    # # Make sure there is data in nifti_path / tmp_dcm2bids / helper
+    # helper_file_list = os.listdir(helper_path)
+    # if not helper_file_list:
+    #     raise ValueError('No data to process')
+    #
+    # # Create list of acquisitions
+    # acquisition_names = []
+    # acquisition_numbers = []
+    # modality = []
+    #
+    # # Create lists containing all acquisition names and numbers
+    # for file in [file for file in helper_file_list if file.endswith(".json")]:
+    #     name, ext = os.path.splitext(file)
+    #     # Check for both.gz and .nii
+    #     niftis = [name + ext for ext in [".nii", ".nii.gz"] if (name + ext) in helper_file_list]
+    #     nifti = str(niftis[0])
+    #
+    #     # Read json file
+    #     _, json_data = read_nii(os.path.join(helper_path, nifti))
+    #
+    #     # Create future folder name
+    #     acquisition_numbers.append(json_data['SeriesNumber'])
+    #     acquisition_names.append(json_data['SeriesDescription'])
+    #     # Modality could be used as acquisition name
+    #     modality.append(json_data['Modality'])
+    #
+    # # Remove duplicates
+    # acquisition_numbers, ia = np.unique(acquisition_numbers, return_index=True)
+    # acquisition_names_short = []
+    # modality_short = []
+    # for iAcq in ia:
+    #     acquisition_names_short.append(acquisition_names[iAcq])
+    #     modality_short.append(modality[iAcq])
+    #
+    # # Folder where the different nifti acquisitions will be stored
+    # output_dir = os.path.join(path_nifti, 'code')
+    #
+    # for iAcq in range(len(acquisition_names_short)):
+    #     # Create a config.json file, place it in nifti_path / code
+    #     config_file_path = create_config(output_dir, acquisition_numbers[iAcq], acquisition_names_short[iAcq], modality_short[iAcq])
+    #
+    #     # Call dcm2bids
+    #     participant = ''
+    subprocess.run(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', path_config_dcm2bids], check=True)
+
+
+# def create_config(output_dir, acquisition_number, acquisition_name, modality):
+#     """ Creates a config.json file used by dcm2bids to sort the nifti files of a same acquisition into a same folder
+#
+#     Args:
+#         output_dir (str): path to the folder where dcm2bids will store the acquisitions as a folder
+#         acquisition_number (int): number of the acquisition
+#         acquisition_name (str): name of the acquisition
+#         modality (str): name of the modality used during the acquisition
+#
+#     Returns:
+#         file_path: path to the folder where the nifti and json files corresponding to the acquisition have been stored
+#
+#     """
+#     # Define the config file name
+#     name = str(acquisition_number) + '_' + acquisition_name
+#     file_path = os.path.join(output_dir, name + '.json')
+#
+#     # Create a dictionary that will be used to write a config.json file
+#     config = {
+#         "searchMethod": "fnmatch",
+#         "defaceTpl": "pydeface --outfile {dstFile} {srcFile}",
+#         "descriptions": [{
+#             "dataType": name,
+#             "SeriesDescription": name,
+#             "modalityLabel": modality,
+#             "criteria": {
+#                 "SeriesDescription": acquisition_name,
+#                 "SeriesNumber": str(acquisition_number)
+#             },
+#         }],
+#     }
+#
+#     # Create a config.json file that will be used by dcm2bids to separate the nifti files
+#     with open(file_path, 'w') as config_file:
+#         json.dump(config, config_file)
+#
+#     # Close file
+#     config_file.close()
+#
+#     return file_path

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -24,12 +24,11 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     """
     # TODO: remove temp tmp_dcm2bids (if user wants to)
 
-    # # Create the folder where the nifti files will be stored
-    # # TODO: might crash if folder already exists
-    # os.makedirs(path_nifti)
-    #
-    # # Create bids structure for data
-    # # TODO; use dcm2bids as python package (no system call)
+    # Create the folder where the nifti files will be stored
+    if not os.exists(path_nifti):
+        os.makedirs(path_nifti)
+    # Create bids structure for data
+    # TODO; use dcm2bids as python package (no system call)
     subprocess.run(['dcm2bids_scaffold', '-o', path_nifti], check=True)
     #
     # # Copy original dicom files into nifti_path/sourcedata
@@ -80,52 +79,4 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     # # Folder where the different nifti acquisitions will be stored
     # output_dir = os.path.join(path_nifti, 'code')
     #
-    # for iAcq in range(len(acquisition_names_short)):
-    #     # Create a config.json file, place it in nifti_path / code
-    #     config_file_path = create_config(output_dir, acquisition_numbers[iAcq], acquisition_names_short[iAcq], modality_short[iAcq])
-    #
-    #     # Call dcm2bids
-    #     participant = ''
     subprocess.run(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', path_config_dcm2bids], check=True)
-
-
-# def create_config(output_dir, acquisition_number, acquisition_name, modality):
-#     """ Creates a config.json file used by dcm2bids to sort the nifti files of a same acquisition into a same folder
-#
-#     Args:
-#         output_dir (str): path to the folder where dcm2bids will store the acquisitions as a folder
-#         acquisition_number (int): number of the acquisition
-#         acquisition_name (str): name of the acquisition
-#         modality (str): name of the modality used during the acquisition
-#
-#     Returns:
-#         file_path: path to the folder where the nifti and json files corresponding to the acquisition have been stored
-#
-#     """
-#     # Define the config file name
-#     name = str(acquisition_number) + '_' + acquisition_name
-#     file_path = os.path.join(output_dir, name + '.json')
-#
-#     # Create a dictionary that will be used to write a config.json file
-#     config = {
-#         "searchMethod": "fnmatch",
-#         "defaceTpl": "pydeface --outfile {dstFile} {srcFile}",
-#         "descriptions": [{
-#             "dataType": name,
-#             "SeriesDescription": name,
-#             "modalityLabel": modality,
-#             "criteria": {
-#                 "SeriesDescription": acquisition_name,
-#                 "SeriesNumber": str(acquisition_number)
-#             },
-#         }],
-#     }
-#
-#     # Create a config.json file that will be used by dcm2bids to separate the nifti files
-#     with open(file_path, 'w') as config_file:
-#         json.dump(config, config_file)
-#
-#     # Close file
-#     config_file.close()
-#
-#     return file_path

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -10,7 +10,7 @@ import os
 import sys
 import subprocess
 import dcm2bids
-from dcm2bids.scaffold import scaffold
+# from dcm2bids.scaffold import scaffold
 
 from shimmingtoolbox import __dir_config_dcm2bids__
 


### PR DESCRIPTION
There was a bug in the dicom_to_nifti function that forgot to call dcm2bids_scaffold and dcm2bids_helper which create the file hierarchy needed to respect BIDS convention and be used by other BIDS library (missing mandatory calls to work).

This pull-request wants to add these calls and check which code is necessary or not to have a final BIDS file hierarchy.