### PR TITLE
Fix GH Actions badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # shimming-toolbox
 
- [![Build Status](https://github.com/shimming-toolbox/shimming-toolbox/actions?query=workflow%3A%22CI-Tests/badge.svg)](https://github.com/shimming-toolbox/shimming-toolbox/actions?query=workflow%3A%22CI-Tests) [![Documentation Status](https://readthedocs.org/projects/shimming-toolbox/badge/?version=latest)](https://www.shimming-toolbox.org/en/latest/?badge=latest) [![Coverage Status](https://coveralls.io/repos/github/shimming-toolbox/shimming-toolbox/badge.svg?branch=master)](https://coveralls.io/github/shimming-toolbox/shimming-toolbox?branch=master)
+ [![Build Status](https://github.com/shimming-toolbox/shimming-toolbox/workflows/CI-Tests/badge.svg)](https://github.com/shimming-toolbox/shimming-toolbox/actions?query=workflow%3ACI-Tests) [![Documentation Status](https://readthedocs.org/projects/shimming-toolbox/badge/?version=latest)](https://www.shimming-toolbox.org/en/latest/?badge=latest) [![Coverage Status](https://coveralls.io/repos/github/shimming-toolbox/shimming-toolbox/badge.svg?branch=master)](https://coveralls.io/github/shimming-toolbox/shimming-toolbox?branch=master)
 
 
 Code for performing real-time shimming using external MRI shim coils


### PR DESCRIPTION
**Why this change was necessary**
Old badge had some typos in it.

**What this change does**
Uses correct badge URL syntax.