### PR TITLE
Add st_mask.py to cli

### DIFF
--- a/shimmingtoolbox/cli/st_mask.py
+++ b/shimmingtoolbox/cli/st_mask.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import logging
+import click
+import numpy as np
+
+from shimmingtoolbox.masking import threshold
+from shimmingtoolbox.masking import shapes
+# import SCT
+# import BET
+
+@click.command()
+@click.option("--verbose", is_flag=True, help="Be more verbose.")
+@click.argument("input", required=True, type=click.File('rb')) # 1 file à la fois ou bien plusieurs d'un coup avec nargs=-1 ?
+@click.option("--method", required=True, type=click.Choice(['SCT','BET','shape','threshold'], case_sensitive=False), help="Indicate which kind od mask: SCT, BET, shape or threshold")
+@click.option("--shape", type=click.Choice(['cube','square'], case_sensitive=False), default='cube', help="Indcate which kinf of shape for method=shape: cube or square")
+@click.option("--size", type=int, default=1, help="Radius of the shape in voxel")
+def main(verbose, input, method, shape, size):
+    if verbose:
+        logging.getLogger().setLevel(logging.INFO)
+    logging.info(f'{input}, {method}, {shape}, {size}')
+
+    # data = np.fromfile(input, dtype=?)  --> Pour écrire le binary file en array ?
+
+    if method == 'shape':
+        st_mask = shapes(input,shape,size) # size en voxel alors que taille attendue en pixel dans cette fonction
+        # input à changer en data ?
+    
+    elif method == 'threshold':
+        st_mask = threshold(input,size) # Pourquoi pas size pour threshold ? Celle-ci est demandée en voxel dans la fonction threshold
+        # input à changer en data ?
+    
+    # elif à venir avec SCT et BET
+    
+    return st_mask
+
+
+if __name__ == '__main__':
+    main()

--- a/shimmingtoolbox/cli/st_mask.py
+++ b/shimmingtoolbox/cli/st_mask.py
@@ -10,27 +10,36 @@ from shimmingtoolbox.masking import shapes
 # import BET
 
 @click.command()
-@click.option("--verbose", is_flag=True, help="Be more verbose.")
 @click.argument("input", required=True, type=click.File('rb')) # 1 file à la fois ou bien plusieurs d'un coup avec nargs=-1 ?
 @click.option("--method", required=True, type=click.Choice(['SCT','BET','shape','threshold'], case_sensitive=False), help="Indicate which kind od mask: SCT, BET, shape or threshold")
 @click.option("--shape", type=click.Choice(['cube','square'], case_sensitive=False), default='cube', help="Indcate which kinf of shape for method=shape: cube or square")
-@click.option("--size", type=int, default=1, help="Radius of the shape in voxel")
-def main(verbose, input, method, shape, size):
-    if verbose:
-        logging.getLogger().setLevel(logging.INFO)
-    logging.info(f'{input}, {method}, {shape}, {size}')
+@click.option("--size", type=int, default=10, help="Radius of the shape in voxel")
+def main(input, method, shape, size):
+    """
+    Apply a s-t mask to the input file. Returns mask with the same method as `method`.
 
-    # data = np.fromfile(input, dtype=?)  --> Pour écrire le binary file en array ?
+    Args:
+        input (binary file): Data to mask.
+        method (str): Length of the side of the square along first dimension (in pixels).
+        shape (str): Shape (cube or square) used when method is shape. If no shape is provided, the cube is used.
+        size (int): Radius of the shape when method is shape (in voxel). If no size is provided, size=10.
+        
+    Returns:
+        numpy.ndarray: Mask with booleans.
+    """
+    
+    # data = np.fromfile(input, dtype=?)  #
+    # To write binary file in array ?
 
     if method == 'shape':
-        st_mask = shapes(input,shape,size) # size en voxel alors que taille attendue en pixel dans cette fonction
-        # input à changer en data ?
+        st_mask = shapes(input,shape,size) # size in voxel while expected in pixel in the function
+        # `data` instead of `input` ?
     
     elif method == 'threshold':
-        st_mask = threshold(input,size) # Pourquoi pas size pour threshold ? Celle-ci est demandée en voxel dans la fonction threshold
-        # input à changer en data ?
+        st_mask = threshold(input,size) # Why not size for threshold ? Size expected in voxel in this function
+        # `data` instead of `input` ?
     
-    # elif à venir avec SCT et BET
+    # elif to come w/ SCT & BET
     
     return st_mask
 

