### PR TITLE
Update dicom_to_nifti with a CLI

### DIFF
--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -49,6 +49,114 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude1",
             "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "1"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude2",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "2"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude3",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "3"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude4",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "4"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude5",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "5"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude6",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "6"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase1",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "1"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase2",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "2"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase3",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "3"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase4",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "4"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase5",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "5"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase6",
+            "criteria": {
+                "SeriesDescription": "a_gre_*",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "6"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude1",
+            "criteria": {
                 "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "1"
@@ -61,42 +169,6 @@
                 "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "2"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude3",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "3"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude4",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "4"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude5",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "5"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude6",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "6"
             }
         },
         {
@@ -115,42 +187,6 @@
                 "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "2"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase3",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "3"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase4",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "4"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase5",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "5"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase6",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "6"
             }
         },
         {

--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -50,7 +50,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude1",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "1"
             }
@@ -59,7 +59,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude2",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "2"
             }
@@ -68,7 +68,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude3",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "3"
             }
@@ -77,7 +77,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude4",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "4"
             }
@@ -86,7 +86,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude5",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "5"
             }
@@ -95,7 +95,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude6",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "6"
             }
@@ -104,7 +104,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase1",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "1"
             }
@@ -113,7 +113,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase2",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "2"
             }
@@ -122,7 +122,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase3",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "3"
             }
@@ -131,7 +131,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase4",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "4"
             }
@@ -140,7 +140,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase5",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "5"
             }
@@ -149,9 +149,33 @@
             "dataType": "fmap",
             "modalityLabel": "phase6",
             "criteria": {
-                "SeriesDescription": "a_gre_*",
+                "SeriesDescription": "*gre_field_map*",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "6"
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "unshimmed_e1",
+            "criteria": {
+                "SeriesDescription": "*gre*UNSHIMMED*",
+                "EchoNumber": "1"
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "unshimmed_e2",
+            "criteria": {
+                "SeriesDescription": "*gre*UNSHIMMED*",
+                "EchoNumber": "2"
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "unshimmed_e3",
+            "criteria": {
+                "SeriesDescription": "*gre*UNSHIMMED*",
+                "EchoNumber": "3"
             }
         }
     ]

--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -1,6 +1,5 @@
 {
     "searchMethod": "fnmatch",
-    "defaceTpl": "pydeface --outfile {dstFile} {srcFile}",
     "descriptions": [
         {
             "dataType": "anat",
@@ -176,6 +175,13 @@
             "criteria": {
                 "SeriesDescription": "*gre*UNSHIMMED*",
                 "EchoNumber": "3"
+            }
+        },
+        {
+            "dataType": "func",
+            "modalityLabel": "bold",
+            "criteria": {
+                "SeriesDescription": "*bold*"
             }
         }
     ]

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
             "st_referencemaps=shimmingtoolbox.cli.referencemaps:main",
             "st_b0maps=shimmingtoolbox.cli.b0map:main",
             "st_download_data=shimmingtoolbox.cli.download_data:download_data",
+            "st_dicom_to_nifti=shimmingtoolbox.cli.dicom_to_nifti:dicom_to_nifti",
         ]
     },
     packages=find_packages(exclude=["contrib", "docs", "tests"]),

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
             "st_referencemaps=shimmingtoolbox.cli.referencemaps:main",
             "st_b0maps=shimmingtoolbox.cli.b0map:main",
             "st_download_data=shimmingtoolbox.cli.download_data:download_data",
-            "st_dicom_to_nifti=shimmingtoolbox.cli.dicom_to_nifti:dicom_to_nifti",
+            "st_dicom_to_nifti=shimmingtoolbox.cli.dicom_to_nifti:dicom_to_nifti_cli",
         ]
     },
     packages=find_packages(exclude=["contrib", "docs", "tests"]),

