### PR TITLE
Change prelude mag parameter to be an optional argument

### DIFF
--- a/examples/general_demo.py
+++ b/examples/general_demo.py
@@ -69,8 +69,8 @@ def general_demo(path_output=os.path.join(os.path.curdir, 'output_dir')):
     nii_mag_e2 = nib.load(fname_mags[1])
 
     # Call prelude to unwrap the phase
-    unwrapped_phase_e1 = prelude(phase_e1, nii_mag_e1.get_fdata(), nii_phase_e1.affine)
-    unwrapped_phase_e2 = prelude(phase_e2, nii_mag_e2.get_fdata(), nii_phase_e2.affine, threshold=200)
+    unwrapped_phase_e1 = prelude(phase_e1, nii_phase_e1.affine, mag=nii_mag_e1.get_fdata())
+    unwrapped_phase_e2 = prelude(phase_e2, nii_phase_e2.affine, mag=nii_mag_e2.get_fdata(), threshold=200)
 
     # Plot results
     fig = Figure(figsize=(10, 10))

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -15,7 +15,7 @@ import numpy as np
 from shimmingtoolbox.utils import run_subprocess
 
 
-def prelude(wrapped_phase, mag, affine, mask=None, threshold=None, is_unwrapping_in_2d=False):
+def prelude(wrapped_phase, affine, mag=None, mask=None, threshold=None, is_unwrapping_in_2d=False):
     """wrapper to FSL prelude
 
     This function enables phase unwrapping by calling FSL prelude on the command line. A mask can be provided to mask
@@ -39,8 +39,11 @@ def prelude(wrapped_phase, mag, affine, mask=None, threshold=None, is_unwrapping
     # Make sure phase and mag are the right shape
     if wrapped_phase.ndim not in [2, 3]:
         raise RuntimeError("Wrapped_phase must be 2d or 3d")
-    if wrapped_phase.shape != mag.shape:
-        raise RuntimeError("The magnitude image (mag) must be the same shape as wrapped_phase")
+    if mag is not None:
+        if wrapped_phase.shape != mag.shape:
+            raise RuntimeError("The magnitude image (mag) must be the same shape as wrapped_phase")
+    else:
+        mag = np.zeros_like(wrapped_phase)
 
     tmp = tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem)
     path_tmp = tmp.name

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -24,10 +24,10 @@ def prelude(wrapped_phase, affine, mag=None, mask=None, threshold=None, is_unwra
 
     Args:
         wrapped_phase (numpy.ndarray): 2D or 3D radian numpy array to perform phase unwrapping. (2 pi interval)
-        mag (numpy.ndarray): 2D or 3D magnitude numpy array corresponding to the phase array
         affine (numpy.ndarray): 2D array containing the transformation coefficients. Can be calculated by using:
             nii = nib.load("nii_path")
             affine = nii.affine
+        mag (numpy.ndarray): 2D or 3D magnitude numpy array corresponding to the phase array
         mask (numpy.ndarray, optional): numpy array of booleans with shape of `complex_array` to mask during phase
                                         unwrapping
         threshold: Threshold value for automatic mask generation (Use either mask or threshold, not both)

--- a/test/test_prelude.py
+++ b/test/test_prelude.py
@@ -64,10 +64,11 @@ class TestCore(object):
         nii_mag_e1 = nib.load(fname_mags[0])
         nii_mag_e2 = nib.load(fname_mags[1])
 
-        self.phase_e1 = phase_e1
-        self.phase_e2 = phase_e2
-        self.mag_e1 = nii_mag_e1.get_fdata()
-        self.mag_e2 = nii_mag_e2.get_fdata()
+        # Make tests fater by having the last dim only be 1
+        self.phase_e1 = np.expand_dims(phase_e1[..., 0], -1)
+        self.phase_e2 = np.expand_dims(phase_e2[..., 0], -1)
+        self.mag_e1 = np.expand_dims(nii_mag_e1.get_fdata()[..., 0], -1)
+        self.mag_e2 = np.expand_dims(nii_mag_e2.get_fdata()[..., 0], -1)
         self.affine_phase_e1 = nii_phase_e1.affine
         self.affine_phase_e2 = nii_phase_e2.affine
 
@@ -76,7 +77,7 @@ class TestCore(object):
         Runs prelude and check output integrity.
         """
         # default prelude call
-        unwrapped_phase_e1 = prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1)
+        unwrapped_phase_e1 = prelude(self.phase_e1, self.affine_phase_e1)
 
         assert (unwrapped_phase_e1.shape == self.phase_e1.shape)
 
@@ -88,10 +89,11 @@ class TestCore(object):
         mask = np.ones(self.phase_e1.shape)
 
         # Call prelude with mask (is_unwrapping_in_2d is also used because it is significantly faster)
-        unwrapped_phase_e1 = prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1, mask, is_unwrapping_in_2d=True)
+        unwrapped_phase_e1 = prelude(self.phase_e1, self.affine_phase_e1, mag=self.mag_e1, mask=mask,
+                                     is_unwrapping_in_2d=True)
 
         # Make sure the phase is not 0. When there isn't a mask, the phase is 0
