### PR TITLE
Update files in /docs/source with the new repository name

### DIFF
--- a/docs/source/2_getting_started/1_installation.rst
+++ b/docs/source/2_getting_started/1_installation.rst
@@ -150,11 +150,11 @@ your system):
 
 .. code:: bash
 
-   git clone https://github.com/shimming-toolbox/shimming-toolbox-py.git
+   git clone https://github.com/shimming-toolbox/shimming-toolbox.git
 
 If you don’t have Git installed, download and extract
 shimming-toolbox from this
-`link <https://github.com/shimming-toolbox/shimming-toolbox-py/archive/master.zip>`__.
+`link <https://github.com/shimming-toolbox/shimming-toolbox/archive/master.zip>`__.
 
 Then, in your Terminal, go to the shimming-toolbox folder and install
 the shimming-toolbox package. The following ``cd`` command assumes

--- a/docs/source/2_getting_started/2_getting_started.rst
+++ b/docs/source/2_getting_started/2_getting_started.rst
@@ -7,7 +7,7 @@ Examples
 --------
 
 Example scripts are located under
-`examples <https://github.com/shimming-toolbox/shimming-toolbox-py/tree/master/examples>`__.
+`examples <https://github.com/shimming-toolbox/shimming-toolbox/tree/master/examples>`__.
 
 general_demo
 ^^^^^^^^^^^^

--- a/docs/source/2_getting_started/3_help.rst
+++ b/docs/source/2_getting_started/3_help.rst
@@ -3,4 +3,4 @@ Help
 
 If you need help using the ``shimming-toolbox``, please contact the
 developer team via a `Github
-issue <https://github.com/shimming-toolbox/shimming-toolbox-py/issues>`__.
+issue <https://github.com/shimming-toolbox/shimming-toolbox/issues>`__.

--- a/docs/source/3_contributing/CONTRIBUTING.rst
+++ b/docs/source/3_contributing/CONTRIBUTING.rst
@@ -14,12 +14,12 @@ Introduction
 First off, thanks for taking the time to contribute to our project! 🎉
 
 When contributing to this repository, please first discuss the change you wish
-to make by opening a new `GitHub issue <https://github.com/shimming-toolbox/shimming-toolbox-py/issues>`_ with one of the templates.
+to make by opening a new `GitHub issue <https://github.com/shimming-toolbox/shimming-toolbox/issues>`_ with one of the templates.
 
 Contributions relating to content of the Github repository can be
-submitted through `GitHub pull requests <https://github.com/shimming-toolbox/shimming-toolbox-py/pulls>`_ (PR).
+submitted through `GitHub pull requests <https://github.com/shimming-toolbox/shimming-toolbox/pulls>`_ (PR).
 
-PR for bug fixes or new features should be based on the `master <https://github.com/shimming-toolbox/shimming-toolbox-py/tree/master>`_ branch.
+PR for bug fixes or new features should be based on the `master <https://github.com/shimming-toolbox/shimming-toolbox/tree/master>`_ branch.
 
 The following GitHub documentation may be useful:
 
@@ -39,7 +39,7 @@ have the rights, contact the team leader.
 Opening an issue
 ----------------
 
-Issues (bugs, enhancement requests, or feature requests) can be submitted `on our project's issue page <https://github.com/shimming-toolbox/shimming-toolbox-py/issues>`_. Please select the appropriate template when creating a new issue.
+Issues (bugs, enhancement requests, or feature requests) can be submitted `on our project's issue page <https://github.com/shimming-toolbox/shimming-toolbox/issues>`_. Please select the appropriate template when creating a new issue.
 
 
 Before Submitting a New Issue

--- a/docs/source/3_contributing/contributors.rst
+++ b/docs/source/3_contributing/contributors.rst
@@ -2,4 +2,4 @@ Contributors
 ============
 
 `List of
-contributors. <https://github.com/shimming-toolbox/shimming-toolbox-py/graphs/contributors>`__
+contributors. <https://github.com/shimming-toolbox/shimming-toolbox/graphs/contributors>`__

--- a/docs/source/4_about/license.rst
+++ b/docs/source/4_about/license.rst
@@ -2,7 +2,7 @@ License and warranty
 ====================
 
 This software is distributed under the following
-`license <https://github.com/shimming-toolbox/shimming-toolbox-py/blob/master/LICENSE>`__.
+`license <https://github.com/shimming-toolbox/shimming-toolbox/blob/master/LICENSE>`__.
 THIS SOFTWARE MAY NOT BE USED FOR MEDICAL DIAGNOSIS AS IT IS NOT
 SANCTIONED BY AUTHORITIES SUCH AS HEALTH CANADA AND THE FOOD AND DRUG
 ADMINISTRATION.


### PR DESCRIPTION
## Description

This PR updates the links in `/docs/source`. It replaces the old `shimming-toolbox-py` by `shimming-toolbox`. These links are the one available on the [shimming-toolbox website](https://shimming-toolbox.org/en/latest/).

## Linked issues

Related to #114  