### PR TITLE
Create new CLI documentation section

### DIFF
--- a/docs/source/6_cli_reference/cli.rst
+++ b/docs/source/6_cli_reference/cli.rst
@@ -1,0 +1,11 @@
+
+CLI Reference
+=============
+
+The following section outlines the CLI of shimming-toolbox.
+
+.. automodule:: shimmingtoolbox.cli.download_data
+   :members:
+
+.. automodule:: shimmingtoolbox.cli.dicom_to_nifti
+   :members:

--- a/docs/source/7_api_reference/api.rst
+++ b/docs/source/7_api_reference/api.rst
@@ -47,9 +47,3 @@ misc
 
 .. automodule:: shimmingtoolbox.utils
    :members:
-
-.. automodule:: shimmingtoolbox.cli.download_data
-   :members:
-
-.. automodule:: shimmingtoolbox.cli.dicom_to_nifti
-   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,4 +25,5 @@ with standard manufacturer-supplied gradient/shim coils or with custom
    3_contributing/*
    4_about/*
    5_other-resources/hardware/*
-   6_api_reference/api.rst
+   6_cli_reference/cli.rst
+   7_api_reference/api.rst


### PR DESCRIPTION

## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

**Why this change was necessary**
Our current way of implementing CLIs consists of wrapping an API,
meaning there is documentation for the API and documentation for
CLIs. Both were implemented in the API section of our doc, which
wasn't accurately reflecting their scope.

**What this change does**
Creates a CLI documentation section just for CLI modules.

**Any side-effects?**
In `docs/`, run `make clean` before rebuilding docs locally.
## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #177
