### PR TITLE
Fix singleton on last dimension error in prelude

### DIFF
--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -10,6 +10,7 @@ import nibabel as nib
 import pathlib
 import tempfile
 import logging
+import numpy as np
 
 from shimmingtoolbox.utils import run_subprocess
 
@@ -80,4 +81,9 @@ def prelude(wrapped_phase, mag, affine, mask=None, threshold=None, is_unwrapping
 
     fname_phase_unwrapped = glob.glob(os.path.join(path_tmp, 'rawPhase_unwrapped*'))[0]
 
-    return nib.load(fname_phase_unwrapped).get_fdata()
+    phase_unwrapped = nib.load(fname_phase_unwrapped).get_fdata()
+
+    for _ in range(wrapped_phase.ndim - phase_unwrapped.ndim):
+        phase_unwrapped = np.expand_dims(phase_unwrapped, -1)
+
+    return phase_unwrapped

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -81,8 +81,9 @@ def prelude(wrapped_phase, mag, affine, mask=None, threshold=None, is_unwrapping
 
     fname_phase_unwrapped = glob.glob(os.path.join(path_tmp, 'rawPhase_unwrapped*'))[0]
 
+    # When loading fname_phase_unwrapped, if a singleton is on the last dimension, it will not appear in the last
+    # dimension in phase_unwrapped. To be consistent with the size of the input, the singleton are added back.
     phase_unwrapped = nib.load(fname_phase_unwrapped).get_fdata()
-
     for _ in range(wrapped_phase.ndim - phase_unwrapped.ndim):
         phase_unwrapped = np.expand_dims(phase_unwrapped, -1)
 

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -81,8 +81,9 @@ def prelude(wrapped_phase, mag, affine, mask=None, threshold=None, is_unwrapping
 
     fname_phase_unwrapped = glob.glob(os.path.join(path_tmp, 'rawPhase_unwrapped*'))[0]
 
-    # When loading fname_phase_unwrapped, if a singleton is on the last dimension, it will not appear in the last
-    # dimension in phase_unwrapped. To be consistent with the size of the input, the singleton are added back.
+    # When loading fname_phase_unwrapped, if a singleton is on the last dimension in wrapped_phase, it will not appear
+    # in the last dimension in phase_unwrapped. To be consistent with the size of the input, the singletons are added
+    # back.
     phase_unwrapped = nib.load(fname_phase_unwrapped).get_fdata()
     for _ in range(wrapped_phase.ndim - phase_unwrapped.ndim):
         phase_unwrapped = np.expand_dims(phase_unwrapped, -1)

--- a/test/test_prelude.py
+++ b/test/test_prelude.py
@@ -168,3 +168,42 @@ class TestCore(object):
         """
         unwrapped_phase_e1 = prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1, threshold=200)
         assert(unwrapped_phase_e1.shape == self.phase_e1.shape)
+
+    def test_3rd_dim_singleton(self):
+        """
+        Call prelude on data with a singleton on the z dimension
+        """
+
+        # Prepare singleton
+        phase_singleton = np.expand_dims(self.phase_e1[..., 0], -1)
+        mag_singleton = np.expand_dims(self.mag_e1[..., 0], -1)
+
+        unwrapped_phase_singleton = prelude(phase_singleton, mag_singleton, self.affine_phase_e1)
+
+        assert unwrapped_phase_singleton.ndim == 3
+
+    def test_2nd_dim_singleton(self):
+        """
+        Call prelude on data with a singleton on the 2nd dimension
+        """
+
+        # Prepare singleton
+        phase_singleton = np.expand_dims(self.phase_e1[:, 0, 0], -1)
+        mag_singleton = np.expand_dims(self.mag_e1[:, 0, 0], -1)
+
+        unwrapped_phase_singleton = prelude(phase_singleton, mag_singleton, self.affine_phase_e1)
+
+        assert unwrapped_phase_singleton.ndim == 2
+
+    def test_2nd_and_3rd_dim_singleton(self):
+        """
+        Call prelude on data with a singleton on the 2nd and 3rd dimension
+        """
+
+        # Prepare singleton
+        phase_singleton = np.expand_dims(np.expand_dims(self.phase_e1[:, 0, 0], -1), -1)
+        mag_singleton = np.expand_dims(np.expand_dims(self.mag_e1[:, 0, 0], -1), -1)
+
+        unwrapped_phase_singleton = prelude(phase_singleton, mag_singleton, self.affine_phase_e1)
+
+        assert unwrapped_phase_singleton.ndim == 3


### PR DESCRIPTION
## Description
This PR addresses an issue in the prelude wrapper that returned the wrong number of dimensions if the input had a singleton in the last dimension. The fix looks at the input and compares it to the output to return the appropriate number of dimensions. This allows to also fix a case where both last dimensions would be 1. I've added tests for all cases (X,Y,1), (X,1) and (X,1,1)

## Linked issues
Fixes #174 
