### PR TITLE
Ensure test environment is set up with test data and soft dependencies before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ install:
   - pip install python-coveralls
 # command to run tests
 script:
-  - echo "Download testing data"
-  - st_download_data testing_data
   - echo "Download prelude"
   - st_download_data prelude
   - echo "Set up prelude"

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 ###############################################################################
-#      Configure tests so that pytest downloads testing data every time.      #
+#                           configure testing suite                           #
 ###############################################################################
 import sys
 import os

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,103 @@
+###############################################################################
+#      Configure tests so that pytest downloads testing data every time.      #
+###############################################################################
+import sys
+import os
+import logging
+from pathlib import Path
+
+import pytest
+from typing import Mapping
+from hashlib import md5
+
+from shimmingtoolbox.cli.download_data import download_data
+
+logger = logging.getLogger(__name__)
+
+
+def test_data_path():
+    # Get the directory where this current file is saved
+    test_path = Path(__file__).resolve().parent
+
+    # create tmp folder
+    tmp_path = test_path / 'testing_data'
+    if not tmp_path.exists():
+        tmp_path.mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def test_data_path_fixture():
+    return test_data_path()
+
+
+def pytest_sessionstart():
+    """Download shimmingtoolbox testing_data prior to test collection."""
+    logger.info("Downloading shimmingtoolbox test data")
+    test_data_location = test_data_path()
+    try:
+        download_data(
+            [
+                # '--verbose',
+                '--output',
+                test_data_location,
+                'testing_data',
+            ]
+        )
+    # click sends a SystemExit upon command completion that needs to be caught.
+    except SystemExit:
+        return
+
+
+@pytest.fixture(scope="session", autouse=True)
+def test_data_integrity(request):
+    files_checksums = dict()
+    for root, _, files in os.walk(test_data_path()):
+        for f in files:
+            fname = os.path.join(root, f)
+            chksum = checksum(fname)
+            files_checksums[fname] = chksum
+    request.addfinalizer(lambda: check_testing_data_integrity(files_checksums))
+
+
+def checksum(fname: os.PathLike) -> str:
+    with open(fname, 'rb') as f:
+        data = f.read()
+    return md5(data).hexdigest()
+
+
+def check_testing_data_integrity(files_checksums: Mapping[os.PathLike, str]):
+    changed = []
+    new = []
+    missing = []
+
+    after = []
+
+    test_data_location = test_data_path()
+
+    for root, _, files in os.walk(test_data_location):
+        for f in files:
+            fname = os.path.join(root, f)
+            chksum = checksum(fname)
+            after.append(fname)
+
+            if fname not in files_checksums:
+                logger.warning(
+                    f"Discovered new file in testing_data that didn't exist before: {(fname, chksum)}"
+                )
+                new.append((fname, chksum))
+
+            elif files_checksums[fname] != chksum:
+                logger.error(
+                    f"Checksum mismatch for test data: {fname}. Got {chksum} instead of {files_checksums[fname]}"
+                )
+                changed.append((fname, chksum))
+
+    for fname, chksum in files_checksums.items():
+        if fname not in after:
+            logger.error(f"Test data missing after test:a: {fname}")
+            missing.append((fname, chksum))
+
+    assert not changed
+    # assert not new
+    assert not missing

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ import sys
 import os
 import logging
 from pathlib import Path
+import subprocess
 
 import pytest
 from typing import Mapping
@@ -30,6 +31,22 @@ def test_data_path():
 @pytest.fixture
 def test_data_path_fixture():
     return test_data_path()
+
+
+@pytest.fixture(params=[pytest.param(0, marks=pytest.mark.prelude)])
+def test_prelude_installation():
+    # note that subprocess.check_call() returns 0 on success, so it must be
+    # negated for the assertion.
+    assert not subprocess.check_call(['which', 'prelude'])
+    return
+
+
+@pytest.fixture(params=[pytest.param(0, marks=pytest.mark.dcm2niix)])
+def test_dcm2niix_installation():
+    # note that subprocess.check_call() returns 0 on success, so it must be
+    # negated for the assertion.
+    assert not subprocess.check_call(['which', 'dcm2niix'])
+    return
 
 
 def pytest_sessionstart():

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from typing import Mapping
 from hashlib import md5
 
