### PR TITLE
Updated load_nifti function to handle rf-maps obtained with Turboflash B1 mapping 

### DIFF
--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -15,7 +15,7 @@ from shimmingtoolbox.download import install_data
 
 URL_DICT: Dict[str, Tuple[List[str], str]] = {
     "testing_data": (
-        ["https://github.com/shimming-toolbox/data-testing/archive/r20210209.zip"],
+        ["https://github.com/shimming-toolbox/data-testing/archive/r20210217.zip"],
         "Light-weighted dataset for testing purpose.",
     ),
     "prelude": (

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -177,7 +177,7 @@ def read_nii(fname_nifti, auto_scale=True):
     image = np.asarray(info.dataobj)
 
     if auto_scale:
-
+        logging.info("Scaling the selected nifti")
         # If Siemens' TurboFLASH B1 mapping (dcm2niix cannot separate phase and magnitude for this sequence)
         if ('SequenceName' in json_data) and 'tfl2d1_16' in json_data['SequenceName']:
 
@@ -242,5 +242,9 @@ def read_nii(fname_nifti, auto_scale=True):
                 image = image * (2 * math.pi / (PHASE_SCALING_SIEMENS * 2)) + math.pi
             else:
                 image = image * (2 * math.pi / PHASE_SCALING_SIEMENS)
+        else:
+            logging.info("Unknown nifti type: No scaling applied")
+    else:
+        logging.info("No scaling applied to selected nifti")
 
     return info, json_data, image

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -161,7 +161,7 @@ def read_nii(fname_nifti, auto_scale=True):
         info (Nifti1Image): Objet containing various data about the nifti file (returned by nibabel.load)
         json_data (dict): Contains the different fields present in the json file corresponding to the nifti file
         image (ndarray): For B0-maps, image contained in the nifti. Siemens phase images are rescaled between 0 and 2pi.
-                         For RF-maps, complex array of dimension (x, y, slice, coil) with phase between -pi and pi.
+        For RF-maps, complex array of dimension (x, y, slice, coil) with phase between -pi and pi.
     """
 
     info = nib.load(fname_nifti)

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -223,14 +223,15 @@ def read_nii(fname_nifti, auto_scale=True):
             mag_vector = np.zeros((image.shape[0], image.shape[1], n_slices*n_coils))
             phase_vector = np.zeros((image.shape[0], image.shape[1], n_slices * n_coils))
             for i in range(n_coils):
-                mag_vector[:, :, i*n_slices:(i+1)*n_slices] = np.flip(b1_mag[:, :, :, i],2)
-                phase_vector[:, :, i*n_slices:(i+1)*n_slices] = np.flip(b1_phase[:, :, :, i],2)
+                mag_vector[:, :, i*n_slices:(i+1)*n_slices] = b1_mag[:, :, :, i]
+                phase_vector[:, :, i*n_slices:(i+1)*n_slices] = b1_phase[:, :, :, i]
 
             for i in range(n_coils):
-                b1_mag_new[:, :, :, i] = mag_vector[:, :, np.arange(0, n_coils*n_slices, n_coils)]
-                b1_phase_new[:, :, :, i] = phase_vector[:, :, np.arange(0, n_coils*n_slices, n_coils)]
+                b1_mag_new[:, :, :, i] = mag_vector[:, :, np.arange(i, n_coils*n_slices, n_coils)]
+                b1_phase_new[:, :, :, i] = phase_vector[:, :, np.arange(i, n_coils*n_slices, n_coils)]
+                image[:, :, :, i] = b1_mag_new[:, :, :, i] * np.exp(1j * b1_phase_new[:, :, :, i])
 
-            image = b1_mag_new * np.exp(1j * b1_phase_new)
+            image = np.multiply(b1_mag_new, np.exp(1j * b1_phase_new))
 
         # If B0 phase maps
         elif ('Manufacturer' in json_data) and (json_data['Manufacturer'] == 'Siemens') \

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -197,7 +197,7 @@ def read_nii(fname_nifti, auto_scale=True):
 
             if image.shape[2] != n_slices:
                 raise ValueError("Wrong array dimension: number of slices not matching")
-            if image.shape[3] != n_coils:
+            if image.shape[3] != 2*n_coils:
                 raise ValueError("Wrong array dimension: number of coils not matching")
             # Calculate B1 efficiency (1ms, pi-pulse) and scale by the ratio of the measured FA to the saturation FA.
             # Get the Transmission amplifier reference amplitude

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -392,3 +392,6 @@ class TestCore(object):
         assert np.angle(b1).max() <= np.pi and np.angle(b1).min() >= -np.pi
 
         # Check masking consistency for all coils at each slice
+        for i in range(b1.shape[2]):
+            for j in range(b1.shape[3]-1):
+                assert ((b1[:, :, i, j] != 0) == (b1[:, :, i, j+1] != 0)).any()

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -22,63 +22,13 @@ class TestCore(object):
                       [[10, 11, 12], [13, 14, 15], [16, 17, 18]],
                       [[19, 20, 21], [22, 23, 24], [25, 26, 27]]])
     _data_volume = np.array([[[[1, 1], [2, 2], [3, 3]], [[4, 4], [5, 5], [6, 6]], [[7, 7], [8, 8], [9, 9]]],
-                            [[[10, 10], [11, 11], [12, 12]], [[13, 13], [14, 14], [15, 15]], [[16, 16], [17, 17], [18, 18]]],
-                            [[[19, 19], [20, 20], [21, 21]], [[22, 22], [23, 23], [24, 24]], [[25, 25], [26, 26], [27, 27]]]])
+                             [[[10, 10], [11, 11], [12, 12]], [[13, 13], [14, 14], [15, 15]],
+                              [[16, 16], [17, 17], [18, 18]]],
+                             [[[19, 19], [20, 20], [21, 21]], [[22, 22], [23, 23], [24, 24]],
+                              [[25, 25], [26, 26], [27, 27]]]])
     _aff = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
     _json_phase = {"Modality": "MR",
-                     "ImageComments": "phase",
-                     "MagneticFieldStrength": 3,
-                     "ImagingFrequency": 123.259,
-                     "Manufacturer": "Siemens",
-                     "ManufacturersModelName": "Prisma_fit",
-                     "InstitutionName": "IUGM",
-                     "InstitutionAddress": "",
-                     "DeviceSerialNumber": "167006",
-                     "StationName": "MRC35049",
-                     "BodyPartExamined": "BRAIN",
-                     "PatientPosition": "HFS",
-                     "ProcedureStepDescription": "dev_acdc",
-                     "SoftwareVersions": "syngo_MR_E11",
-                     "MRAcquisitionType": "2D",
-                     "SeriesDescription": "a_gre_DYNshim",
-                     "ProtocolName": "a_gre_DYNshim",
-                     "ScanningSequence": "GR",
-                     "SequenceVariant": "SP",
-                     "SequenceName": "fl2d6",
-                     "ImageType": ["ORIGINAL", "PRIMARY", "M", "ND"],
-                     "SeriesNumber": 6,
-                     "AcquisitionTime": "16:21:2.480000",
-                     "AcquisitionNumber": 1,
-                     "SliceThickness": 3,
-                     "SpacingBetweenSlices": 3,
-                     "SAR": 0.00453667,
-                     "EchoNumber": 1,
-                     "EchoTime": 0.0025,
-                     "RepetitionTime": 0.5,
-                     "FlipAngle": 25,
-                     "PartialFourier": 1,
-                     "BaseResolution": 128,
-                     "ShimSetting": [620, -7194, -9127, 77, 28, -20, -10, -23],
-                     "TxRefAmp": 222.944,
-                     "PhaseResolution": 1,
-                     "ReceiveCoilName": "HeadNeck_64",
-                     "ReceiveCoilActiveElements": "HC7;NC1,2",
-                     "PulseSequenceDetails": "%CustomerSeq%_a_gre_DYNshim",
-                     "ConsistencyInfo": "N4_VE11C_LATEST_20160120",
-                     "PercentPhaseFOV": 59.375,
-                     "EchoTrainLength": 6,
-                     "PhaseEncodingSteps": 76,
-                     "AcquisitionMatrixPE": 76,
-                     "ReconMatrixPE": 76,
-                     "PixelBandwidth": 600,
-                     "PhaseEncodingDirection": "j-",
-                     "ImageOrientationPatientDICOM": [1, 0, 0, 0, 1, 0],
-                     "InPlanePhaseEncodingDirectionDICOM": "COL",
-                     "ConversionSoftware": "dcm2niix",
-                     "ConversionSoftwareVersion": "v1.0.20181125  (JP2:OpenJPEG) GCC9.3.0",
-                     "Dcm2bidsVersion": "2.1.4"}
-    _json_mag = {"Modality": "MR",
-                   "ImageComments": "magnitude",
+                   "ImageComments": "phase",
                    "MagneticFieldStrength": 3,
                    "ImagingFrequency": 123.259,
                    "Manufacturer": "Siemens",
@@ -129,6 +79,115 @@ class TestCore(object):
                    "ConversionSoftware": "dcm2niix",
                    "ConversionSoftwareVersion": "v1.0.20181125  (JP2:OpenJPEG) GCC9.3.0",
                    "Dcm2bidsVersion": "2.1.4"}
+    _json_mag = {"Modality": "MR",
+                 "ImageComments": "magnitude",
+                 "MagneticFieldStrength": 3,
+                 "ImagingFrequency": 123.259,
+                 "Manufacturer": "Siemens",
+                 "ManufacturersModelName": "Prisma_fit",
+                 "InstitutionName": "IUGM",
+                 "InstitutionAddress": "",
+                 "DeviceSerialNumber": "167006",
+                 "StationName": "MRC35049",
+                 "BodyPartExamined": "BRAIN",
+                 "PatientPosition": "HFS",
+                 "ProcedureStepDescription": "dev_acdc",
+                 "SoftwareVersions": "syngo_MR_E11",
+                 "MRAcquisitionType": "2D",
+                 "SeriesDescription": "a_gre_DYNshim",
+                 "ProtocolName": "a_gre_DYNshim",
+                 "ScanningSequence": "GR",
+                 "SequenceVariant": "SP",
+                 "SequenceName": "fl2d6",
+                 "ImageType": ["ORIGINAL", "PRIMARY", "M", "ND"],
+                 "SeriesNumber": 6,
+                 "AcquisitionTime": "16:21:2.480000",
+                 "AcquisitionNumber": 1,
+                 "SliceThickness": 3,
+                 "SpacingBetweenSlices": 3,
+                 "SAR": 0.00453667,
+                 "EchoNumber": 1,
+                 "EchoTime": 0.0025,
+                 "RepetitionTime": 0.5,
+                 "FlipAngle": 25,
+                 "PartialFourier": 1,
+                 "BaseResolution": 128,
+                 "ShimSetting": [620, -7194, -9127, 77, 28, -20, -10, -23],
+                 "TxRefAmp": 222.944,
+                 "PhaseResolution": 1,
+                 "ReceiveCoilName": "HeadNeck_64",
+                 "ReceiveCoilActiveElements": "HC7;NC1,2",
+                 "PulseSequenceDetails": "%CustomerSeq%_a_gre_DYNshim",
+                 "ConsistencyInfo": "N4_VE11C_LATEST_20160120",
+                 "PercentPhaseFOV": 59.375,
+                 "EchoTrainLength": 6,
+                 "PhaseEncodingSteps": 76,
+                 "AcquisitionMatrixPE": 76,
+                 "ReconMatrixPE": 76,
+                 "PixelBandwidth": 600,
+                 "PhaseEncodingDirection": "j-",
+                 "ImageOrientationPatientDICOM": [1, 0, 0, 0, 1, 0],
+                 "InPlanePhaseEncodingDirectionDICOM": "COL",
+                 "ConversionSoftware": "dcm2niix",
+                 "ConversionSoftwareVersion": "v1.0.20181125  (JP2:OpenJPEG) GCC9.3.0",
+                 "Dcm2bidsVersion": "2.1.4"}
+
+    _json_b1 = {"Modality": "MR",
+                "MagneticFieldStrength": 7,
+                "ImagingFrequency": 297.197,
+                "Manufacturer": "Siemens",
+                "ManufacturersModelName": "Investigational_Device_7T",
+                "InstitutionName": "Hospital",
+                "InstitutionalDepartmentName": "Department",
+                "InstitutionAddress": "Street StreetNo,City,District,CA,ZIP",
+                "DeviceSerialNumber": "79017",
+                "StationName": "AWP79017",
+                "BodyPartExamined": "BRAIN",
+                "PatientPosition": "HFS",
+                "ProcedureStepDescription": "Development^Dr. Cohen-Adad",
+                "SoftwareVersions": "syngo MR E12",
+                "MRAcquisitionType": "2D",
+                "SeriesDescription": "tfl_rfmap_B1shim_flip20_5mm",
+                "ProtocolName": "tfl_rfmap_B1shim_flip20_5mm",
+                "ScanningSequence": "GR",
+                "SequenceVariant": "SK\\SP",
+                "SequenceName": "tfl2d1_16",
+                "SeriesNumber": 67,
+                "AcquisitionTime": "14:21:12.127500",
+                "AcquisitionNumber": 1,
+                "ImageComments": "flip angle map, TraRefAmpl: 225.0 V",
+                "SliceThickness": 5,
+                "SpacingBetweenSlices": 6,
+                "SAR": 0.0250297,
+                "EchoTime": 0.00148,
+                "RepetitionTime": 4,
+                "FlipAngle": 20,
+                "PartialFourier": 1,
+                "Interpolation2D": 1,
+                "BaseResolution": 32,
+                "ShimSetting": [133, 30, 22, -80, 27, -130, -112, -234],
+                "TxRefAmp": 225,
+                "PhaseResolution": 1,
+                "ReceiveCoilName": "NP11_ACDC_SPINE",
+                "ReceiveCoilActiveElements": "1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H",
+                "PulseSequenceDetails": "%SiemensSeq%\\tfl_rfmap",
+                "ConsistencyInfo": "N4_VE12U_LATEST_20181126",
+                "MultibandAccelerationFactor": 8,
+                "PercentPhaseFOV": 100,
+                "PercentSampling": 100,
+                "PhaseEncodingSteps": 32,
+                "AcquisitionMatrixPE": 32,
+                "ReconMatrixPE": 64,
+                "PixelBandwidth": 450,
+                "DwellTime": 3.48e-05,
+                "PhaseEncodingDirection": "j-",
+                "SliceTiming": [0.96875, 0.96875, 0.96875, 0.96875, 0.96875, 0.96875, 0.96875, 0.96875, 0, 0, 0, 0, 0,0,
+                                0, 0],
+                "ImageOrientationPatientDICOM": [1, 0, 0, 0, 1, 0],
+                "InPlanePhaseEncodingDirectionDICOM": "COL",
+                "ConversionSoftware": "dcm2niix",
+                "ConversionSoftwareVersion": "v1.0.20201102",
+                "Dcm2bidsVersion": "2.1.4"}
 
     def setup_method(self):
         """
@@ -174,7 +233,6 @@ class TestCore(object):
         with open(os.path.join(self.data_path_volume, 'dummy_volume.json'), 'w') as json_file:
             self._json_phase['EchoNumber'] = 1
             json.dump(self._json_phase, json_file)
-
 
     def teardown_method(self):
         """
@@ -222,7 +280,8 @@ class TestCore(object):
         niftis, info, json_info = load_nifti(self.tmp_path)
         assert (len(info) == 1), "Wrong number od info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
-        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), "JSON file is not correctly loaded"
+        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase,
+                                                                       sort_keys=True)), "JSON file is not correctly loaded"
         assert (niftis.shape == (3, 3, 3, 1, 1)), "Wrong shape for the Nifti output data"
 
     def test_load_nifti_files(self):
@@ -239,7 +298,8 @@ class TestCore(object):
         niftis, info, json_info = load_nifti(self.data_path)
         assert (len(info) == 1), "Wrong number od info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
-        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), "JSON file is not correctly loaded"
+        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase,
+                                                                       sort_keys=True)), "JSON file is not correctly loaded"
         assert (niftis.shape == (3, 3, 3, 1, 1)), "Wrong shape for the Nifti output data"
 
     def test_load_nifti_json_missing_fail(self):
@@ -307,7 +367,8 @@ class TestCore(object):
         niftis, info, json_info = load_nifti(self.data_path_volume)
         assert (len(info) == 1), "Wrong number of info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
-        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), "JSON file is not correctly loaded"
+        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase,
+                                                                       sort_keys=True)), "JSON file is not correctly loaded"
         assert (niftis.shape == (3, 3, 3, 1, 2)), "Wrong shape for the Nifti output data"
 
     def test_load_nifti_multiple_run(self, monkeypatch):
@@ -332,7 +393,8 @@ class TestCore(object):
         self._json_phase['AcquisitionNumber'] = 1
         assert (len(info) == 1), "Wrong number od info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
-        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), "JSON file is not correctly loaded"
+        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase,
+                                                                       sort_keys=True)), "JSON file is not correctly loaded"
         assert (niftis.shape == (3, 3, 3, 1, 1)), "Wrong shape for the Nifti output data"
 
         monkeypatch.setattr('sys.stdin', StringIO('2\n'))
@@ -387,11 +449,18 @@ class TestCore(object):
         fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'sub-01_run-10_TB1map.nii.gz')
         nii, json_info, b1 = read_nii(fname_b1)
 
-        assert b1.shape == (64, 64, 16, 8)
-        assert np.abs(b1).max() <= 180 and np.abs(b1).min() >= 0
-        assert np.angle(b1).max() <= np.pi and np.angle(b1).min() >= -np.pi
+        assert b1.shape == (64, 64, 16, 8), "Wrong rf-map shape"
+        assert np.abs(b1).max() <= 180 and np.abs(b1).min() >= 0, "Magnitude values out of range"
+        assert np.angle(b1).max() <= np.pi and np.angle(b1).min() >= -np.pi, "Phase values out of range"
 
         # Check masking consistency for all coils at each slice
         for i in range(b1.shape[2]):
-            for j in range(b1.shape[3]-1):
-                assert ((b1[:, :, i, j] != 0) == (b1[:, :, i, j+1] != 0)).any()
+            for j in range(b1.shape[3] - 1):
+                assert ((b1[:, :, i, j] != 0) == (b1[:, :, i, j + 1] != 0)).any()
+
+        assert [b1[35, 35, 0, 0], b1[35, 35, 6, 7], b1[40, 25, 15, 7]] == [(-4.274539911369111 + 4.599952786001116j),
+                                                                           (-5.8027003257021725 + 2.2042390773527423j),
+                                                                           (-2.1929304691258276 + 1.5241263801971388j)]
+
+        assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1, sort_keys=True)), \
+            "JSON file is not correctly loaded for first RF JSON"

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -382,3 +382,13 @@ class TestCore(object):
         assert nii.shape == (64, 96, 1, 10)
         assert ('P' in json_info['ImageType'])
         assert (phasediff.max() <= 2 * math.pi) and (phasediff.min() >= 0)
+
+    def test_read_nii_b1(self):
+        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'sub-01_run-10_TB1map.nii.gz')
+        nii, json_info, b1 = read_nii(fname_b1)
+
+        assert b1.shape == (64, 64, 16, 8)
+        assert np.abs(b1).max() <= 180 and np.abs(b1).min() >= 0
+        assert np.angle(b1).max() <= np.pi and np.angle(b1).min() >= -np.pi
+
+        # Check masking consistency for all coils at each slice

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -458,9 +458,12 @@ class TestCore(object):
             for j in range(b1.shape[3] - 1):
                 assert ((b1[:, :, i, j] != 0) == (b1[:, :, i, j + 1] != 0)).any()
 
-        assert [b1[35, 35, 0, 0], b1[35, 35, 6, 7], b1[40, 25, 15, 7]] == [(-4.274539911369111 + 4.599952786001116j),
-                                                                           (-5.8027003257021725 + 2.2042390773527423j),
-                                                                           (-2.1929304691258276 + 1.5241263801971388j)]
+        test_values = [format(-4.274539911369111 + 4.599952786001116j, '.5f'),
+                       format(-5.8027003257021725 + 2.2042390773527423j, '.5f'),
+                       format(-2.1929304691258276 + 1.5241263801971388j, '.5f')]
+
+        assert [format(b1[35, 35, 0, 0], '.5f'), format(b1[35, 35, 6, 7], '.5f'), format(b1[40, 25, 15, 7], '.5f')] == \
+               test_values
 
         assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1, sort_keys=True)), \
             "JSON file is not correctly loaded for first RF JSON"

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -471,32 +471,6 @@ class TestCore(object):
         assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1, sort_keys=True)),\
             "JSON file is not correctly loaded for first RF JSON"
 
-    def test_read_nii_b1_without_tags(self):
-        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
-        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting'))
-        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting.json'), 'w') as json_file:
-            self._json_b1_no_shimsetting = self._json_b1.copy()
-            del self._json_b1_no_shimsetting['ShimSetting']
-            json.dump(self._json_b1_no_shimsetting, json_file)
-
-        fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_no_shimsetting.nii")
-        try:
-            read_nii(fname_b1)
-        except ValueError:
-            return 0
-
-        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming'))
-        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming.json'), 'w') as json_file:
-            self._json_b1_no_slicetiming = self._json_b1.copy()
-            del self._json_b1_no_slicetiming['SliceTiming']
-            json.dump(self._json_b1_no_slicetiming, json_file)
-
-        fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_no_slicetiming.nii")
-        try:
-            read_nii(fname_b1)
-        except ValueError:
-            return 0
-
     def test_read_nii_b1_no_scaling(self):
         fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'sub-01_run-10_TB1map.nii.gz')
         _, _, b1 = read_nii(fname_b1, auto_scale=False)
@@ -504,7 +478,35 @@ class TestCore(object):
         test_values = [87.0, 1890.0, 37.0]
         assert [b1[35, 35, 0, 0], b1[35, 35, 6, 13], b1[40, 25, 15, 7]] == test_values
 
-    def test_read_nii_b1_wrong_dims(self):
+    def test_read_nii_b1_no_shimsetting(self):
+        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
+        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting'))
+        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting.json'), 'w') as json_file:
+            self._json_b1_no_shimsetting = self._json_b1.copy()
+            del self._json_b1_no_shimsetting['ShimSetting']
+            json.dump(self._json_b1_no_shimsetting, json_file)
+
+        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting.nii')
+        try:
+            read_nii(fname_b1)
+        except ValueError:
+            return 0
+
+    def test_read_nii_b1_no_slicetiming(self):
+        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
+        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming'))
+        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming.json'), 'w') as json_file:
+            self._json_b1_no_slicetiming = self._json_b1.copy()
+            del self._json_b1_no_slicetiming['SliceTiming']
+            json.dump(self._json_b1_no_slicetiming, json_file)
+
+        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming.nii')
+        try:
+            read_nii(fname_b1)
+        except ValueError:
+            return 0
+
+    def test_read_nii_b1_wrong_shimsetting(self):
         dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
         nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_wrong_shimsetting'))
         with open(os.path.join(self.data_path_b1, 'dummy_b1_wrong_shimsetting.json'), 'w') as json_file:
@@ -518,10 +520,12 @@ class TestCore(object):
         except ValueError:
             return 0
 
+    def test_read_nii_b1_wrong_slicetiming(self):
+        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
         nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_wrong_slicetiming'))
         with open(os.path.join(self.data_path_b1, 'dummy_b1_wrong_slicetiming.json'), 'w') as json_file:
             self._json_b1_wrong_slicetiming = self._json_b1.copy()
-            self._json_b1_wrong_shimsetting['SliceTiming'] = str(np.zeros([15]))
+            self._json_b1_wrong_slicetiming['SliceTiming'] = str(np.zeros([15]))
             json.dump(self._json_b1_wrong_slicetiming, json_file)
 
         fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_wrong_slicetiming.nii")


### PR DESCRIPTION
## Description

In order to perform RF-shimming, the first step is to load the acquired B<sub>1</sub> maps in the toolbox.
Due to a problem in the conversion from `dicom` to `nifti` mentioned in #58 , we decided for now to directly start from a `nifti`  file that is returned when running dicom_to_nifti with the folder containing the dicoms acquired using the RF-mapping sequence (turbo flash sequence on a 7T Siemens Magneton Terra). 

##### Implementation:

The `load_nifti` function now checks if the nifti has been obtained using a `tfl2d1_16` and then scales and reshuffles the data contained in the nifti in order to output a complex array (x, y, slices, coils) corresponding to the individual B1 maps for every coil/slice. The returned array will directly by used as input for the rf-shimming optimization process.

## Linked issues
Resolves #210 
