### PR TITLE
Fix link to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ or write it with `install --user` (for a user-local install) in order to be allo
 
 ## Development
 
-Please see the documentation for instructions on building and testing a [development version](docs/2_getting_started/1_installation.md) of shimming-toolbox-py.
+Please see the documentation for instructions on building and testing a [development version](https://shimming-toolbox.org/en/latest/2_getting_started/1_installation.html) of shimming-toolbox-py.
 
 ## Contributing
 


### PR DESCRIPTION
**Why this change was necessary**
The link was pointing to an old nonexistant md file.

**What this change does**
See title

**Any side-effects?**
None

**Additional context/notes/links**

Resolves #99 - broken link on README


----

#