+from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox.cli.download_data import download_data
 
 logger = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ def test_data_path():
     test_path = Path(__file__).resolve().parent
 
     # create tmp folder
-    tmp_path = test_path / 'testing_data'
+    tmp_path = test_path / __dir_testing__
     if not tmp_path.exists():
         tmp_path.mkdir()
     return tmp_path

--- a/conftest.py
+++ b/conftest.py
@@ -19,13 +19,13 @@ logger = logging.getLogger(__name__)
 
 def test_data_path():
     # Get the directory where this current file is saved
-    test_path = Path(__file__).resolve().parent
+    repo_path = Path(__file__).resolve().parent
 
-    # create tmp folder
-    tmp_path = test_path / __dir_testing__
-    if not tmp_path.exists():
-        tmp_path.mkdir()
-    return tmp_path
+    # create ./testing_data folder
+    test_path = repo_path / __dir_testing__
+    if not test_path.exists():
+        test_path.mkdir()
+    return test_path
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -56,7 +56,7 @@ def pytest_sessionstart():
     try:
         download_data(
             [
-                # '--verbose',
+                '--verbose',
                 '--output',
                 test_data_location,
                 'testing_data',
@@ -65,6 +65,7 @@ def pytest_sessionstart():
     # click sends a SystemExit upon command completion that needs to be caught.
     except SystemExit:
         return
+    logger.info("Test data download complete. Beginning testing session...")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/docs/source/2_getting_started/1_installation.rst
+++ b/docs/source/2_getting_started/1_installation.rst
@@ -203,3 +203,25 @@ shimming-toolbox directory:
 See https://docs.pytest.org/ for more options.
 
 If all tests pass, shimming-toolbox was installed successfully.
+
+Testing subsets of soft dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``prelude`` and ``dcm2niix`` are soft dependencies, so you may wish to run the
+parts of the testing suite that do not depend on them.
+
+To test shimming-toolbox without ``prelude`` and without ``dcm2niix``:
+
+.. code:: bash
+
+   cd shimming-toolbox
+   pytest -m "not prelude and not dcm2niix"
+
+To test shimming-toolbox without ``prelude`` and with ``dcm2niix``, you can use the above block but modifying the ``-m`` argument to ``"not prelude"``.
+
+To test shimming-toolbox with ``prelude`` and without ``dcm2niix``, you can use the above block but modifying the ``-m`` argument to ``"not dcm2niix"``.
+
+To test **only** the parts of shimming-toolbox dependent on ``prelude`` or
+``dcm2niix``, the corresponding ``-m`` argument is ``"prelude or dcm2niix"``
+
+Note that supplying the ``"-m"`` argument ``"prelude and dcm2niix"`` only runs tests dependent on both ``prelude`` **and** ``dcm2niix``.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    prelude: marks tests dependent on prelude
+    dcm2niix: marks tests dependent on dcm2niix

--- a/test/cli/test_cli_dicom_to_nifti.py
+++ b/test/cli/test_cli_dicom_to_nifti.py
@@ -4,12 +4,14 @@
 import os
 import pathlib
 import tempfile
+import pytest
 
 from click.testing import CliRunner
 from shimmingtoolbox.cli.dicom_to_nifti import dicom_to_nifti_cli
 from shimmingtoolbox import __dir_testing__
 
 
+@pytest.mark.dcm2niix
 def test_cli_dicom_to_nifti():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()

--- a/test/cli/test_cli_dicom_to_nifti.py
+++ b/test/cli/test_cli_dicom_to_nifti.py
@@ -17,8 +17,10 @@ def test_cli_dicom_to_nifti():
         path_dicoms = os.path.join(__dir_testing__, 'dicom_unsorted')
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        result = runner.invoke(dicom_to_nifti_cli, ['-input', path_dicoms, '-output', path_nifti,
-                                                    '-subject', subject_id])
+        result = runner.invoke(
+            dicom_to_nifti_cli,
+            ['-input', path_dicoms, '-output', path_nifti, '-subject', subject_id],
+        )
 
         assert result.exit_code == 0
         # Check that dicom_to_nifti was invoked, not if files were actually created (API test already looks for that)

--- a/test/cli/test_cli_dicom_to_nifti.py
+++ b/test/cli/test_cli_dicom_to_nifti.py
@@ -19,10 +19,8 @@ def test_cli_dicom_to_nifti(test_dcm2niix_installation):
         path_dicoms = os.path.join(__dir_testing__, 'dicom_unsorted')
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        result = runner.invoke(
-            dicom_to_nifti_cli,
-            ['-input', path_dicoms, '-output', path_nifti, '-subject', subject_id],
-        )
+        result = runner.invoke(dicom_to_nifti_cli, ['-input', path_dicoms, '-output', path_nifti,
+                                                    '-subject', subject_id])
 
         assert result.exit_code == 0
         # Check that dicom_to_nifti was invoked, not if files were actually created (API test already looks for that)

--- a/test/cli/test_cli_dicom_to_nifti.py
+++ b/test/cli/test_cli_dicom_to_nifti.py
@@ -12,7 +12,7 @@ from shimmingtoolbox import __dir_testing__
 
 
 @pytest.mark.dcm2niix
-def test_cli_dicom_to_nifti():
+def test_cli_dicom_to_nifti(test_dcm2niix_installation):
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -9,26 +9,39 @@ from shimmingtoolbox import __dir_testing__
 
 
 def test_dicom_to_nifti():
-    with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        dicom_to_nifti(os.path.join(__dir_testing__, 'dicom_unsorted'), path_nifti, subject_id=subject_id)
+        dicom_to_nifti(
+            os.path.join(__dir_testing__, 'dicom_unsorted'),
+            path_nifti,
+            subject_id=subject_id,
+        )
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.
         for i in range(1, 7):
             for modality in ['phase', 'magnitude']:
                 for ext in ['nii.gz', 'json']:
-                    assert os.path.exists(os.path.join(path_nifti, subject_id, 'fmap', subject_id + '_{}{}.{}'.format(
-                        modality, i, ext)))
+                    assert os.path.exists(
+                        os.path.join(
+                            path_nifti,
+                            subject_id,
+                            'fmap',
+                            subject_id + '_{}{}.{}'.format(modality, i, ext),
+                        )
+                    )
 
 
 def test_dicom_to_nifti_realtime_zshim():
     """Test dicom_to_nifti outputs the correct files for realtime_zshimming_data"""
-    with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        dicom_to_nifti(os.path.join(__dir_testing__, 'realtime_zshimming_data'), path_nifti,
-                       subject_id=subject_id)
+        dicom_to_nifti(
+            os.path.join(__dir_testing__, 'realtime_zshimming_data'),
+            path_nifti,
+            subject_id=subject_id,
+        )
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.
 
@@ -37,30 +50,57 @@ def test_dicom_to_nifti_realtime_zshim():
             for modality in ['phase', 'magnitude']:
                 for ext in ['nii.gz', 'json']:
                     if modality == 'phase':
-                        assert os.path.exists(os.path.join(path_nifti, subject_id, sequence_type,
-                                                           subject_id + f'_{modality}{2}.{ext}'))
+                        assert os.path.exists(
+                            os.path.join(
+                                path_nifti,
+                                subject_id,
+                                sequence_type,
+                                subject_id + f'_{modality}{2}.{ext}',
+                            )
+                        )
                     else:
-                        assert os.path.exists(os.path.join(path_nifti, subject_id, sequence_type,
-                                                           subject_id + f'_{modality}{i+1}.{ext}'))
+                        assert os.path.exists(
+                            os.path.join(
+                                path_nifti,
+                                subject_id,
+                                sequence_type,
+                                subject_id + f'_{modality}{i+1}.{ext}',
+                            )
+                        )
 
         sequence_type = 'anat'
         for i in range(3):
             for ext in ['nii.gz', 'json']:
                 assert os.path.exists(
-                    os.path.join(path_nifti, subject_id, sequence_type, subject_id + f'_unshimmed_e{i+1}.{ext}'))
+                    os.path.join(
+                        path_nifti,
+                        subject_id,
+                        sequence_type,
+                        subject_id + f'_unshimmed_e{i+1}.{ext}',
+                    )
+                )
 
         sequence_type = 'func'
         for ext in ['nii.gz', 'json']:
             assert os.path.exists(
-                os.path.join(path_nifti, subject_id, sequence_type, subject_id + f'_bold.{ext}'))
+                os.path.join(
+                    path_nifti, subject_id, sequence_type, subject_id + f'_bold.{ext}'
+                )
+            )
+
 
             
 def test_dicom_to_nifti_remove_tmp():
     """Test the remove_tmp folder"""
