### PR TITLE
Update shimming-toolbox package install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - unzip -o dcm2niix_lnx.zip
   - sudo install dcm2nii* /usr/bin/
   -
-  - pip install -e .[testing]
+  - pip install .
   - pip install python-coveralls
 # command to run tests
 script:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
             "st_dicom_to_nifti=shimmingtoolbox.cli.dicom_to_nifti:dicom_to_nifti_cli",
         ]
     },
-    packages=find_packages(exclude=["contrib", "docs", "tests"]),
+    packages=find_packages(exclude=["docs"]),
     install_requires=[
         "click",
         "dcm2bids==2.1.4",


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
**Why this change was necessary**
The install command referenced a deprecated extra for the package
install directive. This testing extra was already added to the default
installation.

**What this change does**
Removes the old extra as well as the -e flag since installing the
project in editable mode is not necessary in the Travis environment.

Adds an `__init__.py` file to the CLI module that allows it to be imported for the CLI entrypoints defined in `setup.py`.
This missing `__init__.py` was discovered when the -e flag was removed from the `pip install` directive in the Travis config.

**Any side-effects?**
1 less warning in the build logs!
## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #145 - Update Travis build with correct pip install for shimming-toolbox
Related to #97
