### PR TITLE
Added possibility to identify TFL sequence for rf mapping

### DIFF
--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -219,6 +219,13 @@
             "criteria": {
                 "SeriesDescription": "*bold*"
             }
+        },
+        {
+            "dataType": "rfmap",
+            "modalityLabel": "TB1map",
+            "criteria": {
+                "SequenceName": "tfl2d1_16"
+            }
         }
     ]
 }


### PR DESCRIPTION
## Context
During the dicom to nifti conversion, the file `config/dcm2bids.json` is used to specify how different sequences might be identified. 
Here I just added the possibility to identify the Turboflash sequence for B1 mapping based on the tag `SequenceName` which should return `tfl2d1_16`.
The name TB1map for the file is chosen because it's what should soon be used for these kind of nifti files according to the [WIP for the BIDS v1.5.0](https://bids-specification.readthedocs.io/en/latest/04-modality-specific-files/01-magnetic-resonance-imaging-data.html).
I tested it on a set of dicoms from the MNI and the sequence was indeed identified and converted in its own `rfmap`folder.