-    with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        dicom_to_nifti(os.path.join(__dir_testing__, 'dicom_unsorted'), path_nifti, subject_id=subject_id, remove_tmp=True)
+        dicom_to_nifti(
+            os.path.join(__dir_testing__, 'dicom_unsorted'),
+            path_nifti,
+            subject_id=subject_id,
+            remove_tmp=True,
+        )
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.
         assert os.path.exists(path_nifti)

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -6,8 +6,10 @@ import tempfile
 
 from shimmingtoolbox.dicom_to_nifti import dicom_to_nifti
 from shimmingtoolbox import __dir_testing__
+import pytest
 
 
+@pytest.mark.dcm2niix
 def test_dicom_to_nifti():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
@@ -32,6 +34,7 @@ def test_dicom_to_nifti():
                     )
 
 
+@pytest.mark.dcm2niix
 def test_dicom_to_nifti_realtime_zshim():
     """Test dicom_to_nifti outputs the correct files for realtime_zshimming_data"""
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
@@ -89,7 +92,7 @@ def test_dicom_to_nifti_realtime_zshim():
             )
 
 
-            
+@pytest.mark.dcm2niix
 def test_dicom_to_nifti_remove_tmp():
     """Test the remove_tmp folder"""
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -10,7 +10,7 @@ import pytest
 
 
 @pytest.mark.dcm2niix
