### PR TITLE
Add ability to read from the PMU

### DIFF
--- a/shimmingtoolbox/pmu.py
+++ b/shimmingtoolbox/pmu.py
@@ -8,72 +8,111 @@
 import numpy as np
 
 
-def read_resp(fname_pmu):
+class PmuResp(object):
     """
-    Read a Siemens Physiological Log file. Returns a tuple
-    with the logging data as numpy integer array and times
-    in the form of milliseconds past midnight.
+    PMU object containing the pressure values of a Siemens .resp file
 
-    Args:
-        fname_pmu: srt or file object
-                   a file name to open or an already opened file-like object
-    Returns:
-        tuple:
-            data_trimmed: centered around 0 (goes from -2047 to 2048)
-            start_time_mdh
-            stop_time_mdh
-            start_time_mpcu
-            stop_time_mpcu
+    Attributes:
+            fname (str): Filename of the Siemens .resp file
+            data (numpy.ndarray): Pressure values ranging from -2048 to 2047
+            start_time_mdh (int): Start time in milliseconds past midnight (mdh clock is expected to be the closest to
+                                  the image header)
+            stop_time_mdh (int): Stop time in milliseconds past midnight (mdh clock is expected to be the closest to
+                                 the image header)
+            start_time_mpcu (int): Start time in milliseconds past midnight
+            stop_time_mpcu (int): Stop time in milliseconds past midnight
     """
-    f = None
-    try:
-        f = fname_pmu if hasattr(fname_pmu, 'read') else open(fname_pmu)
-        lines = [line for line in f]
-    finally:
-        if f:
-            f.close()
+    def __init__(self, fname_pmu):
+        """
 
-    # Most values are space separated on a single (the first) line
-    fields = lines[0].split(' ')
+        Args:
+            fname_pmu (str): Filename of the Siemens .resp file
+        """
 
-    if fields[5] != 5002:
-        # non cardiac gate close seems to be missing
-        clean_fields = []
-        start_field = 4
-    else:
-        # cardiac has gate closed and 5002 info field
-        clean_fields = fields[5]
-        start_field = 5
+        attributes = self.read_resp(fname_pmu)
 
-    # Remove anything bracketed by 5002, 6002 (Information Fields)
-    include = True
-    for field in fields[start_field:]:
-        if include:
-            if field == '5002':
-                include = False
-            else:
-                clean_fields.append(field)
+        self.fname = attributes['fname']
+        self.data = attributes['data']
+        self.start_time_mdh = attributes['start_time_mdh']
+        self.stop_time_mdh = attributes['stop_time_mdh']
+        self.start_time_mpcu = attributes['start_time_mpcu']
+        self.stop_time_mpcu = attributes['stop_time_mpcu']
+
+    def read_resp(self, fname_pmu):
+        """
+        Read a Siemens Physiological Log file. Returns a tuple
+        with the logging data as numpy integer array and times
+        in the form of milliseconds past midnight.
+
+        Args:
+            fname_pmu: srt or file object
+                       a file name to open or an already opened file-like object
+        Returns:
+            tuple:
+                data_trimmed
+                start_time_mdh
+                stop_time_mdh
+                start_time_mpcu
+                stop_time_mpcu
+        """
+        f = None
+        try:
+            f = fname_pmu if hasattr(fname_pmu, 'read') else open(fname_pmu)
+            lines = [line for line in f]
+        finally:
+            if f:
+                f.close()
+
+        # Most values are space separated on a single (the first) line
+        fields = lines[0].split(' ')
+
+        if fields[5] != 5002:
+            # non cardiac gate close seems to be missing
+            clean_fields = []
+            start_field = 4
         else:
-            if field == '6002':
-                include = True
+            # cardiac has gate closed and 5002 info field
+            clean_fields = fields[5]
+            start_field = 5
 
-    # Drop the '6003\r\n' at the end
-    clean_fields = clean_fields[:-1]
+        # Remove anything bracketed by 5002, 6002 (Information Fields)
+        include = True
+        for field in fields[start_field:]:
+            if include:
+                if field == '5002':
+                    include = False
+                else:
+                    clean_fields.append(field)
+            else:
+                if field == '6002':
+                    include = True
 
