### PR TITLE
ci: Add pre-commit configs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,42 @@
+name: Pre-commit check hooks
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+
+jobs:
+  pre-commit-checks:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Cache pip dependencies
+        id: cache-pip-dependencies
+        uses: actions/cache@v2
+        with:
+          # Ubuntu-specific, see
+          # https://github.com/actions/cache/blob/main/examples.md#python---pip
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install shimming-toolbox
+        if: steps.cache-pip-dependencies.cache-hit != 'true'
+        run: |
+          pip install ".[docs, dev]"
+      - name: Run pre-commit large file check
+        run: pre-commit run --all-files check-added-large-files
+      - name: Run pre-commit Python syntax check
+        run: pre-commit run --all-files check-ast
+      - name: Run pre-commit merge conflict string check
+        run: pre-commit run --all-files check-merge-conflict
+      - name: Run pre-commit YAML check # for GitHub Actions configs
+        run: pre-commit run --all-files check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: check-merge-conflict
+    -   id: check-ast
+    -   id: check-added-large-files

--- a/docs/source/contributing/CONTRIBUTING.rst
+++ b/docs/source/contributing/CONTRIBUTING.rst
@@ -69,7 +69,7 @@ Some good real-life examples:
 Opening a Branch
 ----------------
 
-If you are part of the core developer team, you can open a branchdirectly in this repository. Prefix the branch name with a personal
+If you are part of the core developer team, you can open a branch directly in this repository. Prefix the branch name with a personal
 identifier (e.g. your initials) and a forward slash; If the branch you are working on is in response to an issue, provide the issue number;
 Add some text that make the branch name meaningful.
 
@@ -81,6 +81,11 @@ Examples:
 
 Developing
 ----------
+
+Pre-commit checks
+~~~~~~~~~~~~~~~~~
+
+We use ``pre-commit`` to enforce conventions like file sizes, correct Python syntax, and no merge conflict strings in the changeset. After you've installed ``shimming-toolbox``, install the hooks by running ``pre-commit install`` at the root of the repo clone.
 
 Conflicts
 ~~~~~~~~~
@@ -110,7 +115,7 @@ Please use the `Google style docstrings <https://sphinxcontrib-napoleon.readthed
 Testing
 ~~~~~~~
 
-Please add tests, especially with new code. As of now, we have unit tests (in `/test`). They are straightforward to augment, but we understand
+Please add tests, especially with new code. As of now, we have unit tests (in ``/test``). They are straightforward to augment, but we understand
 it's the extra mile; it would still be appreciated if you provide something lighter (eg. in the commit messages or in the PR or issue text)
 that demonstrates that an issue was fixed, or a feature is functional.
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -165,7 +165,7 @@ that you followed the ``git clone`` instruction above:
 .. code:: bash
 
    cd shimming-toolbox
-   pip install -e ".[docs]"
+   pip install -e ".[docs,dev]"
 
 .. NOTE ::
    If you downloaded shimming-toolbox using the link above
@@ -184,7 +184,7 @@ version of the project from GitHub and reinstall the application:
 
    cd shimming-toolbox
    git pull
-   pip install -e ".[docs]"
+   pip install -e ".[docs,dev]"
 
 Testing the installation
 ------------------------

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(
     ],
     extras_require={
         'docs': ["sphinx>=1.6", "sphinx_rtd_theme>=0.2.4", "sphinx-click"],
+        'dev': ["pre-commit>=2.10.0"]
     },
 )


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [ ] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

**Why this change was necessary**
We want to enforce file size limits on commits to ensure contributors
don't accidentally commit massive files to the repo and pollute the
history. This should be checked both locally and on GitHub.

**What this change does**
 - Adds `pre-commit` as an optional `dev` dependency
 - Adds `pre-commit` hooks for YAML check, merge conflict string
 check, AST check, and large file (>500kb) check
 - Adds GitHub Action to run above pre-commit checks on each PR and
 push to master
 - Updates documentation to instruct contributors to install `dev` dependencies

**Additional context/notes/links**
 - https://github.com/pre-commit/pre-commit-hooks#check-added-large-files
 - https://pre-commit.com

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #199