### PR TITLE
Add ability to get timing data from scans

### DIFF
--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -15,7 +15,7 @@ from shimmingtoolbox.download import install_data
 
 URL_DICT: Dict[str, Tuple[List[str], str]] = {
     "testing_data": (
-        ["https://github.com/shimming-toolbox/data-testing/archive/r20201014.zip"],
+        ["https://github.com/shimming-toolbox/data-testing/archive/r20201021.zip"],
         "Light-weighted dataset for testing purpose.",
     ),
     "prelude": (

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -15,7 +15,7 @@ from shimmingtoolbox.download import install_data
 
 URL_DICT: Dict[str, Tuple[List[str], str]] = {
     "testing_data": (
-        ["https://github.com/shimming-toolbox/data-testing/archive/r20201008.zip"],
+        ["https://github.com/shimming-toolbox/data-testing/archive/r20201014.zip"],
         "Light-weighted dataset for testing purpose.",
     ),
     "prelude": (

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -15,40 +15,21 @@ logger = logging.getLogger(__name__)
 PHASE_SCALING_SIEMENS = 4096
 
 
-# TODO: possibly input dict (obtained from the json)
-def get_acquisition_times(fname_acquisition):
+def get_acquisition_times(nii_data, json_data):
     """
-    Return the acquisition timestamps from a nifti file with corresponding json sidecar. This assumes BIDS
-    convention
+    Return the acquisition timestamps from a json sidecar. This assumes BIDS convention.
 
     Args:
-        fname_acquisition (str): Filename corresponding to a nifti file. The file must have a json sidecar with the
-                                 same name in the same folder. (nifti.nii nifti.json)
-                                 Supported extensions : ".nii", ".nii.gz".
+        nii_data (nibabel.Nifti1Image): Nibabel object containing the image timeseries.
+        json_data (dict): Json dict corresponding to a nifti sidecar.
 
     Returns:
-        numpy.ndarray: Acquisition timestamps in ms
+        numpy.ndarray: Acquisition timestamps in ms.
 
     """
     # Get number of volumes
-    nii_fieldmap = nib.load(fname_acquisition)
-    n_volumes = nii_fieldmap.header['dim'][4]
+    n_volumes = nii_data.header['dim'][4]
 
-    # get time between volumes and acquisition start time
-    fname, ext = os.path.splitext(fname_acquisition)
-    if ext == '.nii':
-        fname_acquisition_json = fname + '.json'
-    elif ext == '.gz':
-        # Disregard gz and test for nii
-        fname, ext = os.path.splitext(fname)
-        if ext == '.nii':
-            fname_acquisition_json = fname + '.json'
-        else:
-            raise RuntimeError('Input file is not a .nii.gz file')
-    else:
-        raise RuntimeError('Input file is not a .nii or .XX.gz file')
-
-    json_data = json.load(open(fname_acquisition_json))
     delta_t = json_data['RepetitionTime'] * 1000  # [ms]
     acq_start_time_iso = json_data['AcquisitionTime']  # ISO format
     acq_start_time_ms = iso_times_to_ms(np.array([acq_start_time_iso]))[0]  # [ms]

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8
 # Misc functions
 
+import numpy as np
 import os
 import tqdm
 import subprocess
@@ -53,6 +54,39 @@ def add_suffix(fname, suffix):
 
     stem, ext = _splitext(fname)
     return os.path.join(stem + suffix + ext)
+
+
+def dicom_times_to_ms(dicom_times):
+    """
+    Convert dicom acquisition times to ms
+
+    Args:
+        dicom_times (numpy.ndarray): 1D array of time strings from dicoms.
+                                     Suported formats: "HHMMSS.mmmmmm" or "HH:MM:SS.mmmmmm"
+
+    Returns:
+        numpy.ndarray: 1D array of times in milliseconds
+    """
+
+    ms_times = []
+
+    for a_time in dicom_times:
+        if len(a_time) == 13 and a_time[6] == '.' and isinstance(a_time, str):
+            hours = int(a_time[0:2])
+            minutes = int(a_time[2:4])
+            seconds = int(a_time[4:6])
+            micros = int(a_time[7:13])
+        elif len(a_time) == 15 and a_time[2] + a_time[5] + a_time[8] == ['::.'] or isinstance(a_time, str):
+            hours = int(a_time[0:2])
+            minutes = int(a_time[3:5])
+            seconds = int(a_time[6:8])
+            micros = int(a_time[9:15])
+        else:
+            raise RuntimeError("Input format does not follow 'HHMMSS.mmmmmm'")
+
+        ms_times.append(1000 * (hours * 3600 + minutes * 60 + seconds) + micros / 1000)  # ms
+
+    return np.array(ms_times)
 
 
 def st_progress_bar(*args, **kwargs):

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -56,7 +56,7 @@ def add_suffix(fname, suffix):
     return os.path.join(stem + suffix + ext)
 
 
-def dicom_times_to_ms(dicom_times):
+def iso_times_to_ms(dicom_times):
     """
     Convert dicom acquisition times to ms
 

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -56,13 +56,13 @@ def add_suffix(fname, suffix):
     return os.path.join(stem + suffix + ext)
 
 
-def iso_times_to_ms(dicom_times):
+def iso_times_to_ms(iso_times):
     """
     Convert dicom acquisition times to ms
 
     Args:
-        dicom_times (numpy.ndarray): 1D array of time strings from dicoms.
-                                     Suported formats: "HHMMSS.mmmmmm" or "HH:MM:SS.mmmmmm"
+        iso_times (numpy.ndarray): 1D array of time strings from dicoms.
+                                   Suported formats: "HHMMSS.mmmmmm" or "HH:MM:SS.mmmmmm"
 
     Returns:
         numpy.ndarray: 1D array of times in milliseconds
@@ -70,7 +70,7 @@ def iso_times_to_ms(dicom_times):
 
     ms_times = []
 
-    for a_time in dicom_times:
+    for a_time in iso_times:
         if len(a_time) == 13 and a_time[6] == '.' and isinstance(a_time, str):
             hours = int(a_time[0:2])
             minutes = int(a_time[2:4])

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -88,26 +88,24 @@ def test_timing_images():
 
         return np.array(ms_times)
 
-    fname_pmu = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
-    pmu = PmuResp(fname_pmu)
-
-    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_fieldmap.nii.gz')
-    fname_json_phase_diff = os.path.join(__dir_testing__, 'nifti', 'sub-example', 'fmap',
-                                         'sub-example_phasediff.json')
-
     # get time between volumes and acquisition start time
+    fname_json_phase_diff = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                                         'sub-example_phasediff.json')
     json_data = json.load(open(fname_json_phase_diff))
     delta_t = json_data['RepetitionTime'] * 1000  # [ms]
-    acq_start_time = json_data['AcquisitionTime']  # ISO format
-    acq_start_time = dicom_times_to_ms(np.array([acq_start_time]))[0]  # [ms]
+    acq_start_time_iso = json_data['AcquisitionTime']  # ISO format
+    acq_start_time_ms = dicom_times_to_ms(np.array([acq_start_time_iso]))[0]  # [ms]
 
     # Get the number of volumes
+    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                                  'sub-example_fieldmap.nii.gz')
     nii_fieldmap = nib.load(fname_fieldmap)
     n_volumes = nii_fieldmap.header['dim'][4]
 
-    # Get the pressure values at the iterpolated timestamps
-    fieldmap_timestamps = np.linspace(acq_start_time, ((n_volumes - 1) * delta_t) + acq_start_time, n_volumes)
+    # Get the pressure values at the interpolated timestamps
+    fname_pmu = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
+    pmu = PmuResp(fname_pmu)
+    fieldmap_timestamps = np.linspace(acq_start_time_ms, ((n_volumes - 1) * delta_t) + acq_start_time_ms, n_volumes)
     acquisition_pressures = pmu.interp_resp_trace(fieldmap_timestamps)
 
     # Get B0 data

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -7,6 +7,7 @@ import numpy as np
 # TODO remove matplotlib import once finalized
 from matplotlib.figure import Figure
 import nibabel as nib
+import json
 
 from shimmingtoolbox.masking.shapes import shapes
 from shimmingtoolbox import __dir_shimmingtoolbox__
@@ -55,22 +56,25 @@ def test_interp_resp_trace():
 def test_timing_images():
     """Check the matching of timing between MR images and PMU timestamps"""
 
+    # Get B0 data
+    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                                  'sub-example_fieldmap.nii.gz')
+    nii_fieldmap = nib.load(fname_fieldmap)
+    fieldmap = nii_fieldmap.get_fdata()
+
     # Get the pressure values
     fname_pmu = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
     pmu = PmuResp(fname_pmu)
 
     # Get acquisition timestamps
-    fname_phase_diff = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                         'sub-example_phasediff.nii.gz')
-    fieldmap_timestamps = get_acquisition_times(fname_phase_diff)
+    fname_phase_diff_json = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                                         'sub-example_phasediff.json')
+    with open(fname_phase_diff_json) as json_file:
+        json_data = json.load(json_file)
+    fieldmap_timestamps = get_acquisition_times(nii_fieldmap, json_data)
 
     # Interpolate PMU values onto MRI acquisition timestamp
     acquisition_pressures = pmu.interp_resp_trace(fieldmap_timestamps)
