### PR TITLE
Cache SCT in GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,11 +58,24 @@ jobs:
           unzip -o dcm2niix_lnx.zip
           sudo install dcm2nii* /usr/bin/
 
-      - name: SpinalCord Toolbox installation
+      - name: Spinal Cord Toolbox clone
         run: |
-          cd ../..
+          cd $HOME/work
           git clone --depth 1 https://github.com/neuropoly/spinalcordtoolbox
           cd spinalcordtoolbox
+          git rev-parse HEAD > $HOME/work/.sct_HEAD_hash
+
+      - name: Cache SCT
+        id: cache-sct
+        uses: actions/cache@v2
+        with:
+          path: ~/work/spinalcordtoolbox
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('~/work/.sct_HEAD_hash')}}
+
+      - name: Spinal Cord Toolbox installation
+        if: steps.cache-sct.outputs.cache-hit != 'true'
+        run: |
+          cd ../../spinalcordtoolbox
           ./install_sct -y
 
       - name: prelude macOS

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           path: ~/work/spinalcordtoolbox
           # Use commit hash file from previous step as key
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('~/work/.sct_HEAD_hash') }}
+          key: ${{ matrix.os }}-python-${{ matrix.python-version }}-${{ hashFiles('~/work/.sct_HEAD_hash') }}
 
       - name: Spinal Cord Toolbox installation
         if: steps.cache-sct.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           path: ~/work/spinalcordtoolbox
           # Use commit hash file from previous step as key
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('~/work/.sct_HEAD_hash')}}
+          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('~/work/.sct_HEAD_hash') }}
 
       - name: Spinal Cord Toolbox installation
         if: steps.cache-sct.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/work/spinalcordtoolbox
+          # Use commit hash file from previous step as key
           key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('~/work/.sct_HEAD_hash')}}
 
       - name: Spinal Cord Toolbox installation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,7 @@ jobs:
           cd ~/work
           git clone --depth 1 https://github.com/neuropoly/spinalcordtoolbox
           cd spinalcordtoolbox
+          # Use HEAD commit hash as key for cache
           git rev-parse HEAD > $GITHUB_WORKSPACE/.sct_HEAD_hash
           cat $GITHUB_WORKSPACE/.sct_HEAD_hash
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,8 @@ jobs:
           cd ~/work
           git clone --depth 1 https://github.com/neuropoly/spinalcordtoolbox
           cd spinalcordtoolbox
-          git rev-parse HEAD > .sct_HEAD_hash
-          cat .sct_HEAD_hash
+          git rev-parse HEAD > $GITHUB_WORKSPACE/.sct_HEAD_hash
+          cat $GITHUB_WORKSPACE/.sct_HEAD_hash
 
       - name: Cache SCT
         id: cache-sct
@@ -74,7 +74,7 @@ jobs:
         with:
           path: ~/work/spinalcordtoolbox
           # Use commit hash file from previous step as key
-          key: ${{ matrix.os }}_python-${{ matrix.python-version }}-${{ hashFiles('~/work/spinalcordtoolbox/.sct_HEAD_hash') }}
+          key: ${{ matrix.os }}_python-${{ matrix.python-version }}-${{ hashFiles('**/.sct_HEAD_hash') }}
 
       - name: Spinal Cord Toolbox installation
         if: steps.cache-sct.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
           - '3.8'
 
     steps:
+      - name: Get home directory
+        run: echo $HOME
       - uses: actions/checkout@v2
 
       - name: Set XCode version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,8 @@ jobs:
           cd ~/work
           git clone --depth 1 https://github.com/neuropoly/spinalcordtoolbox
           cd spinalcordtoolbox
-          git rev-parse HEAD > ~/work/.sct_HEAD_hash
-          cat ~/work/.sct_HEAD_hash
+          git rev-parse HEAD > .sct_HEAD_hash
+          cat .sct_HEAD_hash
 
       - name: Cache SCT
         id: cache-sct
