### PR TITLE
Check installation and versions of 3rd party binaries

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ from hashlib import md5
 
 from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox.cli.download_data import download_data
+from shimmingtoolbox.cli.check_env import check_dcm2niix_installation, check_prelude_installation
 
 logger = logging.getLogger(__name__)
 
@@ -35,17 +36,17 @@ def test_data_path_fixture():
 
 @pytest.fixture(params=[pytest.param(0, marks=pytest.mark.prelude)])
 def test_prelude_installation():
-    # note that subprocess.check_call() returns 0 on success, so it must be
-    # negated for the assertion.
-    assert not subprocess.check_call(['which', 'prelude'])
+    # note that check_prelude_installation() returns 0 on success, so it must
+    # be negated for the assertion.
+    assert not check_prelude_installation()
     return
 
 
 @pytest.fixture(params=[pytest.param(0, marks=pytest.mark.dcm2niix)])
 def test_dcm2niix_installation():
-    # note that subprocess.check_call() returns 0 on success, so it must be
-    # negated for the assertion.
-    assert not subprocess.check_call(['which', 'dcm2niix'])
+    # note that check_dcm2niix_installation() returns 0 on success, so it must
+    # be negated for the assertion.
+    assert not check_dcm2niix_installation()
     return
 
 

--- a/docs/source/6_cli_reference/cli.rst
+++ b/docs/source/6_cli_reference/cli.rst
@@ -9,3 +9,6 @@ The following section outlines the CLI of shimming-toolbox.
 
 .. automodule:: shimmingtoolbox.cli.dicom_to_nifti
    :members:
+
+.. automodule:: shimmingtoolbox.cli.check_env
+   :members:

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "scipy~=1.5.0",
         "tqdm",
         "matplotlib~=3.1.2",
+        "psutil~=5.7.3",
         "pytest~=4.6.3",
         "pytest-cov~=2.5.1",
     ],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(
         'console_scripts': [
             "st_download_data=shimmingtoolbox.cli.download_data:download_data",
             "st_dicom_to_nifti=shimmingtoolbox.cli.dicom_to_nifti:dicom_to_nifti_cli",
-            "st_prepare_fieldmap= shimmingtoolbox.cli.prepare_fieldmap:prepare_fieldmap_cli"
+            "st_prepare_fieldmap=shimmingtoolbox.cli.prepare_fieldmap:prepare_fieldmap_cli",
+            "st_check_dependencies=shimmingtoolbox.cli.check_env:check_dependencies",
+            "st_dump_env_info=shimmingtoolbox.cli.check_env:dump_env_info"
         ]
     },
     packages=find_packages(exclude=["docs"]),

--- a/shimmingtoolbox/cli/check_env.py
+++ b/shimmingtoolbox/cli/check_env.py
@@ -11,10 +11,37 @@ import subprocess
 import os
 import platform
 import psutil