-    # Returned values will be a numpy array of ints
-    data = np.asarray([int(field) for field in clean_fields])
+        # Drop the '6003\r\n' at the end
+        clean_fields = clean_fields[:-1]
 
-    # Extract the start/stop times from subsequent lines
-    start_time_mdh = int([line for line in lines if line.startswith('LogStartMDHTime')][0].split()[1])
-    stop_time_mdh = int([line for line in lines if line.startswith('LogStopMDHTime')][0].split()[1])
-    start_time_mpcu = int([line for line in lines if line.startswith('LogStartMPCUTime')][0].split()[1])
-    stop_time_mpcu = int([line for line in lines if line.startswith('LogStopMPCUTime')][0].split()[1])
+        # Returned values will be a numpy array of ints
+        data = np.asarray([int(field) for field in clean_fields])
 
-    # Get rid of the 5000 and 6000 trigger marks from the data. Also, in the case of ECG log files
-    # we'll also have multiple traces in the file. The second trace will be offset by 8192 so for ECG
-    # files limiting the data to points in the range 0..4095 will give us just the first channel's data.
-    # We are assuming that the 5000/6000 marks are inserted into the data values list rather than overwriting.
-    # That is we assume they do *not* occupy a raster position.
-    data_cleaned = data[data < 4096] - 2048
+        # Extract the start/stop times from subsequent lines
+        start_time_mdh = int([line for line in lines if line.startswith('LogStartMDHTime')][0].split()[1])
+        stop_time_mdh = int([line for line in lines if line.startswith('LogStopMDHTime')][0].split()[1])
+        start_time_mpcu = int([line for line in lines if line.startswith('LogStartMPCUTime')][0].split()[1])
+        stop_time_mpcu = int([line for line in lines if line.startswith('LogStopMPCUTime')][0].split()[1])
 
-    return data_cleaned, start_time_mdh, stop_time_mdh, start_time_mpcu, stop_time_mpcu
+        # Get rid of the 5000 and 6000 trigger marks from the data. Also, in the case of ECG log files
+        # we'll also have multiple traces in the file. The second trace will be offset by 8192 so for ECG
+        # files limiting the data to points in the range 0..4095 will give us just the first channel's data.
+        # We are assuming that the 5000/6000 marks are inserted into the data values list rather than overwriting.
+        # That is we assume they do *not* occupy a raster position.
+        data_cleaned = data[data < 4096] - 2048
+
+        attributes = {
+            'fname': fname_pmu,
+            'data': data_cleaned,
+            'start_time_mdh': start_time_mdh,
+            'stop_time_mdh': stop_time_mdh,
+            'start_time_mpcu': start_time_mpcu,
+            'stop_time_mpcu': stop_time_mpcu
+        }
+
+        return attributes

--- a/shimmingtoolbox/pmu.py
+++ b/shimmingtoolbox/pmu.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*
 #
-# Low level read of Siemens Physiological Log files
+# Read Siemens Physiological Log files
 # Adapted from https://gist.github.com/rtrhd/6172344
 #
 