--- a/shimmingtoolbox/cli/st_mask_cube.py
+++ b/shimmingtoolbox/cli/st_mask_cube.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import click
+import nibabel as nib
+
+from shimmingtoolbox.masking.shapes import shape_cube
+
+
+@click.command()
+@click.argument("filename", required=True, type=click.Path(exists=True, file_okay=False))
+@click.option("--len_dim1", '-l1', required=True, type=click.IntRange(0, 255, clamp=True), help="Length of the side "
+                                                                                                "of the cube along "
+                                                                                                "third dimension (in "
+                                                                                                "pixels)")
+@click.option("--len_dim2", '-l2', required=True, type=click.IntRange(0, 255, clamp=True), help="Length of the side "
+                                                                                                "of the cube along "
+                                                                                                "third dimension (in "
+                                                                                                "pixels)")
+@click.option("--len_dim3", '-l3', required=True, type=click.IntRange(0, 127, clamp=True), help="Length of the side "
+                                                                                                "of the cube along "
+                                                                                                "third dimension (in "
+                                                                                                "pixels)")
+@click.option("--center_dim", nargs=3, default=0, help="Center of the cube along first, second and third dimension "
+                                                       "(in pixels). If no center is provided, the middle is used.")
+def st_mask_cube(filename, len_dim1, len_dim2, len_dim3, center_dim):
+    """
+        Apply a cube mask to the input file. Returns mask.
+
+        Args:
+            filename (str): Data to mask.
+            len_dim1 (int): Length of the side of the cube along first dimension (in pixels).
+            len_dim2 (int): Length of the side of the cube along second dimension (in pixels).
+            len_dim3 (int): Length of the side of the cube along third dimension (in pixels).
+            center_dim (int): Center of the cube along first, second and third dimension (in pixels). If no center is
+                            provided, the middle is used.
+
+        Return:
+            mask_cube (numpy.ndarray): Mask with booleans. True where the cube is located and False in the background.
+        """
+    img_nifti = nib.load(filename)
+    data = img_nifti.get_fdata()  # convert nifty file to numpy array
+
+    mask_cube = shape_cube(data, len_dim1, len_dim2, len_dim3, center_dim)
+
+    return mask_cube

--- a/shimmingtoolbox/cli/st_mask_square.py
+++ b/shimmingtoolbox/cli/st_mask_square.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import click
+import nibabel as nib
+import numpy as np
+
+from shimmingtoolbox.masking.shapes import shape_square
+
+
+@click.command()
+@click.argument("filename", required=True, type=click.Path(exists=True, file_okay=False))
+@click.option("--len_dim1", '-l1', required=True, type=click.IntRange(0, 255, clamp=True), help="Length of the side "
+                                                                                                "of the square along "
+                                                                                                "third dimension (in "
+                                                                                                "pixels)")
+@click.option("--len_dim2", '-l2', required=True, type=click.IntRange(0, 255, clamp=True), help="Length of the side "
+                                                                                                "of the square along "
+                                                                                                "third dimension (in "
+                                                                                                "pixels)")
+@click.option("--center_dim", nargs=2, default=0, help="Center of the square along first and second dimension (in "
+                                                       "pixels). If no center is provided, the middle is used.")
+def st_mask_cube(filename, len_dim1, len_dim2, center_dim):
+    """
+            Apply a square mask to the input file. Returns mask.
+
+            Args:
+                filename (str): Data to mask.
+                len_dim1 (int): Length of the side of the square along first dimension (in pixels).
+                len_dim2 (int): Length of the side of the square along second dimension (in pixels).
+                center_dim (int): Center of the square along first and second dimension (in pixels). If no center is
+                                provided, the middle is used.
+
+            Return:
+                mask_square (numpy.ndarray): Mask with booleans.
+            """
+    img_nifti = nib.load(filename)
+    data = img_nifti.get_fdata()  # convert nifty file to numpy array
+    mask_square = np.array([[[]]])  # initialization of 3D array
+
+    for z in range(data.shape[2]):
+        img_2d = data[:, :, z]  # extraction of a MRI slice
+        mask = shape_square(img_2d, len_dim1, len_dim2, center_dim)  # application of the mask on each slice
+        mask_square.append(mask)  # addition of each masked slice to form a 3D array
+        # problem with np.append & boolean mask
+
+    return mask_square

--- a/shimmingtoolbox/cli/st_mask_threshold.py
+++ b/shimmingtoolbox/cli/st_mask_threshold.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import click
+import nibabel as nib
+
+from shimmingtoolbox.masking.threshold import threshold
+
+
+@click.command()
+@click.argument("filename", required=True, type=click.Path(exists=True, file_okay=False))
+@click.option("--thr", default=30, help="Value to threshold the data: voxels will be set to zero if their value is "
+                                        "equal or less than this threshold")
+def st_mask_threshold(filename, thr):
+    """
+        Apply a threshold mask to the input file. Returns mask.
+
+        Args:
+            filename (str): Data to be masked
+            thr: Value to threshold the data: voxels will be set to zero if their
+                value is equal or less than this threshold
+
+        Returns:
+            mask_thr (numpy.ndarray): Boolean mask with same dimensions as data
+        """
+    img_nifti = nib.load(filename)
+    data = img_nifti.get_fdata()  # convert nifty file to numpy array
+
+    mask_thr = threshold(data, thr)
+
+    return mask_thr


### PR DESCRIPTION
Create CLI for creating mask #88 

st_mask.py contains a CLI command to create a mask from those present in the shimming-toolbox. The command has 1 argument (input) and 3 options (method, shape and size). The mask has been applied to the input according to the 3 other criteria.

Several questions remain:
Which default size for size?
Input is a binary file, should it be converted to an array?
Size cannot be applied for threshold? It is expected for shape but in pixel
