### PR TITLE
Invert JSON echo numbers for test_load_nifti test

### DIFF
--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -263,10 +263,10 @@ class TestCore(object):
         niftis, info, json_info = load_nifti(self.tmp_path)
         assert (len(info) == 2), "Wrong number od info data 1"
         assert (len(json_info) == 2), "Wrong number of JSON data 1"
-        self._json_phase['EchoNumber'] = 2
+        self._json_phase['EchoNumber'] = 1
         assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded for first JSON1"
-        self._json_phase['EchoNumber'] = 1
+        self._json_phase['EchoNumber'] = 2
         assert (json.dumps(json_info[1], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded for second JSON 1"
         assert (niftis.shape == (3, 3, 3, 2, 1)), "Wrong shape for the Nifti output data 1"
@@ -275,10 +275,10 @@ class TestCore(object):
         niftis, info, json_info = load_nifti(self.tmp_path)
         assert (len(info) == 2), "Wrong number of info data 2"
         assert (len(json_info) == 2), "Wrong number of JSON data 2"
-        self._json_phase['EchoNumber'] = 2
+        self._json_phase['EchoNumber'] = 1
         assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded for first JSON 2"
-        self._json_phase['EchoNumber'] = 1
+        self._json_phase['EchoNumber'] = 2
         assert (json.dumps(json_info[1], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded for second JSON 2"
         assert (niftis.shape == (3, 3, 3, 2, 1)), "Wrong shape for the Nifti output data 2"


### PR DESCRIPTION

## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
**Why this change was necessary**
Running pytest led to a local failure while Travis was able to run the
tests correctly.

**What this change does**
Inverts JSON echo numbers: if previously set to 2, it's not set to 1
and if previously set to 1 it's now set to 2.

**Any side-effects?**
Tests pass locally.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

**Additional context/notes/links**

Resolves #130