@@ -50,7 +50,8 @@ class PmuResp(object):
         Returns:
             dict: A dict containing the ``fname_pmu`` infos. Contains the following keys:
                 {
-                  ``data_trimmed``
+                  ``fname``
+                  ``data``
                   ``start_time_mdh``
                   ``stop_time_mdh``
                   ``start_time_mpcu``

--- a/shimmingtoolbox/pmu.py
+++ b/shimmingtoolbox/pmu.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+#
+# Low level read of Siemens Physiological Log files
+# Adapted from https://gist.github.com/rtrhd/6172344
+#
+
+import numpy as np
+
+
+def read_resp(fname_pmu):
+    """
+    Read a Siemens Physiological Log file. Returns a tuple
+    with the logging data as numpy integer array and times
+    in the form of milliseconds past midnight.
+
+    Args:
+        fname_pmu: srt or file object
+                   a file name to open or an already opened file-like object
+    Returns:
+        tuple:
+            data_trimmed: centered around 0 (goes from -2047 to 2048)
+            start_time_mdh
+            stop_time_mdh
+            start_time_mpcu
+            stop_time_mpcu
+    """
+    f = None
+    try:
+        f = fname_pmu if hasattr(fname_pmu, 'read') else open(fname_pmu)
+        lines = [line for line in f]
+    finally:
+        if f:
+            f.close()
+
+    # Most values are space separated on a single (the first) line
+    fields = lines[0].split(' ')
+
+    if fields[5] != 5002:
+        # non cardiac gate close seems to be missing
+        clean_fields = []
+        start_field = 4
+    else:
+        # cardiac has gate closed and 5002 info field
+        clean_fields = fields[5]
+        start_field = 5
+
+    # Remove anything bracketed by 5002, 6002 (Information Fields)
+    include = True
+    for field in fields[start_field:]:
+        if include:
+            if field == '5002':
+                include = False
+            else:
+                clean_fields.append(field)
+        else:
+            if field == '6002':
+                include = True
+
+    # Drop the '6003\r\n' at the end
+    clean_fields = clean_fields[:-1]
+
+    # Returned values will be a numpy array of ints
+    data = np.asarray([int(field) for field in clean_fields])
+
+    # Extract the start/stop times from subsequent lines
+    start_time_mdh = int([line for line in lines if line.startswith('LogStartMDHTime')][0].split()[1])
+    stop_time_mdh = int([line for line in lines if line.startswith('LogStopMDHTime')][0].split()[1])
+    start_time_mpcu = int([line for line in lines if line.startswith('LogStartMPCUTime')][0].split()[1])
+    stop_time_mpcu = int([line for line in lines if line.startswith('LogStopMPCUTime')][0].split()[1])
+
+    # Get rid of the 5000 and 6000 trigger marks from the data. Also, in the case of ECG log files
+    # we'll also have multiple traces in the file. The second trace will be offset by 8192 so for ECG
+    # files limiting the data to points in the range 0..4095 will give us just the first channel's data.
+    # We are assuming that the 5000/6000 marks are inserted into the data values list rather than overwriting.
+    # That is we assume they do *not* occupy a raster position.
+    data_cleaned = data[data < 4096] - 2048
+
+    return data_cleaned, start_time_mdh, stop_time_mdh, start_time_mpcu, stop_time_mpcu

--- a/shimmingtoolbox/pmu.py
+++ b/shimmingtoolbox/pmu.py
@@ -118,3 +118,25 @@ class PmuResp(object):
         }
 
         return attributes
+
+    def interp_resp_trace(self, acquisition_times):
+        """
+        Interpolates ``data`` to the specified ``acquisition_times`
+
+        Args:
+            acquisition_times (numpy.ndarray): 1D array of the times in milliseconds past midnight of the desired
+                                               times to interpolate the resp_trace. Times must be within
+                                               ``self.start_time_mdh`` and ``self.stop_time_mdh``
+
+        Returns:
+            numpy.ndarray: 1D array with interpolated times
+        """
+        if np.any(self.start_time_mdh > acquisition_times) or np.all(self.stop_time_mdh < acquisition_times):
+            raise RuntimeError("acquisition_times don't fit within time limits for resp trace")
+
+        raster = float(self.stop_time_mdh - self.start_time_mdh) / len(self.data-1)
+        times = (self.start_time_mdh + raster * np.arange(len(self.data)))  # ms
+
+        interp_data = np.interp(acquisition_times, times, self.data)
+
+        return interp_data

--- a/shimmingtoolbox/pmu.py
+++ b/shimmingtoolbox/pmu.py
@@ -45,15 +45,17 @@ class PmuResp(object):
         in the form of milliseconds past midnight.
 
         Args:
-            fname_pmu: srt or file object
-                       a file name to open or an already opened file-like object
+            fname_pmu: Filename of the Siemens .resp file
+
         Returns:
