### PR TITLE
[chore][cli/download_data] Remove stale TODO

### DIFF
--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -28,7 +28,6 @@ def main(verbose, output, data):
         output: Output folder.
         data: The data to be downloaded.
     """
-    # TODO: logging does not seem to output on the terminal
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
     logging.info(f'{output}, {data}')


### PR DESCRIPTION
**Why this change was necessary**
The `--verbose` flag works as expected, so the TODO has already been
addressed.

**What this change does**
Remove the TODO.

**Any side-effects?**
None

**Additional context/notes/links**

Resolves #89


----

#