--- a/shimmingtoolbox/cli/dicom_to_nifti.py
+++ b/shimmingtoolbox/cli/dicom_to_nifti.py
@@ -13,12 +13,12 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(
     context_settings=CONTEXT_SETTINGS,
 )
-@click.option('-i', '--input', 'path_dicoms', type=click.Path(), required=True, help="Input path of dicom folder")
-@click.option('-o', '--output', 'path_nifti', type=click.Path(), default=os.curdir, help="Output path for niftis")
-@click.option('-s', '--subject', required=True, help="Name of the patient")
-@click.option('-c', '--config', 'fname_config', type=click.Path(), default=__dir_config_dcm2bids__,
+@click.option('-input', 'path_dicoms', type=click.Path(), required=True, help="Input path of dicom folder")
+@click.option('-output', 'path_nifti', type=click.Path(), default=os.curdir, help="Output path for niftis")
+@click.option('-subject', required=True, help="Name of the patient")
+@click.option('-config', 'fname_config', type=click.Path(), default=__dir_config_dcm2bids__,
               help="Full file path and name of the bids config file")
-@click.option('--remove_tmp/--dont_remove_tmp', default=False,
+@click.option('-remove_tmp/-dont_remove_tmp', default=False,
               help="Specifies if tmp folder will be deleted after processing")
 def dicom_to_nifti_cli(path_dicoms, path_nifti, subject, fname_config, remove_tmp):
     """Converts dicom files into nifti files by calling dcm2bids."""

--- a/shimmingtoolbox/cli/dicom_to_nifti.py
+++ b/shimmingtoolbox/cli/dicom_to_nifti.py
@@ -20,8 +20,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               help="Full file path and name of the bids config file")
 @click.option('--remove_tmp/--dont_remove_tmp', default=False,
               help="Specifies if tmp folder will be deleted after processing")
-def dicom_to_nifti(path_dicoms, path_nifti, subject, fname_config, remove_tmp):
+def dicom_to_nifti_cli(path_dicoms, path_nifti, subject, fname_config, remove_tmp):
     """Converts dicom files into nifti files by calling dcm2bids."""
 
-    dicom_to_nifti(path_dicoms, path_nifti, subject_id=subject, path_config_dcm2bids=fname_config,
-                   remove_tmp=remove_tmp)
+    dicom_to_nifti(path_dicoms, path_nifti, subject_id=subject, path_config_dcm2bids=fname_config, remove_tmp=remove_tmp)

--- a/shimmingtoolbox/cli/dicom_to_nifti.py
+++ b/shimmingtoolbox/cli/dicom_to_nifti.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import click
+import os
+
+from shimmingtoolbox.dicom_to_nifti import dicom_to_nifti
+from shimmingtoolbox import __dir_config_dcm2bids__
+
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+)
+@click.option('-i', '--input', 'path_dicoms', type=click.Path(), required=True, help="Input path of dicom folder")
+@click.option('-o', '--output', 'path_nifti', type=click.Path(), default=os.curdir, help="Output path for niftis")
+@click.option('-s', '--subject', required=True, help="Name of the patient")
+@click.option('-c', '--config', 'fname_config', type=click.Path(), default=__dir_config_dcm2bids__,
+              help="Full file path and name of the bids config file")
+@click.option('--remove_tmp/--dont_remove_tmp', default=False,
+              help="Specifies if tmp folder will be deleted after processing")
+def dicom_to_nifti(path_dicoms, path_nifti, subject, fname_config, remove_tmp):
+    """Converts dicom files into nifti files by calling dcm2bids."""
+
+    dicom_to_nifti(path_dicoms, path_nifti, subject_id=subject, path_config_dcm2bids=fname_config,
+                   remove_tmp=remove_tmp)

--- a/shimmingtoolbox/cli/dicom_to_nifti.py
+++ b/shimmingtoolbox/cli/dicom_to_nifti.py
@@ -23,4 +23,5 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 def dicom_to_nifti_cli(path_dicoms, path_nifti, subject, fname_config, remove_tmp):
     """Converts dicom files into nifti files by calling dcm2bids."""
 