-def test_dicom_to_nifti():
+def test_dicom_to_nifti(test_dcm2niix_installation):
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
@@ -35,7 +35,7 @@ def test_dicom_to_nifti():
 
 
 @pytest.mark.dcm2niix
-def test_dicom_to_nifti_realtime_zshim():
+def test_dicom_to_nifti_realtime_zshim(test_dcm2niix_installation):
     """Test dicom_to_nifti outputs the correct files for realtime_zshimming_data"""
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
@@ -93,7 +93,7 @@ def test_dicom_to_nifti_realtime_zshim():
 
 
 @pytest.mark.dcm2niix
-def test_dicom_to_nifti_remove_tmp():
+def test_dicom_to_nifti_remove_tmp(test_dcm2niix_installation):
     """Test the remove_tmp folder"""
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -9,42 +9,28 @@ from shimmingtoolbox import __dir_testing__
 import pytest
 
 
-@pytest.mark.dcm2niix
-def test_dicom_to_nifti(test_dcm2niix_installation):
-    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+def test_dicom_to_nifti():
+    with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        dicom_to_nifti(
-            os.path.join(__dir_testing__, 'dicom_unsorted'),
-            path_nifti,
-            subject_id=subject_id,
-        )
+        dicom_to_nifti(os.path.join(__dir_testing__, 'dicom_unsorted'), path_nifti, subject_id=subject_id)
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.
         for i in range(1, 7):
             for modality in ['phase', 'magnitude']:
                 for ext in ['nii.gz', 'json']:
-                    assert os.path.exists(
-                        os.path.join(
-                            path_nifti,
-                            subject_id,
-                            'fmap',
-                            subject_id + '_{}{}.{}'.format(modality, i, ext),
-                        )
-                    )
+                    assert os.path.exists(os.path.join(path_nifti, subject_id, 'fmap', subject_id + '_{}{}.{}'.format(
+                        modality, i, ext)))
 
 
 @pytest.mark.dcm2niix
 def test_dicom_to_nifti_realtime_zshim(test_dcm2niix_installation):
     """Test dicom_to_nifti outputs the correct files for realtime_zshimming_data"""
-    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+    with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        dicom_to_nifti(
-            os.path.join(__dir_testing__, 'realtime_zshimming_data'),
-            path_nifti,
-            subject_id=subject_id,
-        )
+        dicom_to_nifti(os.path.join(__dir_testing__, 'realtime_zshimming_data'), path_nifti,
+                       subject_id=subject_id)
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.
 
@@ -53,57 +39,30 @@ def test_dicom_to_nifti_realtime_zshim(test_dcm2niix_installation):
             for modality in ['phase', 'magnitude']:
                 for ext in ['nii.gz', 'json']:
                     if modality == 'phase':
-                        assert os.path.exists(
-                            os.path.join(
-                                path_nifti,
-                                subject_id,
-                                sequence_type,
-                                subject_id + f'_{modality}{2}.{ext}',
-                            )
-                        )
+                        assert os.path.exists(os.path.join(path_nifti, subject_id, sequence_type,
+                                                           subject_id + f'_{modality}{2}.{ext}'))
                     else:
-                        assert os.path.exists(
-                            os.path.join(
-                                path_nifti,
-                                subject_id,
-                                sequence_type,
-                                subject_id + f'_{modality}{i+1}.{ext}',
-                            )
-                        )
+                        assert os.path.exists(os.path.join(path_nifti, subject_id, sequence_type,
+                                                           subject_id + f'_{modality}{i+1}.{ext}'))
 
         sequence_type = 'anat'
         for i in range(3):
             for ext in ['nii.gz', 'json']:
                 assert os.path.exists(
-                    os.path.join(
-                        path_nifti,
-                        subject_id,
-                        sequence_type,
-                        subject_id + f'_unshimmed_e{i+1}.{ext}',
-                    )
-                )
+                    os.path.join(path_nifti, subject_id, sequence_type, subject_id + f'_unshimmed_e{i+1}.{ext}'))
 
         sequence_type = 'func'
         for ext in ['nii.gz', 'json']:
             assert os.path.exists(
-                os.path.join(
-                    path_nifti, subject_id, sequence_type, subject_id + f'_bold.{ext}'
-                )
-            )
-
+                os.path.join(path_nifti, subject_id, sequence_type, subject_id + f'_bold.{ext}'))
 
 @pytest.mark.dcm2niix
 def test_dicom_to_nifti_remove_tmp(test_dcm2niix_installation):
     """Test the remove_tmp folder"""
-    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+    with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        dicom_to_nifti(
-            os.path.join(__dir_testing__, 'dicom_unsorted'),
-            path_nifti,
-            subject_id=subject_id,
-            remove_tmp=True,
-        )
+        dicom_to_nifti(os.path.join(__dir_testing__, 'dicom_unsorted'), path_nifti, subject_id=subject_id, remove_tmp=True)
         # Check that all the files (.nii.gz and .json) are created with the expected names. The test data has 6
         # magnitude and phase data.
         assert os.path.exists(path_nifti)

--- a/test/test_prelude.py
+++ b/test/test_prelude.py
@@ -7,12 +7,13 @@ import glob
 import nibabel as nib
 import numpy as np
 import logging
+import pytest
 
 from shimmingtoolbox.unwrap import prelude
 
 
+@pytest.mark.prelude
 class TestCore(object):
-
     def setup(self):
         # Get the directory where this current file is saved
         self.full_path = Path(__file__).resolve().parent
@@ -41,7 +42,9 @@ class TestCore(object):
         path_data = glob.glob(os.path.join(self.toolbox_path, 'testing_data*'))[0]
 
         # Open phase data