+import sys
 
 from typing import Dict, Tuple, List
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+
+
+def print_ok(more=None):
+    print("[{}OK{}]{}".format(bcolors.OKGREEN, bcolors.ENDC, more if more is not None else ""))
+
+
+def print_warning(more=None):
+    print("[{}WARNING{}]{}".format(bcolors.WARNING, bcolors.ENDC, more if more is not None else ""))
+
+
+def print_fail(more=None):
+    print("[{}FAIL{}]{}".format(bcolors.FAIL, bcolors.ENDC, more if more is not None else ""))
+
+
+def print_line(string):
+    """print without carriage return"""
+    sys.stdout.write(string.ljust(52, '.'))
+    sys.stdout.flush()
 
 
 @click.command(
@@ -25,20 +52,32 @@ def check_dependencies():
     """Verifies dependencies are installed by calling helper functions and
     formatting output accordingly.
     """
+    check_name = "Check if {} is installed"
+
+    # Prelude
+    prelude_check_msg = check_name.format("prelude")
+    print_line(prelude_check_msg)
     # 0 indicates prelude is installed.
     prelude_exit_code: int = check_prelude_installation()
     # negating condition because 0 indicates prelude is installed.
     if not prelude_exit_code:
-        print(get_prelude_version())
+        print_ok()
+        print("    " + get_prelude_version().replace("\n", "\n    "))
     else:
+        print_fail()
         print(f"Error {prelude_exit_code}: prelude is not installed or not in your PATH.")
 
+    # dcm2niix
+    dcm2niix_check_msg = check_name.format("dcm2niix")
+    print_line(dcm2niix_check_msg)
     # 0 indicates dcm2niix is installed.
     dcm2niix_exit_code: int = check_dcm2niix_installation()
     # negating condition because 0 indicates dcm2niix is installed.
     if not dcm2niix_exit_code:
-        print(get_dcm2niix_version())
+        print_ok()
+        print("    " + get_dcm2niix_version().replace("\n", "\n    "))
     else:
+        print_fail()
         print(f"Error {dcm2niix_exit_code}: dcm2niix is not installed or not in your PATH.")
 
     return
@@ -54,7 +93,7 @@ def check_prelude_installation() -> int:
         int: Exit code. 0 on success, nonzero on failure.
     """
 
-    return subprocess.check_call(['which', 'prelude'])
+    return subprocess.check_call(['which', 'prelude'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
 def check_dcm2niix_installation() -> int:
@@ -66,7 +105,7 @@ def check_dcm2niix_installation() -> int:
     Returns:
         int: Exit code. 0 on success, nonzero on failure.
     """
-    return subprocess.check_call(['which', 'dcm2niix'])
+    return subprocess.check_call(['which', 'dcm2niix'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
 def get_prelude_version() -> str:

--- a/shimmingtoolbox/cli/check_env.py
+++ b/shimmingtoolbox/cli/check_env.py
@@ -30,7 +30,7 @@ def check_dependencies():
     dcm2niix_exit_code: int = check_dcm2niix_installation()
     # negating condition because 0 indicates dcm2niix is installed.
     if not dcm2niix_exit_code:
-        print("dcm2niix is installed.")
+        print(get_dcm2niix_version())
     else:
         print(f"Error {dcm2niix_exit_code}: dcm2niix is not installed or not in your PATH.")
 
@@ -60,3 +60,22 @@ def check_dcm2niix_installation() -> int:
         int: Exit code. 0 on success, nonzero on failure.
     """
     return subprocess.check_call(['which', 'dcm2niix'])
+
+def get_dcm2niix_version() -> str:
+    """Gets the ``dcm2niix`` installation version.
+
+    This function calls ``dcm2niix --version`` and captures the output to
+    obtain the installation version.
+
+    Returns:
+        str: Version of the ``dcm2niix`` installation.
+    """
+    # `dcm2niix --version` returns an error code and output is in stderr
+    dcm2niix_version: str = subprocess.run(["dcm2niix", "--version"], capture_output=True, encoding="utf-8")
+    # If the behaviour of dcm2niix changes to output help with a 0 exit code,
+    # this function must fail loudly so we can update its behaviour
+    # accordingly:
+    assert dcm2niix_version.returncode != 0
+    version_output: str = dcm2niix_version.stdout.rstrip()
+    return version_output
+

--- a/shimmingtoolbox/cli/check_env.py
+++ b/shimmingtoolbox/cli/check_env.py
@@ -22,7 +22,7 @@ def check_dependencies():
     prelude_exit_code: int = check_prelude_installation()
     # negating condition because 0 indicates prelude is installed.
     if not prelude_exit_code:
-        print("prelude is installed.")
+        print(get_prelude_version())
     else:
         print(f"Error {prelude_exit_code}: prelude is not installed or not in your PATH.")
 
@@ -60,6 +60,29 @@ def check_dcm2niix_installation() -> int:
         int: Exit code. 0 on success, nonzero on failure.
     """
     return subprocess.check_call(['which', 'dcm2niix'])
+
+
+def get_prelude_version() -> str:
+    """Gets the ``prelude`` installation version.
+
+    This function calls ``prelude --help`` and parses the output to obtain the
+    installation version.
+
+    Returns:
+        str: Version of the ``prelude`` installation.
+    """
+    # `prelude --help` returns an error code and output is in stderr
+    prelude_help = subprocess.run(["prelude", "--help"], capture_output=True, encoding="utf-8")
+    # If the behaviour of FSL prelude changes to output help in stdout with a
+    # 0 exit code, this function must fail loudly so we can update its
+    # behaviour accordingly:
+    assert prelude_help.returncode != 0
+    # we're capturing stderr instead of stdout
+    help_output: str = prelude_help.stderr.rstrip()
+    # remove beginning newline and drop help info to keep version info
+    version: str = help_output.split("\n\n")[0].replace("\n","", 1)
+    return version
+
 
 def get_dcm2niix_version() -> str:
     """Gets the ``dcm2niix`` installation version.

--- a/shimmingtoolbox/cli/check_env.py
+++ b/shimmingtoolbox/cli/check_env.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Check the installation of the dependencies
+
+import click
+import subprocess
+from typing import Dict, Tuple, List
+
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    help="Verify that the dependencies are installed and available to the toolbox."
+)
+def check_dependencies():
+    """Verifies dependencies are installed by calling helper functions and
+    formatting output accordingly.
+    """
+    # 0 indicates prelude is installed.
+    prelude_exit_code: int = check_prelude_installation()
+    # negating condition because 0 indicates prelude is installed.
+    if not prelude_exit_code:
+        print("prelude is installed.")
+    else:
+        print(f"Error {prelude_exit_code}: prelude is not installed or not in your PATH.")
+
+    # 0 indicates dcm2niix is installed.
+    dcm2niix_exit_code: int = check_dcm2niix_installation()
+    # negating condition because 0 indicates dcm2niix is installed.
+    if not dcm2niix_exit_code:
+        print("dcm2niix is installed.")
+    else:
+        print(f"Error {dcm2niix_exit_code}: dcm2niix is not installed or not in your PATH.")
+
+    return
+
+
+def check_prelude_installation() -> int:
+    """Checks that ``prelude`` is installed.
+
+    This function calls ``which prelude`` and checks the exit code to verify
+    that ``prelude`` is installed.
+
+    Returns:
+        int: Exit code. 0 on success, nonzero on failure.
+    """
+
+    return subprocess.check_call(['which', 'prelude'])
+
+
+def check_dcm2niix_installation() -> int:
+    """Checks that ``dcm2niix`` is installed.
+
+    This function calls ``which dcm2niix`` and checks the exit code to verify
+    that ``dcm2niix`` is installed.
+
+    Returns:
+        int: Exit code. 0 on success, nonzero on failure.
+    """
+    return subprocess.check_call(['which', 'dcm2niix'])

--- a/test/cli/test_check_env.py
+++ b/test/cli/test_check_env.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+
+import re
+from click.testing import CliRunner
+import shimmingtoolbox.cli.check_env as st_ce
+
+@pytest.mark.dcm2niix
+@pytest.mark.prelude
+def test_check_dependencies(test_dcm2niix_installation, test_prelude_installation):
+    runner = CliRunner()
+
+    result = runner.invoke(st_ce.check_dependencies)
+    assert result.exit_code == 0
+
+
+def test_dump_env_info():
+    runner = CliRunner()
+
+    result = runner.invoke(st_ce.dump_env_info)
+    assert result.exit_code == 0
+
+
+def test_check_prelude_installation():
+    """Tests that the function returns an exit code as expected, does not test
+    the exit code value itself, so it does not depend on prelude being
+    installed.
+    """
+    check_prelude_installation_exit = st_ce.check_prelude_installation()
+    assert isinstance(check_prelude_installation_exit, int)
+
+
+def test_check_dcm2niix_installation():
+    """Tests that the function returns an exit code as expected, does not test
+    the exit code value itself, so it does not depend on dcm2niix being
+    installed.
+    """
+    check_dcm2niix_installation_exit = st_ce.check_dcm2niix_installation()
+    assert isinstance(check_dcm2niix_installation_exit, int)
+
+
+@pytest.mark.prelude
+def test_get_prelude_version(test_prelude_installation):
+    """Checks prelude version output for expected structure.
+    """
+    prelude_version_info = st_ce.get_prelude_version()
+    version_regex = r"Part of FSL.*\nprelude.*\nPhase.*\nCopyright.*"
+    assert re.search(version_regex, prelude_version_info)
+
+
+@pytest.mark.dcm2niix
+def test_get_dcm2niix_version(test_dcm2niix_installation):
+    """Checks dcm2niix version output for expected structure.
+    """
+    dcm2niix_version_info = st_ce.get_dcm2niix_version()
+    version_regex = r"Chris.*\nv\d\.\d.\d{8}"
+    assert re.search(version_regex, dcm2niix_version_info)
+
+
+def test_get_env_info():
+    env_info = st_ce.get_env_info()
+    assert isinstance(env_info, str)
+
+
+def test_get_pkg_info():
+    pkg_info = st_ce.get_pkg_info()
+    version_regex = r"\d*\.\d*\.\d*"
+    assert re.search(version_regex, pkg_info)


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
ST relies on `prelude` and `dcm2niix` for a lot of its functionality. Therefore, it's necessary to have a simpler tool to check that these dependencies are installed, as well as provide some output about their versions. Additionally, this basic check should also output information about the environment, for debugging purposes.

Some additional refactoring is included in this PR to reduce duplication of functionality in `conftest.py` as a result of #136.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #161 