-    dicom_to_nifti(path_dicoms, path_nifti, subject_id=subject, path_config_dcm2bids=fname_config, remove_tmp=remove_tmp)
+    dicom_to_nifti(path_dicoms, path_nifti, subject_id=subject, path_config_dcm2bids=fname_config,
+                   remove_tmp=remove_tmp)

--- a/test/cli/test_cli_dicom_to_nifti.py
+++ b/test/cli/test_cli_dicom_to_nifti.py
@@ -17,7 +17,8 @@ def test_cli_dicom_to_nifti():
         path_dicoms = os.path.join(__dir_testing__, 'dicom_unsorted')
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        result = runner.invoke(dicom_to_nifti_cli, ['-i', path_dicoms, '-o', path_nifti, '-s', subject_id])
+        result = runner.invoke(dicom_to_nifti_cli, ['-input', path_dicoms, '-output', path_nifti,
+                                                    '-subject', subject_id])
 
         assert result.exit_code == 0
         # Check that dicom_to_nifti was invoked, not if files were actually created (API test already looks for that)

--- a/test/cli/test_cli_dicom_to_nifti.py
+++ b/test/cli/test_cli_dicom_to_nifti.py
@@ -10,7 +10,7 @@ from shimmingtoolbox.cli.dicom_to_nifti import dicom_to_nifti_cli
 from shimmingtoolbox import __dir_testing__
 
 
-def test_dicom_to_nifti_cli():
+def test_cli_dicom_to_nifti():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 

--- a/test/cli/test_dicom_to_nifti_cli.py
+++ b/test/cli/test_dicom_to_nifti_cli.py
@@ -1,0 +1,24 @@
+#!usr/bin/env python3
+# coding: utf-8
+
+import os
+import pathlib
+import tempfile
+
+from click.testing import CliRunner
+from shimmingtoolbox.cli.dicom_to_nifti import dicom_to_nifti_cli
+from shimmingtoolbox import __dir_testing__
+
+
+def test_dicom_to_nifti_cli():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        path_dicoms = os.path.join(__dir_testing__, 'dicom_unsorted')
+        path_nifti = os.path.join(tmp, 'nifti')
+        subject_id = 'sub-test'
+        result = runner.invoke(dicom_to_nifti_cli, ['-i', path_dicoms, '-o', path_nifti, '-s', subject_id])
+
+        assert result.exit_code == 0
+        # Check that dicom_to_nifti was invoked, not if files were actually created (API test already looks for that)
+        assert os.path.isdir(path_nifti)

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -6,6 +6,7 @@ import tempfile
 
 from shimmingtoolbox.dicom_to_nifti import dicom_to_nifti
 from shimmingtoolbox import __dir_testing__
+from shimmingtoolbox import __dir_shimmingtoolbox__
 
 
 def test_dicom_to_nifti():
@@ -13,9 +14,36 @@ def test_dicom_to_nifti():
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        dicom_to_nifti(__dir_testing__, path_nifti, subject_id=subject_id)
+        dicom_to_nifti(os.path.join(__dir_shimmingtoolbox__, __dir_testing__, 'dicom_unsorted'), path_nifti, subject_id=subject_id)
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.
+        for i in range(1, 7):
+            for modality in ['phase', 'magnitude']:
+                for ext in ['nii.gz', 'json']:
+                    assert os.path.exists(os.path.join(path_nifti, subject_id, 'fmap', subject_id + '_{}{}.{}'.format(
+                        modality, i, ext)))
+
+
+def test_dicom_to_nifti_realtime_zshim():
+    # TODO: put as decorator
+    with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
+        path_nifti = os.path.join(tmp, 'nifti')
+        subject_id = 'sub-test'
+        dicom_to_nifti(os.path.join(__dir_shimmingtoolbox__, __dir_testing__, 'realtime_zshimming_data'), path_nifti,
+                       subject_id=subject_id)
+        # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
+        # magnitude and phase data.
+
+        for sequence_type in ['anat', 'fmap', 'func']:
+            if sequence_type == 'fmap':
+                pass
+            if sequence_type == 'anat':
+                pass
+            else:  # sequence_type == func
+                pass
+
+        assert True
+
         for i in range(1, 7):
             for modality in ['phase', 'magnitude']:
                 for ext in ['nii.gz', 'json']:

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -34,18 +34,24 @@ def test_dicom_to_nifti_realtime_zshim():
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.
 
