### PR TITLE
[docs][installation] Add FSL Prelude as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ It is also [in the AUR](https://aur.archlinux.org/packages/dcm2niix/) (`pikaur -
 and [`conda`](https://anaconda.org/conda-forge/dcm2niix) (`conda install -c conda-forge/label/cf202003 dcm2niix`).
 Unfortunately, the version [currently in Debian/Ubuntu](https://packages.ubuntu.com/eoan/dcm2niix) (`apt install dcm2niix`) is too old to work reliably.
 
-Once you have `dcm2niix`, install this package and the rest of its dependencies with:
+You will also need to install [FSL](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation) using Python 2.
+
+Once you have `dcm2niix` and FSL, install this package and the rest of its dependencies with:
 
 ```
 $ pip install shimmingtoolbox@git+https://github.com/shimming-toolbox/shimming-toolbox

--- a/docs/source/2_getting_started/1_installation.rst
+++ b/docs/source/2_getting_started/1_installation.rst
@@ -144,6 +144,8 @@ Development version
 
 Ensure that you have ``dcm2niix`` installed on your system.
 
+You will also need to install `FSL <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation>`__ using Python 2.
+
 To install the development version of shimming-toolbox, clone
 shimming-toolbox's repository (you will need to have Git installed on
 your system):


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [ ] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
**Why this change was necessary**
FSL Prelude is a critical dependency that shimming-toolbox needs to
run. It was previously not included in the installation instructions
in the README for user installation nor in RTD for development
installation.

**What this change does**
See title

**Any side-effects?**
None

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #122 - FSL and prelude not included in installation documentation