### PR TITLE
[fix][download_data] Automatically generate dataset info in CLI help message

### DIFF
--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -14,8 +14,14 @@ from shimmingtoolbox.download import install_data
 #     1. String description of the item
 
 URL_DICT: Dict[str, Tuple[List[str], str]] = {
-    "testing_data": (["https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"], "Light-weighted dataset for testing purpose."),
-    "prelude": (["https://github.com/shimming-toolbox/binaries/raw/master/prelude"], "Binary for prelude software")
+    "testing_data": (
+        ["https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"],
+        "Light-weighted dataset for testing purpose.",
+    ),
+    "prelude": (
+        ["https://github.com/shimming-toolbox/binaries/raw/master/prelude"],
+        "Binary for prelude software",
+    ),
 }
 
 dataset_list_str: str = ""
@@ -23,7 +29,10 @@ dataset_list_str: str = ""
 for item in URL_DICT.items():
     dataset_list_str += f"\n\n - {item[0]}: {item[1][1]}"
 
-@click.command(help=f"Download data from the internet. The available datasets are:{dataset_list_str}")
+
+@click.command(
+    help=f"Download data from the internet. The available datasets are:{dataset_list_str}"
+)
 @click.option("--verbose", is_flag=True, help="Be more verbose.")
 @click.option("--output", help="Output folder.")
 @click.argument("data")

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -15,7 +15,7 @@ from shimmingtoolbox.download import install_data
 
 URL_DICT: Dict[str, Tuple[List[str], str]] = {
     "testing_data": (["https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"], "Light-weighted dataset for testing purpose."),
-    "prelude": (["https://github.com/shimming-toolbox/binaries/raw/master/prelude"], "Binary for prelude software") # TODO: What does prelude do? is it another dataset?
+    "prelude": (["https://github.com/shimming-toolbox/binaries/raw/master/prelude"], "Binary for prelude software")
 }
 
 dataset_list_str: str = ""

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -3,19 +3,27 @@
 import os
 import logging
 import click
+from typing import Dict, Tuple, List
 
 from shimmingtoolbox.download import install_data
 
-dict_url = {
-    "testing_data": ["https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"],
-    "prelude": ["https://github.com/shimming-toolbox/binaries/raw/master/prelude"]
+# URL dictionary is in the format:
+# - key: name of item to download
+# - value: tuple containing:
+#     0. List containing the item's URL string
+#     1. String description of the item
+
+URL_DICT: Dict[str, Tuple[List[str], str]] = {
+    "testing_data": (["https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"], "Light-weighted dataset for testing purpose."),
+    "prelude": (["https://github.com/shimming-toolbox/binaries/raw/master/prelude"], "Binary for prelude software") # TODO: What does prelude do? is it another dataset?
 }
 
+dataset_list_str: str = ""
 
-# TODO: display automatically the list of data available from the dict above
-# TODO: wrap the help properly
-@click.command(help="Download data from the internet. The available datasets are:"
-                    "- testing_data: Light-weighted dataset for testing purpose.")
+for item in URL_DICT.items():
+    dataset_list_str += f"\n\n - {item[0]}: {item[1][1]}"
+
+@click.command(help=f"Download data from the internet. The available datasets are:{dataset_list_str}")
 @click.option("--verbose", is_flag=True, help="Be more verbose.")
 @click.option("--output", help="Output folder.")
 @click.argument("data")
@@ -32,7 +40,7 @@ def main(verbose, output, data):
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
     logging.info(f'{output}, {data}')
-    url = dict_url[data]
+    url = URL_DICT[data]
     if output is None:
         output = os.path.join(os.path.abspath(os.curdir), data)
     install_data(url, output, keep=True)

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -40,7 +40,7 @@ def main(verbose, output, data):
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
     logging.info(f'{output}, {data}')
-    url = URL_DICT[data]
+    url = URL_DICT[data][0]
     if output is None:
         output = os.path.join(os.path.abspath(os.curdir), data)
     install_data(url, output, keep=True)


### PR DESCRIPTION
**Why this change was necessary**
The desired behaviour is to automatically generate a list of data
available using the URL dictionary.

**What this change does**
Modifies the format of the URL dictionary to include the dataset
description. Then, the URL dictionary is walked to generate a
multiline string containing the available dataset names and
descriptions. This string description is then used in the `help` kw
arg in the `click` command decorator for `main()`.

~~Note that I'm not sure what `prelude` does, so I have a TODO left in
the source code until I have more information.~~ Done

**Any side-effects?**
The spacing of the output is wonky as a result of the double
newline (\n) used. I tried using a single newline, but click seems to
get rid of those, which is *not* the behaviour of attempting to print
an f-string containing single newline chars:

```
print(f"hello\nhi")
```

This forced me to use double newline chars for each dataset option.

Furthermore, any attempt to indent each option doesn't seem to work
either, so I suspect that `click` does some kind of whitespace
trimming.

The resulting output of running the file with the `--help` flag:

```
$ python download_data.py --help
Usage: download_data.py [OPTIONS] DATA

  Download data from the internet. The available datasets are:

  - testing_data: Light-weighted dataset for testing purpose.

  - prelude: Binary for prelude software

Options:
  --verbose      Be more verbose.
  --output TEXT  Output folder.
  --help         Show this message and exit.
```

**Additional context/notes/links**

Related to #91 - Address TODOs in cli/download_data.py