### PR TITLE
Update __dir_testing__ to be an absolute path

### DIFF
--- a/examples/general_demo.py
+++ b/examples/general_demo.py
@@ -45,8 +45,8 @@ def general_demo(path_output=os.path.join(os.path.curdir, 'output_dir')):
     logging.basicConfig(level='INFO')
 
     # Download example data
-    path_testing_data = os.path.join(path_output, __dir_testing__)
-    run_subprocess(f'st_download_data {__dir_testing__} --output {path_testing_data}')
+    path_testing_data = os.path.join(path_output, 'testing_data')
+    run_subprocess(f'st_download_data testing_data --output {path_testing_data}')
 
     # Transfer from dicom to nifti
     path_dicom_unsorted = os.path.join(path_testing_data, 'dicom_unsorted')

--- a/examples/general_demo.py
+++ b/examples/general_demo.py
@@ -29,7 +29,6 @@ import nibabel as nib
 
 from shimmingtoolbox.unwrap import prelude
 from shimmingtoolbox.utils import run_subprocess
-from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox import dicom_to_nifti
 
 

--- a/shimmingtoolbox/__init__.py
+++ b/shimmingtoolbox/__init__.py
@@ -10,7 +10,7 @@ __version__ = metadata.version(__name__)
 del metadata
 
 __dir_shimmingtoolbox__ = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-__dir_testing__ = 'testing_data'
+__dir_testing__ = os.path.join(__dir_shimmingtoolbox__, 'testing_data')
 __dir_config_dcm2bids__ = os.path.join(__dir_shimmingtoolbox__, 'config', 'dcm2bids.json')
 
 from .dicom_to_nifti import dicom_to_nifti


### PR DESCRIPTION
## Description
This PR updates the `__dir_testing__` global variable to be an absolute path instead of a relative path. It makes it more in line with the other variable such as `__dir_config_dcm2bids__`.  

Changing this has consequences on the general_demo script which used this variable. The problem was fixed.

## Linked issues
Fixes #121 
