### PR TITLE
Fix coveralls 3.0.0 bug and github actions macos 11.0 bug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - 'macos-10.15'
-          - 'macos-11.0'
+          # - 'macos-11.0'
           - 'ubuntu-18.04'
           - 'ubuntu-20.04'
           - 'ubuntu-16.04'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,6 +108,6 @@ jobs:
     - name: Finished
       run: |
         pip3 install --upgrade coveralls
-        coveralls --service=github --finish
+        coveralls --finish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload Coverage
         run: |
           pip3 install coveralls
-          coveralls
+          coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: ${{ matrix.os }}-Python-${{ matrix.python-version }}
@@ -108,6 +108,6 @@ jobs:
     - name: Finished
       run: |
         pip3 install --upgrade coveralls
-        coveralls --finish
+        coveralls --service=github --finish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
As mentioned in [ivadomed](https://github.com/ivadomed/ivadomed/pull/628), coveralls introduced a bug with release 3.0.0. This fixes the error by:

```
run: |
  coveralls
to

run: |
  coveralls --service=github
```

While doing the checks, Github actions CI on MacOS 11.0 also fail. See this [issue](https://github.com/actions/virtual-environments/issues/2381). Since no timeframe is provided for the resolution. The build will be commented out until a fix is done.

## Linked issues
Fixes #206
https://github.com/actions/virtual-environments/issues/2381