-        fname_phases = glob.glob(os.path.join(path_data, 'sub-fieldmap', 'fmap', '*phase*.nii.gz'))
+        fname_phases = glob.glob(
+            os.path.join(path_data, 'sub-fieldmap', 'fmap', '*phase*.nii.gz')
+        )
         if len(fname_phases) > 2:
             raise IndexError('Phase data parsing is wrongly parsed')
 
@@ -53,7 +56,9 @@ class TestCore(object):
         phase_e2 = np.interp(nii_phase_e2.get_fdata(), [0, 4096], [-np.pi, np.pi])
 
         # Open mag data
-        fname_mags = glob.glob(os.path.join(path_data, 'sub-fieldmap', 'fmap', '*magnitude*.nii.gz'))
+        fname_mags = glob.glob(
+            os.path.join(path_data, 'sub-fieldmap', 'fmap', '*magnitude*.nii.gz')
+        )
 
         if len(fname_mags) > 2:
             raise IndexError('Mag data parsing is wrongly parsed')
@@ -75,7 +80,7 @@ class TestCore(object):
         # default prelude call
         unwrapped_phase_e1 = prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1)
 
-        assert (unwrapped_phase_e1.shape == self.phase_e1.shape)
+        assert unwrapped_phase_e1.shape == self.phase_e1.shape
 
     def test_non_default_mask(self):
         """
@@ -85,10 +90,16 @@ class TestCore(object):
         mask = np.ones(self.phase_e1.shape)
 
         # Call prelude with mask (is_unwrapping_in_2d is also used because it is significantly faster)
-        unwrapped_phase_e1 = prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1, mask, is_unwrapping_in_2d=True)
+        unwrapped_phase_e1 = prelude(
+            self.phase_e1,
+            self.mag_e1,
+            self.affine_phase_e1,
+            mask,
+            is_unwrapping_in_2d=True,
+        )
 
         # Make sure the phase is not 0. When there isn't a mask, the phase is 0
-        assert(unwrapped_phase_e1[5, 5, 5] != 0)
+        assert unwrapped_phase_e1[5, 5, 5] != 0
 
     def test_wrong_size_mask(self):
         # Create mask with wrong dimensions
@@ -157,11 +168,13 @@ class TestCore(object):
         mag_e1_2d = self.mag_e1[:, :, 0]
         unwrapped_phase_e1 = prelude(phase_e1_2d, mag_e1_2d, self.affine_phase_e1)
 
-        assert(unwrapped_phase_e1.shape == phase_e1_2d.shape)
+        assert unwrapped_phase_e1.shape == phase_e1_2d.shape
 
     def test_threshold(self):
         """
         Call prelude with a threshold for masking
         """
-        unwrapped_phase_e1 = prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1, threshold=200)
-        assert(unwrapped_phase_e1.shape == self.phase_e1.shape)
+        unwrapped_phase_e1 = prelude(
+            self.phase_e1, self.mag_e1, self.affine_phase_e1, threshold=200
+        )
+        assert unwrapped_phase_e1.shape == self.phase_e1.shape

--- a/test/test_prelude.py
+++ b/test/test_prelude.py
@@ -7,6 +7,7 @@ import glob
 import nibabel as nib
 import numpy as np
 import logging
+import pytest
 
 from shimmingtoolbox.unwrap import prelude
 

--- a/test/test_prelude.py
+++ b/test/test_prelude.py
@@ -7,7 +7,6 @@ import glob
 import nibabel as nib
 import numpy as np
 import logging
-import pytest
 
 from shimmingtoolbox.unwrap import prelude
 
@@ -15,6 +14,7 @@ from shimmingtoolbox.unwrap import prelude
 @pytest.mark.prelude
 @pytest.mark.usefixtures("test_prelude_installation")
 class TestCore(object):
+
     def setup(self):
         # Get the directory where this current file is saved
         self.full_path = Path(__file__).resolve().parent
@@ -43,9 +43,7 @@ class TestCore(object):
         path_data = glob.glob(os.path.join(self.toolbox_path, 'testing_data*'))[0]
 
         # Open phase data
-        fname_phases = glob.glob(
-            os.path.join(path_data, 'sub-fieldmap', 'fmap', '*phase*.nii.gz')
-        )
+        fname_phases = glob.glob(os.path.join(path_data, 'sub-fieldmap', 'fmap', '*phase*.nii.gz'))
         if len(fname_phases) > 2:
             raise IndexError('Phase data parsing is wrongly parsed')
 
@@ -57,9 +55,7 @@ class TestCore(object):
         phase_e2 = np.interp(nii_phase_e2.get_fdata(), [0, 4096], [-np.pi, np.pi])
 
         # Open mag data
-        fname_mags = glob.glob(
-            os.path.join(path_data, 'sub-fieldmap', 'fmap', '*magnitude*.nii.gz')
-        )
+        fname_mags = glob.glob(os.path.join(path_data, 'sub-fieldmap', 'fmap', '*magnitude*.nii.gz'))
 
         if len(fname_mags) > 2:
             raise IndexError('Mag data parsing is wrongly parsed')
@@ -81,7 +77,7 @@ class TestCore(object):
         # default prelude call
         unwrapped_phase_e1 = prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1)
 
-        assert unwrapped_phase_e1.shape == self.phase_e1.shape
+        assert (unwrapped_phase_e1.shape == self.phase_e1.shape)
 
     def test_non_default_mask(self):
         """
