### PR TITLE
Update minimum version to Python 3.7

### DIFF
--- a/docs/source/2_getting_started/1_installation.rst
+++ b/docs/source/2_getting_started/1_installation.rst
@@ -22,7 +22,7 @@ if it is installed), run the following command:
    conda search python
 
 If a list of available Python versions are displayed and versions
->=3.6.0 are available, you may skip to the next section (Git).
+>=3.7.0 are available, you may skip to the next section (Git).
 
 Linux
 -----
@@ -112,13 +112,17 @@ but the one we recommend and will use in our installation guide is
 Miniconda. We strongly recommend you create a virtual environment before
 you continue with your installation.
 
-To create a Python 3.6 virtual environment named "shim_venv", in a
+Although the shimming-toolbox package on PyPI supports Python versions 3.7
+and greater, we recommend you only use shimming-toolbox with Python 3.7, as
+our tests only cover that version for now.
+
+To create a Python 3.7 virtual environment named "shim_venv", in a
 terminal window (macOS or Linux) or Anaconda Prompt (Windows) run the
 following command and answer "y" to the installation instructions:
 
 .. code:: bash
 
-   conda create -n shim_venv python=3.6
+   conda create -n shim_venv python=3.7
 
 Then, activate your virtual environment:
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,7 +9,7 @@ sphinx:
   builder: html
 
 python:
-    version: 3.6
+    version: 3.7
     install:
       - method: pip
         path: .

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="shimmingtoolbox",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     version="0.1.0",
     description="Code for performing real-time shimming using external MRI shim coils",
     long_description=long_description,


### PR DESCRIPTION
**Why this change was necessary**
We do all our testing on Travis with Python 3.7. For the sake of
consistency and to focus our efforts better on features rather than
version compatibility, we should explicitly require at least Python
3.7 for the package and strongly recommend that Python 3.7 is used by
users and contributors.

**What this change does**
Changes package setup.py, RTD config, and documentation to use Python 3.7.

**Any side-effects?**
Users and contributors will have to create a new virtual environment
following the directions from the documentation, then reinstall the package.

**Additional context/notes/links**

Resolves #98 - Doc should recommend installing conda with py3.7


----

#