-
-    # Get B0 data
-    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_fieldmap.nii.gz')
-    fieldmap = nib.load(fname_fieldmap).get_fdata()
 
     # Set up mask
     mask_len1 = 15

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -90,9 +90,11 @@ def test_timing_images():
         return np.array(ms_times)
 
     # TODO: Move to appropriate place
+    # TODO: possibly input dict (obtained from the json)
     def get_acquisition_times(fname_acquisition):
         """
-        Return the acquisition timestamps from a nifti file with corresponding json bids sidecar
+        Return the acquisition timestamps from a nifti file with corresponding json sidecar. This assumes BIDS
+        convention
 
         Args:
             fname_acquisition (str): Filename corresponding to a nifti file. The file must have a json sidecar with the
@@ -128,14 +130,16 @@ def test_timing_images():
 
         return np.linspace(acq_start_time_ms, ((n_volumes - 1) * delta_t) + acq_start_time_ms, n_volumes)  # [ms]
 
-    # Get the pressure values at the interpolated timestamps
+    # Get the pressure values
     fname_pmu = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
     pmu = PmuResp(fname_pmu)
 
-    # Get acquisition timestamps and pressures
+    # Get acquisition timestamps
     fname_phase_diff = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
                                          'sub-example_phasediff.nii.gz')
     fieldmap_timestamps = get_acquisition_times(fname_phase_diff)
+
+    # Interpolate PMU values onto MRI acquisition timestamp
     acquisition_pressures = pmu.interp_resp_trace(fieldmap_timestamps)
 
     # Get B0 data
@@ -177,7 +181,7 @@ def test_timing_images():
     ax = fig.add_subplot(212)
     ax.plot(fieldmap_timestamps / 1000, fieldmap_mean, label='Mean B0')
     ax.legend()
-    ax.set_title("Fieldmap average over unmasked region (hz) vs time (s)")
+    ax.set_title("Fieldmap average over unmasked region (Hz) vs time (s)")
 
     fname_figure = os.path.join(__dir_shimmingtoolbox__, 'pmu_plot.png')
     fig.savefig(fname_figure)
@@ -187,12 +191,12 @@ def test_timing_images():
     ax = fig.add_subplot(211)
     im = ax.imshow(fieldmap_masked[:, :, 0, 0])
     fig.colorbar(im)
-    ax.set_title("Mask (hz)")
+    ax.set_title("Mask (Hz)")
 
     ax = fig.add_subplot(212)
     im = ax.imshow(fieldmap[:, :, 0, 0])
     fig.colorbar(im)
-    ax.set_title("Fieldmap (hz)")
+    ax.set_title("Fieldmap (Hz)")
 
     fname_figure = os.path.join(__dir_shimmingtoolbox__, 'mask.png')
     fig.savefig(fname_figure)

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -84,11 +84,11 @@ def test_timing_images():
 
     # Apply mask and compute the average for each timepoint
     fieldmap_masked = np.zeros_like(fieldmap)
-    fieldmap_mean = np.zeros([fieldmap.shape[3]])
+    fieldmap_avg = np.zeros([fieldmap.shape[3]])
     for i_time in range(fieldmap.shape[3]):
         fieldmap_masked[:, :, :, i_time] = fieldmap[:, :, :, i_time] * mask
         masked_array = np.ma.array(fieldmap[:, :, :, i_time], mask=mask == False)
-        fieldmap_mean[i_time] = np.ma.average(masked_array)
+        fieldmap_avg[i_time] = np.ma.average(masked_array)
 
     # Reshape pmu datapoints to fit those of the acquisition
     pmu_times = np.linspace(pmu.start_time_mdh, pmu.stop_time_mdh, len(pmu.data))
@@ -98,10 +98,10 @@ def test_timing_images():
     pmu_times_within_range = pmu_times_within_range[pmu_times_within_range < fieldmap_timestamps[fieldmap.shape[3] - 1]]
 
     # Compute correlation
-    pmu_data_within_range_ds = scipy.signal.resample(pmu_data_within_range, acquisition_pressures.shape[0])
-    pearson = np.corrcoef(acquisition_pressures, pmu_data_within_range_ds)
+    pmu_data_within_range_ds = scipy.signal.resample(pmu_data_within_range, fieldmap_avg.shape[0])
+    pearson = np.corrcoef(fieldmap_avg, pmu_data_within_range_ds)
 
-    assert(pearson[0, 1] == 0.784021686600437)
+    assert(pearson[0, 1] == 0.6031485150782748)
 
     # # Plot results
     # fig = Figure(figsize=(10, 10))
@@ -112,7 +112,7 @@ def test_timing_images():
     # ax.legend()
     # ax.set_title("Pressure [-2048, 2047] vs time (s) ")
     # ax = fig.add_subplot(212)
-    # ax.plot(fieldmap_timestamps / 1000, fieldmap_mean, label='Mean B0')
+    # ax.plot(fieldmap_timestamps / 1000, fieldmap_avg, label='Mean B0')
     # ax.legend()
     # ax.set_title("Fieldmap average over unmasked region (Hz) vs time (s)")
     #

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -3,7 +3,6 @@
 
 import os
 import numpy as np
-
 import nibabel as nib
 import json
 import scipy.signal

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -91,31 +91,23 @@ def test_timing_images():
     fname_pmu = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
     pmu = PmuResp(fname_pmu)
 
-    # TODO: Update testing data with the updated niftis processed by the new version of dcm2niix
-    #  (Note: the appropriate version is currently the dev version as of oct 16 2020)
     fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                              'sub-example_fieldmap.nii.gz')
+                                  'sub-example_fieldmap.nii.gz')
     fname_json_phase_diff = os.path.join(__dir_testing__, 'nifti', 'sub-example', 'fmap',
-                              'sub-example_phasediff.json')
+                                         'sub-example_phasediff.json')
 
     # get time between volumes and acquisition start time
     json_data = json.load(open(fname_json_phase_diff))
-    # TODO: TimeBetweenVolumes will most likely be changed to repetitionTime eventually according to
-    #  https://github.com/UNFmontreal/Dcm2Bids/issues/90
-    delta_t = json_data['TimeBetweenVolumes'] * 1000  # [ms]
+    delta_t = json_data['RepetitionTime'] * 1000  # [ms]
     acq_start_time = json_data['AcquisitionTime']  # ISO format
     acq_start_time = dicom_times_to_ms(np.array([acq_start_time]))[0]  # [ms]
 
     # Get the number of volumes
     nii_fieldmap = nib.load(fname_fieldmap)
     n_volumes = nii_fieldmap.header['dim'][4]
+
+    # Get the pressure values at the iterpolated timestamps
     fieldmap_timestamps = np.linspace(acq_start_time, ((n_volumes - 1) * delta_t) + acq_start_time, n_volumes)
-
-    # These timestamps were generated as explained here: https://github.com/UNFmontreal/Dcm2Bids/issues/90
-    # in microseconds
-    # data_timestamps = ['121821.960000', '121822.745000', '121816.452500', '121817.240000', '121818.025000',
-    #                    '121821.172500', '121820.385000', '121818.812500', '121819.600000', '121823.532500']
-
     acquisition_pressures = pmu.interp_resp_trace(fieldmap_timestamps)
 
     # Get B0 data

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -101,7 +101,7 @@ def test_timing_images():
     pmu_data_within_range_ds = scipy.signal.resample(pmu_data_within_range, fieldmap_avg.shape[0])
     pearson = np.corrcoef(fieldmap_avg, pmu_data_within_range_ds)
 
-    assert(pearson[0, 1] == 0.6031485150782748)
+    assert(np.isclose(pearson[0, 1], 0.6031485150782748))
 
     # # Plot results
     # fig = Figure(figsize=(10, 10))

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -90,6 +90,7 @@ def test_timing_images():
 
     # Sanity check -->
     # TODO: use assert
+    # TODO: downsample the PMU trace and use np.corrcoeff with assert
     pmu_times = np.linspace(pmu.start_time_mdh, pmu.stop_time_mdh, len(pmu.data))
     pmu_times_within_range = pmu_times[pmu_times > fieldmap_timestamps[0]]
     pmu_data_within_range = pmu.data[pmu_times > fieldmap_timestamps[0]]

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -137,19 +137,23 @@ def test_timing_images():
 
     # Sanity check -->
     pmu_times = np.linspace(pmu.start_time_mdh, pmu.stop_time_mdh, len(pmu.data))
+    pmu_times_within_range = pmu_times[pmu_times > fieldmap_timestamps[0]]
+    pmu_data_within_range = pmu.data[pmu_times > fieldmap_timestamps[0]]
+    pmu_data_within_range = pmu_data_within_range[pmu_times_within_range < fieldmap_timestamps[fieldmap.shape[3] - 1]]
+    pmu_times_within_range = pmu_times_within_range[pmu_times_within_range < fieldmap_timestamps[fieldmap.shape[3] - 1]]
 
     # Plot results
     fig = Figure(figsize=(10, 10))
     ax = fig.add_subplot(211)
-    ax.plot(fieldmap_timestamps, acquisition_pressures, label='Interpolated pressures')
+    ax.plot(fieldmap_timestamps / 1000, acquisition_pressures, label='Interpolated pressures')
     # ax.plot(pmu_times, pmu.data, label='Raw pressures')
+    ax.plot(pmu_times_within_range / 1000, pmu_data_within_range, label='Pmu pressures')
     ax.legend()
-    ax.set_title("Pressure vs time (-2048-2047)")
-
+    ax.set_title("Pressure [-2048, 2047] vs time (s) ")
     ax = fig.add_subplot(212)
-    ax.plot(fieldmap_timestamps, fieldmap_mean, label='Mean B0')
+    ax.plot(fieldmap_timestamps / 1000, fieldmap_mean, label='Mean B0')
     ax.legend()
-    ax.set_title("Fieldmap average over unmasked region vs time (hz)")
+    ax.set_title("Fieldmap average over unmasked region (hz) vs time (s)")
 
     fname_figure = os.path.join(__dir_shimmingtoolbox__, 'pmu_plot.png')
     fig.savefig(fname_figure)

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -45,17 +45,66 @@ def test_interp_resp_trace():
     assert(np.all(np.isclose(acq_pressure[index_pmu_interp], pmu.data[index_pmu_data], atol=1, rtol=0.08)))
 
 
+from matplotlib.figure import Figure
+from shimmingtoolbox import __dir_shimmingtoolbox__
+
+
 def test_timing_images():
     """Check the matching of timing between MR images and PMU timestamps"""
-    a=1
+
     fname_pmu = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
     pmu = PmuResp(fname_pmu)
     fname_data = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap', '')
 
     # These timestamps were generated as explained here: https://github.com/UNFmontreal/Dcm2Bids/issues/90
     # in microseconds
-    data_timestamps = [121821.960000, 121822.745000, 121816.452500, 121817.240000, 121818.025000, 121821.172500,
-                       121820.385000, 121818.812500, 121819.600000, 121823.532500]
-    # TODO: convert to ms
-    1000 * (12 * 3600 + 18 * 60 + 21) + 960
-    acquisition_times = []
+    data_timestamps = ['121821.960000', '121822.745000', '121816.452500', '121817.240000', '121818.025000',
+                       '121821.172500', '121820.385000', '121818.812500', '121819.600000', '121823.532500']
+
+    # Convert to ms
+    def dicom_times_to_ms(dicom_times):
+        """
+        Convert dicom acquisition times to ms
+
+        Args:
+            dicom_times (numpy.ndarray): 1D array of time strings from dicoms. Format: "HHMMSS.mmmmmm"
+
+        Returns:
+            numpy.ndarray: 1D array of times in milliseconds
+        """
+
+        ms_times = []
+
+        for a_time in dicom_times:
+            if len(a_time) != 13 or a_time[6] != '.' or not isinstance(a_time, str):
+                raise RuntimeError("Input format does not follow 'HHMMSS.mmmmmm'")
+            hours = int(a_time[0:2])
+            minutes = int(a_time[2:4])
+            seconds = int(a_time[4:6])
+            micros = int(a_time[7:13])
+
+            ms_times.append(1000 * (hours * 3600 + minutes * 60 + seconds) + micros / 1000)  # ms
+
+        return ms_times
+
+    acquisition_times = dicom_times_to_ms(data_timestamps)
+
+    acquisition_times = sorted(acquisition_times)
+    acquisition_times = np.array(acquisition_times)
+
+    acquisition_pressures = pmu.interp_resp_trace(acquisition_times)
+
+    # Sanity check -->
+    pmu_times = np.linspace(pmu.start_time_mdh, pmu.stop_time_mdh, len(pmu.data))
+
+    # Plot results
+    fig = Figure(figsize=(10, 10))
+    # FigureCanvas(fig)
+    ax = fig.add_subplot(111)
+    ax.plot(acquisition_times, acquisition_pressures)
+    ax.plot(pmu_times, pmu.data)
+    ax.set_title("test")
+
+    fname_figure = os.path.join(__dir_shimmingtoolbox__, 'pmu_plot.png')
+    fig.savefig(fname_figure)
+

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox.pmu import PmuResp
-from shimmingtoolbox.utils import dicom_times_to_ms
+from shimmingtoolbox.utils import iso_times_to_ms
 
 
 def test_read_resp():
@@ -93,7 +93,7 @@ def test_timing_images():
         json_data = json.load(open(fname_acquisition_json))
         delta_t = json_data['RepetitionTime'] * 1000  # [ms]
         acq_start_time_iso = json_data['AcquisitionTime']  # ISO format
-        acq_start_time_ms = dicom_times_to_ms(np.array([acq_start_time_iso]))[0]  # [ms]
+        acq_start_time_ms = iso_times_to_ms(np.array([acq_start_time_iso]))[0]  # [ms]
 
         return np.linspace(acq_start_time_ms, ((n_volumes - 1) * delta_t) + acq_start_time_ms, n_volumes)  # [ms]
 

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -44,3 +44,18 @@ def test_interp_resp_trace():
 
     assert(np.all(np.isclose(acq_pressure[index_pmu_interp], pmu.data[index_pmu_data], atol=1, rtol=0.08)))
 
+
+def test_timing_images():
+    """Check the matching of timing between MR images and PMU timestamps"""
+    a=1
+    fname_pmu = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
+    pmu = PmuResp(fname_pmu)
+    fname_data = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap', '')
+
+    # These timestamps were generated as explained here: https://github.com/UNFmontreal/Dcm2Bids/issues/90
+    # in microseconds
+    data_timestamps = [121821.960000, 121822.745000, 121816.452500, 121817.240000, 121818.025000, 121821.172500,
+                       121820.385000, 121818.812500, 121819.600000, 121823.532500]
+    # TODO: convert to ms
+    1000 * (12 * 3600 + 18 * 60 + 21) + 960
+    acquisition_times = []

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox.pmu import PmuResp
+from shimmingtoolbox.utils import dicom_times_to_ms
 
 
 def test_read_resp():
@@ -54,40 +55,6 @@ from shimmingtoolbox.masking.shapes import shapes
 
 def test_timing_images():
     """Check the matching of timing between MR images and PMU timestamps"""
-
-    # TODO: Move to appropriate place
-    # Convert to ms
-    def dicom_times_to_ms(dicom_times):
-        """
-        Convert dicom acquisition times to ms
-
-        Args:
-            dicom_times (numpy.ndarray): 1D array of time strings from dicoms.
-                                         Suported formats: "HHMMSS.mmmmmm" or "HH:MM:SS.mmmmmm"
-
-        Returns:
-            numpy.ndarray: 1D array of times in milliseconds
-        """
-
-        ms_times = []
-
-        for a_time in dicom_times:
-            if len(a_time) == 13 and a_time[6] == '.' and isinstance(a_time, str):
-                hours = int(a_time[0:2])
-                minutes = int(a_time[2:4])
-                seconds = int(a_time[4:6])
-                micros = int(a_time[7:13])
-            elif len(a_time) == 15 and a_time[2] + a_time[5] + a_time[8] == ['::.'] or isinstance(a_time, str):
-                hours = int(a_time[0:2])
-                minutes = int(a_time[3:5])
-                seconds = int(a_time[6:8])
-                micros = int(a_time[9:15])
-            else:
-                raise RuntimeError("Input format does not follow 'HHMMSS.mmmmmm'")
-
-            ms_times.append(1000 * (hours * 3600 + minutes * 60 + seconds) + micros / 1000)  # ms
-
-        return np.array(ms_times)
 
     # TODO: Move to appropriate place
     # TODO: possibly input dict (obtained from the json)

--- a/test/test_pmu.py
+++ b/test/test_pmu.py
@@ -4,14 +4,11 @@
 import os
 import numpy as np
 
-# TODO remove matplotlib import once finalized
-from matplotlib.figure import Figure
 import nibabel as nib
 import json
 import scipy.signal
 
 from shimmingtoolbox.masking.shapes import shapes
-from shimmingtoolbox import __dir_shimmingtoolbox__
 from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox.pmu import PmuResp
 from shimmingtoolbox.load_nifti import get_acquisition_times
@@ -57,7 +54,7 @@ def test_interp_resp_trace():
 def test_timing_images():
     """Check the matching of timing between MR images and PMU timestamps"""
 
-    # Get B0 data
+    # Get fieldmap
     fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
                                   'sub-example_fieldmap.nii.gz')
     nii_fieldmap = nib.load(fname_fieldmap)
@@ -107,34 +104,33 @@ def test_timing_images():
 
     assert(pearson[0, 1] == 0.784021686600437)
 
-    # TODO: remove plot once code finalized
-    # Plot results
-    fig = Figure(figsize=(10, 10))
-    ax = fig.add_subplot(211)
-    ax.plot(fieldmap_timestamps / 1000, acquisition_pressures, label='Interpolated pressures')
-    # ax.plot(pmu_times, pmu.data, label='Raw pressures')
-    ax.plot(pmu_times_within_range / 1000, pmu_data_within_range, label='Pmu pressures')
-    ax.legend()
-    ax.set_title("Pressure [-2048, 2047] vs time (s) ")
-    ax = fig.add_subplot(212)
-    ax.plot(fieldmap_timestamps / 1000, fieldmap_mean, label='Mean B0')
-    ax.legend()
-    ax.set_title("Fieldmap average over unmasked region (Hz) vs time (s)")
-
-    fname_figure = os.path.join(__dir_shimmingtoolbox__, 'pmu_plot.png')
-    fig.savefig(fname_figure)
-
-    # Plot mask
-    fig = Figure(figsize=(10, 10))
-    ax = fig.add_subplot(211)
-    im = ax.imshow(fieldmap_masked[:, :, 0, 0])
-    fig.colorbar(im)
-    ax.set_title("Mask (Hz)")
-
-    ax = fig.add_subplot(212)
-    im = ax.imshow(fieldmap[:, :, 0, 0])
-    fig.colorbar(im)
-    ax.set_title("Fieldmap (Hz)")
-
-    fname_figure = os.path.join(__dir_shimmingtoolbox__, 'mask.png')
-    fig.savefig(fname_figure)
+    # # Plot results
+    # fig = Figure(figsize=(10, 10))
+    # ax = fig.add_subplot(211)
+    # ax.plot(fieldmap_timestamps / 1000, acquisition_pressures, label='Interpolated pressures')
+    # # ax.plot(pmu_times, pmu.data, label='Raw pressures')
+    # ax.plot(pmu_times_within_range / 1000, pmu_data_within_range, label='Pmu pressures')
+    # ax.legend()
+    # ax.set_title("Pressure [-2048, 2047] vs time (s) ")
+    # ax = fig.add_subplot(212)
+    # ax.plot(fieldmap_timestamps / 1000, fieldmap_mean, label='Mean B0')
+    # ax.legend()
+    # ax.set_title("Fieldmap average over unmasked region (Hz) vs time (s)")
+    #
+    # fname_figure = os.path.join(__dir_shimmingtoolbox__, 'pmu_plot.png')
+    # fig.savefig(fname_figure)
+    #
+    # # Plot mask
+    # fig = Figure(figsize=(10, 10))
+    # ax = fig.add_subplot(211)
+    # im = ax.imshow(fieldmap_masked[:, :, 0, 0])
+    # fig.colorbar(im)
+    # ax.set_title("Mask (Hz)")
+    #
+    # ax = fig.add_subplot(212)
+    # im = ax.imshow(fieldmap[:, :, 0, 0])
+    # fig.colorbar(im)
+    # ax.set_title("Fieldmap (Hz)")
+    #
+    # fname_figure = os.path.join(__dir_shimmingtoolbox__, 'mask.png')
+    # fig.savefig(fname_figure)


### PR DESCRIPTION
## Description
Realtime processing requires the extraction of the time from the scans. The PMU for example requires the time in milliseconds past midnight to interpolate the pressure data to those points. The times can easily be fetched using the dicom files but it becomes more tricky with the niftis.

## Changes
- Adds a function `get_acquisition_times(nii_data, json_data)` to easily get the timepoints of a time series using the json sidecar and nibabel object
- Adds a function `iso_times_to_ms(iso_times)` to convert dicom iso format time to milliseconds past midnight
- Adds a test `test_timing_images()` to look at the correlation between the PMU pressure and the fieldmap. See this https://github.com/shimming-toolbox/shimming-toolbox/pull/149#issuecomment-712450819

## Linked issues
Fixes #148 
