### PR TITLE
Update download_data CLI dataset links

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'console_scripts': [
             "st_referencemaps=shimmingtoolbox.cli.referencemaps:main",
             "st_b0maps=shimmingtoolbox.cli.b0map:main",
-            "st_download_data=shimmingtoolbox.cli.download_data:main",
+            "st_download_data=shimmingtoolbox.cli.download_data:download_data",
         ]
     },
     packages=find_packages(exclude=["contrib", "docs", "tests"]),

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -48,7 +48,6 @@ def download_data(verbose, output, data):
         output: Output folder.
         data: The data to be downloaded.
     """
-    click.echo("test")
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
     logging.info(f'{output}, {data}')

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -15,7 +15,7 @@ from shimmingtoolbox.download import install_data
 
 URL_DICT: Dict[str, Tuple[List[str], str]] = {
     "testing_data": (
-        ["https://github.com/shimming-toolbox/data-testing/archive/r20200713.zip"],
+        ["https://github.com/shimming-toolbox/data-testing/archive/r20200806.zip"],
         "Light-weighted dataset for testing purpose.",
     ),
     "prelude": (

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -36,7 +36,7 @@ for item in URL_DICT.items():
 @click.option("--verbose", is_flag=True, help="Be more verbose.")
 @click.option("--output", help="Output folder.")
 @click.argument("data")
-def main(verbose, output, data):
+def download_data(verbose, output, data):
     """
     Download data from the internet.
 
@@ -45,6 +45,7 @@ def main(verbose, output, data):
         output: Output folder.
         data: The data to be downloaded.
     """
+    click.echo("test")
     if verbose:
         logging.getLogger().setLevel(logging.INFO)
     logging.info(f'{output}, {data}')
@@ -53,6 +54,3 @@ def main(verbose, output, data):
         output = os.path.join(os.path.abspath(os.curdir), data)
     install_data(url, output, keep=True)
 
-
-if __name__ == '__main__':
-    main()

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -24,6 +24,8 @@ URL_DICT: Dict[str, Tuple[List[str], str]] = {
     ),
 }
 
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
 dataset_list_str: str = ""
 
 for item in URL_DICT.items():
@@ -31,6 +33,7 @@ for item in URL_DICT.items():
 
 
 @click.command(
+    context_settings=CONTEXT_SETTINGS,
     help=f"Download data from the internet. The available datasets are:{dataset_list_str}"
 )
 @click.option("--verbose", is_flag=True, help="Be more verbose.")


### PR DESCRIPTION
This PR updates the link to the latest datasets in data-testing. The new dataset mainly adds the realtime_zshim dataset so that we have the required data to perform realtime zshimming.

The PR also adds the ability to show the help by using the `-h` option.

We could consider changing the prefix to the CLI in the same PR.

Fixes #84
Fixes #85

Future PRs:
Create and update CLIs for realtime zshimming