### PR TITLE
Fix Travis coveralls post-build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - sudo install dcm2nii* /usr/bin/
   -
   - pip install .
-  - pip install python-coveralls
+  - pip install coveralls
 # command to run tests
 script:
   - echo "Download prelude"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # shimming-toolbox
 
-[![Build Status](https://travis-ci.com/shimming-toolbox/shimming-toolbox.svg?branch=master)](https://travis-ci.com/shimming-toolbox/shimming-toolbox) [![Documentation Status](https://readthedocs.org/projects/shimming-toolbox/badge/?version=latest)](https://www.shimming-toolbox.org/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.com/shimming-toolbox/shimming-toolbox.svg?branch=master)](https://travis-ci.com/shimming-toolbox/shimming-toolbox) [![Documentation Status](https://readthedocs.org/projects/shimming-toolbox/badge/?version=latest)](https://www.shimming-toolbox.org/en/latest/?badge=latest) [![Coverage Status](https://coveralls.io/repos/github/shimming-toolbox/shimming-toolbox/badge.svg?branch=master)](https://coveralls.io/github/shimming-toolbox/shimming-toolbox?branch=master)
 
 
 Code for performing real-time shimming using external MRI shim coils


### PR DESCRIPTION


## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
**Why this change was necessary**
The `coveralls` post-success build step was erroring out due to the
now-wrong package being pip-installed.

**What this change does**
Modifies the setup step to install the correct coveralls package.

**Any side-effects?**
None noticed yet... Will update after running the build.
## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #143 - coveralls crashing in Travis - pip package install needs to be corrected