### PR TITLE
Update download_data link to the latest release

### DIFF
--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -15,7 +15,7 @@ from shimmingtoolbox.download import install_data
 
 URL_DICT: Dict[str, Tuple[List[str], str]] = {
     "testing_data": (
-        ["https://github.com/shimming-toolbox/data-testing/archive/r20210126.zip"],
+        ["https://github.com/shimming-toolbox/data-testing/archive/r20210209.zip"],
         "Light-weighted dataset for testing purpose.",
     ),
     "prelude": (


### PR DESCRIPTION
## Description
This PR updates the link to download our tests to the latest release of [data-testing repo](https://github.com/shimming-toolbox/data-testing/releases/tag/r20210209). The release adds t2w spinal cord data.
