### PR TITLE
Fix RTD badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # shimming-toolbox
 
- [![Build Status](https://github.com/shimming-toolbox/shimming-toolbox/workflows/CI-Tests/badge.svg)](https://github.com/shimming-toolbox/shimming-toolbox/actions?query=workflow%3ACI-Tests) [![Documentation Status](https://readthedocs.org/projects/shimming-toolbox/badge/?version=latest)](https://www.shimming-toolbox.org/en/latest/?badge=latest) [![Coverage Status](https://coveralls.io/repos/github/shimming-toolbox/shimming-toolbox/badge.svg?branch=master)](https://coveralls.io/github/shimming-toolbox/shimming-toolbox?branch=master)
+ [![Build Status](https://github.com/shimming-toolbox/shimming-toolbox/workflows/CI-Tests/badge.svg?branch=master)](https://github.com/shimming-toolbox/shimming-toolbox/actions?query=workflow%3ACI-Tests+branch%3Amaster) [![Coverage Status](https://coveralls.io/repos/github/shimming-toolbox/shimming-toolbox/badge.svg?branch=master)](https://coveralls.io/github/shimming-toolbox/shimming-toolbox?branch=master) [![Documentation Status](https://readthedocs.org/projects/shimming-toolbox-py/badge/?version=latest)](https://shimming-toolbox.org/en/latest/)
 
 
 Code for performing real-time shimming using external MRI shim coils


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [ ] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
**Why this change was necessary**
RTD sticker in README was not pointing to the RTD project, making it
show "Unknown" for the RTD build status.

**What this change does**
Sticker points to
https://readthedocs.org/projects/shimming-toolbox-py/ , but links to
https://shimming-toolbox.org/en/latest/

**Any side-effects?**
None.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
It's a small README fix, so no issue was created.