@@ -74,7 +74,7 @@ jobs:
         with:
           path: ~/work/spinalcordtoolbox
           # Use commit hash file from previous step as key
-          key: ${{ matrix.os }}-python-${{ matrix.python-version }}-${{ hashFiles('~/work/.sct_HEAD_hash') }}
+          key: ${{ matrix.os }}_python-${{ matrix.python-version }}-${{ hashFiles('~/work/spinalcordtoolbox/.sct_HEAD_hash') }}
 
       - name: Spinal Cord Toolbox installation
         if: steps.cache-sct.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,9 @@ jobs:
 
     steps:
       - name: Get home directory
-        run: echo $HOME
+        run: |
+          echo ~
+          echo $HOME
       - uses: actions/checkout@v2
 
       - name: Set XCode version
@@ -60,10 +62,10 @@ jobs:
 
       - name: Spinal Cord Toolbox clone
         run: |
-          cd $HOME/work
+          cd ~/work
           git clone --depth 1 https://github.com/neuropoly/spinalcordtoolbox
           cd spinalcordtoolbox
-          git rev-parse HEAD > $HOME/work/.sct_HEAD_hash
+          git rev-parse HEAD > ~/work/.sct_HEAD_hash
 
       - name: Cache SCT
         id: cache-sct

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,7 @@ jobs:
           git clone --depth 1 https://github.com/neuropoly/spinalcordtoolbox
           cd spinalcordtoolbox
           git rev-parse HEAD > ~/work/.sct_HEAD_hash
+          cat ~/work/.sct_HEAD_hash
 
       - name: Cache SCT
         id: cache-sct

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           path: ~/work/spinalcordtoolbox
           # Use commit hash file from previous step as key
-          key: ${{ matrix.os }}_python-${{ matrix.python-version }}-${{ hashFiles('**/.sct_HEAD_hash') }}
+          key: ${{ matrix.os }}-${{ hashFiles('**/.sct_HEAD_hash') }}
 
       - name: Spinal Cord Toolbox installation
         if: steps.cache-sct.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Clones SCT on every run and stores its HEAD commit hash as the cache
key. If this key doesn't match the previously stored cache key, then
SCT is reinstalled and its install location is added to the cache.

The end goal of caching SCT in this workflow is to speed up CI runs -
SCT doesn't need to be reinstalled from scratch if it hasn't changed.
This speeds up development iteration on PRs with multiple cycles of
commit, request changes, commit.

Overall, these caching rules ensure that SCT updates are still
respected, but on average, a PR with a 1-day lifetime only ever requires
a single installation of SCT in GitHub Actions. As SCT stabilizes, we can consider
pinning a specific version of SCT and caching that.

The first time the cache is built (which is equivalent to our CI without caching SCT):

* [9m33s total](https://github.com/shimming-toolbox/shimming-toolbox/actions/runs/544250520) for the full build matrix
* [5m8s](https://github.com/shimming-toolbox/shimming-toolbox/runs/1847046938?check_suite_focus=true) for the fastest matrix option, Ubuntu 20.04 with Python 3.8:
![image](https://user-images.githubusercontent.com/12765385/107133809-2215ec80-68ba-11eb-93ba-a88f6cefb731.png)


Subsequent CI runs that use cached SCT: 
* [4m6s total](https://github.com/shimming-toolbox/shimming-toolbox/actions/runs/544267629) for the full build matrix
* [3m7s](https://github.com/shimming-toolbox/shimming-toolbox/runs/1847108707?check_suite_focus=true) for the fastest matrix option, Ubuntu 20.04 with Python 3.8:
![image](https://user-images.githubusercontent.com/12765385/107133831-4a9de680-68ba-11eb-8967-4ff0cdb64dad.png)

Note that macOS runners have extremely variable runtime - there's no way around this, as those runners seem to be slammed by many GitHub users trying to run their daily iOS and macOS app builds using GitHub Actions.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
Resolves #216

See also https://github.com/actions/cache