### PR TITLE
Fix local error with load_nifti

### DIFF
--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -58,6 +58,7 @@ def load_nifti(path_data, modality='phase'):
     # Generate file_list
     file_list = []
     [file_list.append(os.path.join(path_data, f)) for f in os.listdir(path_data) if f not in file_list]
+    file_list = sorted(file_list)
 
     nifti_path = ""
     # Check for incompatible acquisition source path

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -93,6 +93,7 @@ def load_nifti(path_data, modality='phase'):
 
     # Get a list of nii files
     nifti_list = [os.path.join(nifti_path, f) for f in os.listdir(nifti_path) if f.endswith((".nii", ".nii.gz"))]
+    nifti_list = sorted(nifti_list)
 
     # Read all images and headers available and store them
     nifti_init = [read_nii(nifti_list[i]) for i in range(len(nifti_list))]

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -266,10 +266,10 @@ class TestCore(object):
         niftis, info, json_info = load_nifti(self.tmp_path)
         assert (len(info) == 2), "Wrong number od info data 1"
         assert (len(json_info) == 2), "Wrong number of JSON data 1"
-        self._json_phase['EchoNumber'] = 2
+        self._json_phase['EchoNumber'] = 1
         assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded for first JSON1"
-        self._json_phase['EchoNumber'] = 1
+        self._json_phase['EchoNumber'] = 2
         assert (json.dumps(json_info[1], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded for second JSON 1"
         assert (niftis.shape == (3, 3, 3, 2, 1)), "Wrong shape for the Nifti output data 1"
@@ -278,10 +278,10 @@ class TestCore(object):
         niftis, info, json_info = load_nifti(self.tmp_path)
         assert (len(info) == 2), "Wrong number of info data 2"
         assert (len(json_info) == 2), "Wrong number of JSON data 2"
-        self._json_phase['EchoNumber'] = 2
+        self._json_phase['EchoNumber'] = 1
         assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded for first JSON 2"
-        self._json_phase['EchoNumber'] = 1
+        self._json_phase['EchoNumber'] = 2
         assert (json.dumps(json_info[1], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded for second JSON 2"
         assert (niftis.shape == (3, 3, 3, 2, 1)), "Wrong shape for the Nifti output data 2"


### PR DESCRIPTION
## Description
Load_nifti does not pass locally on mac but passes on travis. This PR attempts to sort the list in load_nifti to get a consistent output across platforms.

The tests for multiple echoes had to be changed to reflect the sorted list.

## Linked issues
Fixes #130 
