### PR TITLE
Rename phasediff image in dicom_to_nifti

### DIFF
--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -13,6 +13,7 @@ import shutil
 
 from shimmingtoolbox import __dir_config_dcm2bids__
 
+
 def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__, remove_tmp=False):
     """ Converts dicom files into nifti files by calling dcm2bids
 
@@ -54,6 +55,42 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     subprocess.run(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', path_config_dcm2bids],
                    check=True)
 
+    # In the special case where a phasediff should be created but the filename is phase instead. Find the file and
+    # rename it
+    # Go in the fieldmap folder
+    path_fmap = os.path.join(path_nifti, subject_id, 'fmap')
+    if os.path.exists(path_fmap):
+        # Make a list of the json files in fmap folder
+        file_list = []
+        [file_list.append(os.path.join(path_fmap, f)) for f in os.listdir(path_fmap)
+         if os.path.splitext(f)[1] == '.json']
+        file_list = sorted(file_list)
+
+        for fname_json in file_list:
+            is_renaming = False
+            # Open the json file
+            with open(fname_json) as json_file:
+                json_data = json.load(json_file)
+                # Make sure it is a phase data and that the keys EchoTime1 and EchoTime2 are defined
+                if ('ImageType' in json_data) and ('P' in json_data['ImageType']) and \
+                   ('EchoTime1' in json_data) and ('EchoTime2' in json_data):
+                    # Make sure it is not already named phasediff
+                    if len(os.path.basename(fname_json).rsplit('phasediff', 1)) == 1:
+                        # Split the filename in 2 and remove phase
+                        file_parts = fname_json.rsplit('phase', 1)
+                        if len(file_parts) == 2:
+                            # Stitch the filename back together making sure to remove any digits that could be after
+                            # 'phase'
+                            digits = '0123456789'
+                            fname_new_json = file_parts[0] + 'phasediff' + file_parts[1].lstrip(digits)
+                            is_renaming = True
+            # Rename the json file
+            if is_renaming:
+                os.rename(fname_json, fname_new_json)
+                fname_nifti_new = os.path.splitext(fname_new_json)[0] + '.nii.gz'
+                fname_nifti_old = os.path.splitext(fname_json)[0] + '.nii.gz'
+                os.rename(fname_nifti_old, fname_nifti_new)
+
     # if 'win' in sys.platform:
     #     # dcm2bids is broken for windows as a python package so using CLI
     #     # Create bids structure for data
@@ -76,7 +113,8 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     #     if not helper_file_list:
     #         raise ValueError('No data to process')
     #
-    #     subprocess.run(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', path_config_dcm2bids], check=True)
+    #     subprocess.run(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', path_config_dcm2bids],
+    #     check=True)
     # else:
     #     bids_info = dcm2bids.Dcm2bids([path_dicom], subject_id, path_config_dcm2bids, path_nifti)
     #     scaffold()

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -75,7 +75,7 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
                 if ('ImageType' in json_data) and ('P' in json_data['ImageType']) and \
                    ('EchoTime1' in json_data) and ('EchoTime2' in json_data):
                     # Make sure it is not already named phasediff
-                    if len(os.path.basename(fname_json).rsplit('phasediff', 1)) == 1:
+                    if len(os.path.basename(fname_json).split(subject_id, 1)[-1].rsplit('phasediff', 1)) == 1:
                         # Split the filename in 2 and remove phase
                         file_parts = fname_json.rsplit('phase', 1)
                         if len(file_parts) == 2:

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -88,12 +88,7 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
                             is_renaming = True
             # Rename the json file an nifti file
             if is_renaming:
-                if os.path.exists(os.path.splitext(fname_json)[0] + '.nii'):
-                    fname_nifti_new = os.path.splitext(fname_new_json)[0] + '.nii'
-                    fname_nifti_old = os.path.splitext(fname_json)[0] + '.nii'
-                    os.rename(fname_nifti_old, fname_nifti_new)
-                    os.rename(fname_json, fname_new_json)
-                elif os.path.exists(os.path.splitext(fname_json)[0] + '.nii.gz'):
+                if os.path.exists(os.path.splitext(fname_json)[0] + '.nii.gz'):
                     fname_nifti_new = os.path.splitext(fname_new_json)[0] + '.nii.gz'
                     fname_nifti_old = os.path.splitext(fname_json)[0] + '.nii.gz'
                     os.rename(fname_nifti_old, fname_nifti_new)

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -86,12 +86,18 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
                             digits = '0123456789'
                             fname_new_json = file_parts[0] + 'phasediff' + file_parts[1].lstrip(digits)
                             is_renaming = True
-            # Rename the json file
+            # Rename the json file an nifti file
             if is_renaming:
-                os.rename(fname_json, fname_new_json)
-                fname_nifti_new = os.path.splitext(fname_new_json)[0] + '.nii.gz'
-                fname_nifti_old = os.path.splitext(fname_json)[0] + '.nii.gz'
-                os.rename(fname_nifti_old, fname_nifti_new)
+                if os.path.exists(os.path.splitext(fname_json)[0] + '.nii'):
+                    fname_nifti_new = os.path.splitext(fname_new_json)[0] + '.nii'
+                    fname_nifti_old = os.path.splitext(fname_json)[0] + '.nii'
+                    os.rename(fname_nifti_old, fname_nifti_new)
+                    os.rename(fname_json, fname_new_json)
+                elif os.path.exists(os.path.splitext(fname_json)[0] + '.nii.gz'):
+                    fname_nifti_new = os.path.splitext(fname_new_json)[0] + '.nii.gz'
+                    fname_nifti_old = os.path.splitext(fname_json)[0] + '.nii.gz'
+                    os.rename(fname_nifti_old, fname_nifti_new)
+                    os.rename(fname_json, fname_new_json)
 
     # if 'win' in sys.platform:
     #     # dcm2bids is broken for windows as a python package so using CLI

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -71,9 +71,11 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
             # Open the json file
             with open(fname_json) as json_file:
                 json_data = json.load(json_file)
-                # Make sure it is a phase data and that the keys EchoTime1 and EchoTime2 are defined
+                # Make sure it is a phase data and that the keys EchoTime1 and EchoTime2 are defined and that
+                # sequenceName's last digit is 2 (refers to number of echoes when using dcm2bids)
                 if ('ImageType' in json_data) and ('P' in json_data['ImageType']) and \
-                   ('EchoTime1' in json_data) and ('EchoTime2' in json_data):
+                   ('EchoTime1' in json_data) and ('EchoTime2' in json_data) and \
+                   ('SequenceName' in json_data) and (int(json_data['SequenceName'][-1]) == 2):
                     # Make sure it is not already named phasediff
                     if len(os.path.basename(fname_json).split(subject_id, 1)[-1].rsplit('phasediff', 1)) == 1:
                         # Split the filename in 2 and remove phase

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -40,21 +40,22 @@ def test_dicom_to_nifti_realtime_zshim(test_dcm2niix_installation):
                 for ext in ['nii.gz', 'json']:
                     if modality == 'phase':
                         assert os.path.exists(os.path.join(path_nifti, subject_id, sequence_type,
-                                                           subject_id + f'_{modality}{2}.{ext}'))
+                                                           subject_id + f"_{'phasediff'}.{ext}"))
                     else:
                         assert os.path.exists(os.path.join(path_nifti, subject_id, sequence_type,
-                                                           subject_id + f'_{modality}{i+1}.{ext}'))
+                                                           subject_id + f"_{modality}{i+1}.{ext}"))
 
         sequence_type = 'anat'
         for i in range(3):
             for ext in ['nii.gz', 'json']:
                 assert os.path.exists(
-                    os.path.join(path_nifti, subject_id, sequence_type, subject_id + f'_unshimmed_e{i+1}.{ext}'))
+                    os.path.join(path_nifti, subject_id, sequence_type, subject_id + f"_unshimmed_e{i+1}.{ext}"))
 
         sequence_type = 'func'
         for ext in ['nii.gz', 'json']:
             assert os.path.exists(
-                os.path.join(path_nifti, subject_id, sequence_type, subject_id + f'_bold.{ext}'))
+                os.path.join(path_nifti, subject_id, sequence_type, subject_id + f"_bold.{ext}"))
+
 
 @pytest.mark.dcm2niix
 def test_dicom_to_nifti_remove_tmp(test_dcm2niix_installation):


### PR DESCRIPTION
## Description
This PR fixes an issue in dicom_to_nifti where phasediff images were wrongly indentified in their filenames as phase images instead of phasediff images.

The function looks at the output of dcm2bids and if
- It's in fmap directory
- The json file is a phase image, contains both fields EchoTime1 and EchoTime2
- It is not already named phasediff
- It contains phase in the file name
- SequenceName field's last digit is 2 (Refers to the number of echoes when using dcm2bids)

It will rename the json and the nifti to phasediff.

A test was changed to reflect the new names.

## Linked issues
Fixes #190 