-            tuple:
-                data_trimmed
-                start_time_mdh
-                stop_time_mdh
-                start_time_mpcu
-                stop_time_mpcu
+            dict: A dict containing the ``fname_pmu`` infos. Contains the following keys:
+                {
+                  ``data_trimmed``
+                  ``start_time_mdh``
+                  ``stop_time_mdh``
+                  ``start_time_mpcu``
+                  ``stop_time_mpcu``
+                }
         """
         f = None
         try:

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*
 
 import os
+import numpy as np
 
 from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox.pmu import PmuResp
-import numpy as np
 
 
 def test_read_resp():
@@ -27,10 +27,6 @@ def test_read_resp():
         expected_start_time_mpcu == pmu.start_time_mpcu,
         expected_stop_time_mpcu == pmu.stop_time_mpcu
     ])
-
-
-from matplotlib.figure import Figure
-from shimmingtoolbox import __dir_shimmingtoolbox__
 
 
 def test_interp_resp_trace():

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -4,13 +4,13 @@
 import os
 
 from shimmingtoolbox import __dir_testing__
-from shimmingtoolbox.pmu import read_resp
+from shimmingtoolbox.pmu import PmuResp
 import numpy as np
 
 
 def test_read_resp():
     fname = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
-    data_cleaned, start_time_mdh, stop_time_mdh, start_time_mpcu, stop_time_mpcu = read_resp(fname)
+    pmu = PmuResp(fname)
 
     expected_first_data = np.array([1667, 1667, 1682, 1682, 1667])
     expected_last_data = np.array([-2048, -2048, -2048, -2048, -2048])
@@ -20,12 +20,11 @@ def test_read_resp():
     expected_stop_time_mpcu = 44343040
 
     assert np.all([
-        np.all(expected_first_data == data_cleaned[:5]),
-        np.all(expected_last_data == data_cleaned[-5:]),
-        expected_start_time_mdh == start_time_mdh,
-        expected_stop_time_mdh == stop_time_mdh,
-        expected_start_time_mpcu == start_time_mpcu,
-        expected_stop_time_mpcu == stop_time_mpcu
+        np.all(expected_first_data == pmu.data[:5]),
+        np.all(expected_last_data == pmu.data[-5:]),
+        expected_start_time_mdh == pmu.start_time_mdh,
+        expected_stop_time_mdh == pmu.stop_time_mdh,
+        expected_start_time_mpcu == pmu.start_time_mpcu,
+        expected_stop_time_mpcu == pmu.stop_time_mpcu
     ])
-
 

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+
+import os
+
+from shimmingtoolbox import __dir_testing__
+from shimmingtoolbox.pmu import read_resp
+import numpy as np
+
+
+def test_read_resp():
+    fname = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
+    data_cleaned, start_time_mdh, stop_time_mdh, start_time_mpcu, stop_time_mpcu = read_resp(fname)
+
+    expected_first_data = np.array([1667, 1667, 1682, 1682, 1667])
+    expected_last_data = np.array([-2048, -2048, -2048, -2048, -2048])
+    expected_start_time_mdh = 44294387
+    expected_stop_time_mdh = 44343130
+    expected_start_time_mpcu = 44294295
+    expected_stop_time_mpcu = 44343040
+
+    assert np.all([
+        np.all(expected_first_data == data_cleaned[:5]),
+        np.all(expected_last_data == data_cleaned[-5:]),
+        expected_start_time_mdh == start_time_mdh,
+        expected_stop_time_mdh == stop_time_mdh,
+        expected_start_time_mpcu == start_time_mpcu,
+        expected_stop_time_mpcu == stop_time_mpcu
+    ])
+
+

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -28,3 +28,23 @@ def test_read_resp():
         expected_stop_time_mpcu == pmu.stop_time_mpcu
     ])
 
+
+from matplotlib.figure import Figure
+from shimmingtoolbox import __dir_shimmingtoolbox__
+
+
+def test_interp_resp_trace():
+    fname = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
+    pmu = PmuResp(fname)
+
+    # Create time series to interpolate the PMU to
+    num_points = 20
+    acq_times = np.linspace(pmu.start_time_mdh, pmu.stop_time_mdh, num_points)
+
+    acq_pressure = pmu.interp_resp_trace(acq_times)
+
+    index_pmu_data = np.linspace(0, len(pmu.data) - 1, int(num_points)).astype(int)
+    index_pmu_interp = np.linspace(0, num_points - 1, int(num_points)).astype(int)
+
+    assert(np.all(np.isclose(acq_pressure[index_pmu_interp], pmu.data[index_pmu_data], atol=1, rtol=0.08)))
+


### PR DESCRIPTION
## Description
This PR adds the ability to read Siemens respiratory files. It introduces the Class `PmuResp()`, with methods:
- `read_resp(fname)`: read PMU siemens file
- `interp_resp_trace(acq_time)`: Interpolate Siemens PMU data points onto the timing grid given as input argument. This will be used to match PMU trace with individual time point image.

## Linked issues
Fixes #26 