-        for sequence_type in ['anat', 'fmap', 'func']:
-            if sequence_type == 'fmap':
-                pass
-            if sequence_type == 'anat':
-                pass
-            else:  # sequence_type == func
-                pass
-
-        assert True
-
-        for i in range(1, 7):
+        sequence_type = 'fmap'
+        for i in range(2):
             for modality in ['phase', 'magnitude']:
                 for ext in ['nii.gz', 'json']:
-                    assert os.path.exists(os.path.join(path_nifti, subject_id, 'fmap', subject_id + '_{}{}.{}'.format(
-                        modality, i, ext)))
+                    if modality == 'phase':
+                        assert os.path.exists(os.path.join(path_nifti, subject_id, sequence_type,
+                                                           subject_id + f'_{modality}{2}.{ext}'))
+                    else:
+                        assert os.path.exists(os.path.join(path_nifti, subject_id, sequence_type,
+                                                           subject_id + f'_{modality}{i+1}.{ext}'))
+
+        sequence_type = 'anat'
+        for i in range(3):
+            for ext in ['nii.gz', 'json']:
+                assert os.path.exists(
+                    os.path.join(path_nifti, subject_id, sequence_type, subject_id + f'_unshimmed_e{i+1}.{ext}'))
+
+        sequence_type = 'func'
+        for ext in ['nii.gz', 'json']:
+            assert os.path.exists(
+                os.path.join(path_nifti, subject_id, sequence_type, subject_id + f'_bold.{ext}'))

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -25,7 +25,7 @@ def test_dicom_to_nifti():
 
 
 def test_dicom_to_nifti_realtime_zshim():
-    # TODO: put as decorator
+    """Test dicom_to_nifti outputs the correct files for realtime_zshimming_data"""
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -9,7 +9,6 @@ from shimmingtoolbox import __dir_testing__
 
 
 def test_dicom_to_nifti():
-    # TODO: put as decorator
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -6,7 +6,6 @@ import tempfile
 
 from shimmingtoolbox.dicom_to_nifti import dicom_to_nifti
 from shimmingtoolbox import __dir_testing__
-from shimmingtoolbox import __dir_shimmingtoolbox__
 
 
 def test_dicom_to_nifti():
@@ -14,7 +13,7 @@ def test_dicom_to_nifti():
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        dicom_to_nifti(os.path.join(__dir_shimmingtoolbox__, __dir_testing__, 'dicom_unsorted'), path_nifti, subject_id=subject_id)
+        dicom_to_nifti(os.path.join(__dir_testing__, 'dicom_unsorted'), path_nifti, subject_id=subject_id)
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.
         for i in range(1, 7):
@@ -29,7 +28,7 @@ def test_dicom_to_nifti_realtime_zshim():
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        dicom_to_nifti(os.path.join(__dir_shimmingtoolbox__, __dir_testing__, 'realtime_zshimming_data'), path_nifti,
+        dicom_to_nifti(os.path.join(__dir_testing__, 'realtime_zshimming_data'), path_nifti,
                        subject_id=subject_id)
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.


### PR DESCRIPTION
## Description
This PR adds a CLI for the dicom_to_nifti API. See the related issue #86 for the different options.
The PR also modifies the config file to be able to test it with realtime_zshimming_data. It adds the ability to use dicom_to_nifti with anatomical GREs and functional bold files.

TODO:
- [x] dicom_to_nifti_cli
- [x] Update config file
- [x] Create test for new config file

## Linked issues
Fixes #86 
Fixes #112 