@@ -91,16 +87,10 @@ class TestCore(object):
         mask = np.ones(self.phase_e1.shape)
 
         # Call prelude with mask (is_unwrapping_in_2d is also used because it is significantly faster)
-        unwrapped_phase_e1 = prelude(
-            self.phase_e1,
-            self.mag_e1,
-            self.affine_phase_e1,
-            mask,
-            is_unwrapping_in_2d=True,
-        )
+        unwrapped_phase_e1 = prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1, mask, is_unwrapping_in_2d=True)
 
         # Make sure the phase is not 0. When there isn't a mask, the phase is 0
-        assert unwrapped_phase_e1[5, 5, 5] != 0
+        assert(unwrapped_phase_e1[5, 5, 5] != 0)
 
     def test_wrong_size_mask(self):
         # Create mask with wrong dimensions
@@ -169,13 +159,11 @@ class TestCore(object):
         mag_e1_2d = self.mag_e1[:, :, 0]
         unwrapped_phase_e1 = prelude(phase_e1_2d, mag_e1_2d, self.affine_phase_e1)
 
-        assert unwrapped_phase_e1.shape == phase_e1_2d.shape
+        assert(unwrapped_phase_e1.shape == phase_e1_2d.shape)
 
     def test_threshold(self):
         """
         Call prelude with a threshold for masking
         """
-        unwrapped_phase_e1 = prelude(
-            self.phase_e1, self.mag_e1, self.affine_phase_e1, threshold=200
-        )
-        assert unwrapped_phase_e1.shape == self.phase_e1.shape
+        unwrapped_phase_e1 = prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1, threshold=200)
+        assert(unwrapped_phase_e1.shape == self.phase_e1.shape)

--- a/test/test_prelude.py
+++ b/test/test_prelude.py
@@ -13,6 +13,7 @@ from shimmingtoolbox.unwrap import prelude
 
 
 @pytest.mark.prelude
+@pytest.mark.usefixtures("test_prelude_installation")
 class TestCore(object):
     def setup(self):
         # Get the directory where this current file is saved


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

**Why this change was necessary**
We want to ensure that test data has been pulled into the test
environment before running tests.

**What this change does**
Executes the download_data() CLI inside a pytest hook that runs first
when the test suite session begins.

**Any side-effects?**
Creates a new temp directory and populates it with test data.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #118 - Make sure the environment is properly setup and
binaries are present before running pytest

May want to refactor with an @setup decorator:
https://stackoverflow.com/a/12600154/6310633.