-        assert(unwrapped_phase_e1[5, 5, 5] != 0)
+        assert(unwrapped_phase_e1[5, 5, 0] != 0)
 
     def test_wrong_size_mask(self):
         # Create mask with wrong dimensions
@@ -99,7 +101,7 @@ class TestCore(object):
 
         # Call prelude with mask
         try:
-            prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1, mask)
+            prelude(self.phase_e1, self.affine_phase_e1, mag=self.mag_e1, mask=mask)
         except RuntimeError:
             # If an exception occurs, this is the desired behaviour since the mask is the wrong dimensions
             return 0
@@ -113,7 +115,7 @@ class TestCore(object):
         phase_e1 = np.ones([4, 4])
 
         try:
-            prelude(phase_e1, self.mag_e1, self.affine_phase_e1)
+            prelude(phase_e1, self.affine_phase_e1, mag=self.mag_e1)
         except RuntimeError:
             # If an exception occurs, this is the desired behaviour
             return 0
@@ -127,7 +129,7 @@ class TestCore(object):
         mag_e1 = np.ones([4, 4, 4])
 
         try:
-            prelude(self.phase_e1, mag_e1, self.affine_phase_e1)
+            prelude(self.phase_e1, self.affine_phase_e1, mag=mag_e1)
         except RuntimeError:
             # If an exception occurs, this is the desired behaviour
             return 0
@@ -142,7 +144,7 @@ class TestCore(object):
         phase_e1 = np.ones([4])
 
         try:
-            prelude(phase_e1, mag_e1, self.affine_phase_e1)
+            prelude(phase_e1, self.affine_phase_e1, mag=mag_e1)
         except RuntimeError:
             # If an exception occurs, this is the desired behaviour
             return 0
@@ -158,7 +160,7 @@ class TestCore(object):
         # Get first slice
         phase_e1_2d = self.phase_e1[:, :, 0]
         mag_e1_2d = self.mag_e1[:, :, 0]
-        unwrapped_phase_e1 = prelude(phase_e1_2d, mag_e1_2d, self.affine_phase_e1)
+        unwrapped_phase_e1 = prelude(phase_e1_2d, self.affine_phase_e1, mag=mag_e1_2d)
 
         assert(unwrapped_phase_e1.shape == phase_e1_2d.shape)
 
@@ -166,7 +168,7 @@ class TestCore(object):
         """
         Call prelude with a threshold for masking
         """
-        unwrapped_phase_e1 = prelude(self.phase_e1, self.mag_e1, self.affine_phase_e1, threshold=200)
+        unwrapped_phase_e1 = prelude(self.phase_e1, self.affine_phase_e1, mag=self.mag_e1, threshold=200)
         assert(unwrapped_phase_e1.shape == self.phase_e1.shape)
 
     def test_3rd_dim_singleton(self):
@@ -178,7 +180,7 @@ class TestCore(object):
         phase_singleton = np.expand_dims(self.phase_e1[..., 0], -1)
         mag_singleton = np.expand_dims(self.mag_e1[..., 0], -1)
 
-        unwrapped_phase_singleton = prelude(phase_singleton, mag_singleton, self.affine_phase_e1)
+        unwrapped_phase_singleton = prelude(phase_singleton, self.affine_phase_e1, mag=mag_singleton)
 
         assert unwrapped_phase_singleton.ndim == 3
 
@@ -191,7 +193,7 @@ class TestCore(object):
         phase_singleton = np.expand_dims(self.phase_e1[:, 0, 0], -1)
         mag_singleton = np.expand_dims(self.mag_e1[:, 0, 0], -1)
 
-        unwrapped_phase_singleton = prelude(phase_singleton, mag_singleton, self.affine_phase_e1)
+        unwrapped_phase_singleton = prelude(phase_singleton, self.affine_phase_e1, mag=mag_singleton)
 
         assert unwrapped_phase_singleton.ndim == 2
 
@@ -204,6 +206,6 @@ class TestCore(object):
         phase_singleton = np.expand_dims(np.expand_dims(self.phase_e1[:, 0, 0], -1), -1)
         mag_singleton = np.expand_dims(np.expand_dims(self.mag_e1[:, 0, 0], -1), -1)
 
-        unwrapped_phase_singleton = prelude(phase_singleton, mag_singleton, self.affine_phase_e1)
+        unwrapped_phase_singleton = prelude(phase_singleton, self.affine_phase_e1, mag=mag_singleton)
 
         assert unwrapped_phase_singleton.ndim == 3


### PR DESCRIPTION
## Description
Fsl_prelude called by our `prelude` wrapper requires a `mag` input argument. If `mag` is not available or we don't want to mask the fieldmap, `mag` can be a matrix full of ones. 

This PR changes the default behaviour of `prelude` to not require the `mag` argument and sets the default value of mag to be a matrix full of ones.

The tests and different calls to `prelude` were changed to call prelude appropriately.

