### PR TITLE
Raise warning when loading RF nifti with missing SliceTiming

### DIFF
--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -224,7 +224,7 @@
             "dataType": "rfmap",
             "modalityLabel": "TB1map",
             "criteria": {
-                "SequenceName": "tfl2d1_16"
+                "SequenceName": "*tfl2d1_16"
             }
         }
     ]

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -198,25 +198,22 @@ def read_nii(fname_nifti, auto_scale=True):
 
     return info, json_data, image
 
+
 def scale_tfl_b1(image, json_data):
     if 'ShimSetting' in json_data:
-        pass
+        n_coils = len(json_data['ShimSetting'])
+        if image.shape[3] != 2 * n_coils:
+            raise ValueError("Wrong array dimension: number of coils not matching")
     else:
         raise ValueError("Missing json tag: 'ShimSetting'")
 
-    n_coils = len(json_data['ShimSetting'])
-
     if 'SliceTiming' in json_data:
-        pass
+        n_slices = len(json_data['SliceTiming'])
+        if image.shape[2] != n_slices:
+            raise ValueError("Wrong array dimension: number of slices not matching")
     else:
-        raise ValueError("Missing json tag: 'SliceTiming'")
+        raise UserWarning("Missing json tag: 'SliceTiming', slices number cannot be checked.")
 
-    n_slices = len(json_data['SliceTiming'])
-
-    if image.shape[2] != n_slices:
-        raise ValueError("Wrong array dimension: number of slices not matching")
-    if image.shape[3] != 2 * n_coils:
-        raise ValueError("Wrong array dimension: number of coils not matching")
     # Calculate B1 efficiency (1ms, pi-pulse) and scale by the ratio of the measured FA to the saturation FA.
     # Get the Transmission amplifier reference amplitude
     amplifier_voltage = json_data['TxRefAmp']  # [V]

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -171,7 +171,7 @@ def read_nii(fname_nifti, auto_scale=True):
     if os.path.isfile(json_path):
         json_data = json.load(open(json_path))
     else:
-        raise ValueError("Missing json file")
+        raise OSError("Missing json file")
 
     # Store nifti image in a numpy array
     image = np.asarray(info.dataobj)
@@ -187,7 +187,7 @@ def read_nii(fname_nifti, auto_scale=True):
                 and (('ImageComments' in json_data) and ("*phase*" in json_data['ImageComments'])
                      or ('ImageType' in json_data) and ('P' in json_data['ImageType'])):
             # Bootstrap
-            if image.min() < 0:
+            if np.amin(image) < 0:
                 image = image * (2 * math.pi / (PHASE_SCALING_SIEMENS * 2)) + math.pi
             else:
                 image = image * (2 * math.pi / PHASE_SCALING_SIEMENS)
@@ -205,7 +205,7 @@ def scale_tfl_b1(image, json_data):
         if image.shape[3] != 2 * n_coils:
             raise ValueError("Wrong array dimension: number of coils not matching")
     else:
-        raise ValueError("Missing json tag: 'ShimSetting'")
+        raise KeyError("Missing json tag: 'ShimSetting'")
 
     if 'SliceTiming' in json_data:
         n_slices = len(json_data['SliceTiming'])

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -7,6 +7,7 @@ import numpy as np
 import nibabel as nib
 import json
 import math
+import warnings
 
 from shimmingtoolbox.utils import iso_times_to_ms
 
@@ -212,7 +213,8 @@ def scale_tfl_b1(image, json_data):
         if image.shape[2] != n_slices:
             raise ValueError("Wrong array dimension: number of slices not matching")
     else:
-        raise UserWarning("Missing json tag: 'SliceTiming', slices number cannot be checked.")
+        warnings.warn("Missing json tag: 'SliceTiming', slices number cannot be checked.")
+        n_slices = image.shape[2]
 
     # Calculate B1 efficiency (1ms, pi-pulse) and scale by the ratio of the measured FA to the saturation FA.
     # Get the Transmission amplifier reference amplitude

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -252,24 +252,16 @@ class TestCore(object):
         Assert fails without existing path
         :return:
         """
-        try:
+        with pytest.raises(RuntimeError, match="Not an existing NIFTI path"):
             load_nifti("dummy")
-        except RuntimeError:
-            return 0
-
-        assert False, "Did not fail if no valid path given"
 
     def test_load_nifti_mix_file_types_fail(self):
         """
         Assert fails if folder and files in path
         :return:
         """
-        try:
+        with pytest.raises(RuntimeError, match="Directories and files in input path"):
             load_nifti(self.toolbox_path)
-        except:
-            return 0
-
-        assert False, "Did not fail with folder and files in the same path"
 
     def test_load_nifti_folders(self, monkeypatch):
         """
@@ -312,12 +304,8 @@ class TestCore(object):
         :return:
         """
         os.remove(os.path.join(self.data_path, "dummy.json"))
-        try:
+        with pytest.raises(OSError, match="Missing json file"):
             load_nifti(self.data_path)
-        except ValueError:
-            return 0
-
-        assert False, "Did not fail with missing JSON file"
 
     def test_load_nifti_multiple_echoes(self, monkeypatch):
         """
@@ -500,7 +488,7 @@ class TestCore(object):
             json.dump(self._json_b1_no_shimsetting, json_file)
 
         fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting.nii')
-        with pytest.raises(ValueError, match="Missing json tag: 'ShimSetting'"):
+        with pytest.raises(KeyError, match="Missing json tag: 'ShimSetting'"):
             read_nii(fname_b1)
 
     def test_read_nii_b1_wrong_slicetiming(self):

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -512,7 +512,7 @@ class TestCore(object):
             json.dump(self._json_b1_no_slicetiming, json_file)
 
         fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_no_slicetiming.nii")
-        with pytest.raises(UserWarning, match="Missing json tag: 'SliceTiming', slices number cannot be checked."):
+        with pytest.warns(UserWarning, match="Missing json tag: 'SliceTiming', slices number cannot be checked."):
             read_nii(fname_b1)
 
     def test_read_nii_b1_negative_mag(self):

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -1,12 +1,13 @@
 #!usr/bin/env python3
 # -*- coding: utf-8
 
-import shutil
-import os
-import numpy as np
-import nibabel as nib
 import json
+import nibabel as nib
+import numpy as np
 import math
+import os
+import pytest
+import shutil
 
 from io import StringIO
 from pathlib import Path
@@ -478,34 +479,6 @@ class TestCore(object):
         test_values = [87.0, 1890.0, 37.0]
         assert [b1[35, 35, 0, 0], b1[35, 35, 6, 13], b1[40, 25, 15, 7]] == test_values
 
-    def test_read_nii_b1_no_shimsetting(self):
-        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
-        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting'))
-        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting.json'), 'w') as json_file:
-            self._json_b1_no_shimsetting = self._json_b1.copy()
-            del self._json_b1_no_shimsetting['ShimSetting']
-            json.dump(self._json_b1_no_shimsetting, json_file)
-
-        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting.nii')
-        try:
-            read_nii(fname_b1)
-        except ValueError:
-            return 0
-
-    def test_read_nii_b1_no_slicetiming(self):
-        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
-        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming'))
-        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming.json'), 'w') as json_file:
-            self._json_b1_no_slicetiming = self._json_b1.copy()
-            del self._json_b1_no_slicetiming['SliceTiming']
-            json.dump(self._json_b1_no_slicetiming, json_file)
-
-        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming.nii')
-        try:
-            read_nii(fname_b1)
-        except ValueError:
-            return 0
-
     def test_read_nii_b1_wrong_shimsetting(self):
         dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
         nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_wrong_shimsetting'))
@@ -515,10 +488,20 @@ class TestCore(object):
             json.dump(self._json_b1_wrong_shimsetting, json_file)
 
         fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_wrong_shimsetting.nii")
-        try:
+        with pytest.raises(ValueError, match="Wrong array dimension: number of coils not matching"):
             read_nii(fname_b1)
-        except ValueError:
-            return 0
+
+    def test_read_nii_b1_no_shimsetting(self):
+        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
+        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting'))
+        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting.json'), 'w') as json_file:
+            self._json_b1_no_shimsetting = self._json_b1.copy()
+            del self._json_b1_no_shimsetting['ShimSetting']
+            json.dump(self._json_b1_no_shimsetting, json_file)
+
+        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting.nii')
+        with pytest.raises(ValueError, match="Missing json tag: 'ShimSetting'"):
+            read_nii(fname_b1)
 
     def test_read_nii_b1_wrong_slicetiming(self):
         dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
@@ -529,10 +512,20 @@ class TestCore(object):
             json.dump(self._json_b1_wrong_slicetiming, json_file)
 
         fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_wrong_slicetiming.nii")
-        try:
+        with pytest.raises(ValueError, match="Wrong array dimension: number of slices not matching"):
             read_nii(fname_b1)
-        except ValueError:
-            return 0
+
+    def test_read_nii_b1_no_slicetiming(self):
+        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
+        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming'))
+        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming.json'), 'w') as json_file:
+            self._json_b1_no_slicetiming = self._json_b1.copy()
+            del self._json_b1_no_slicetiming['SliceTiming']
+            json.dump(self._json_b1_no_slicetiming, json_file)
+
+        fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_no_slicetiming.nii")
+        with pytest.raises(UserWarning, match="Missing json tag: 'SliceTiming', slices number cannot be checked."):
+            read_nii(fname_b1)
 
     def test_read_nii_b1_negative_mag(self):
         data_negative_mag = self._data_b1.copy()
@@ -543,7 +536,5 @@ class TestCore(object):
             json.dump(self._json_b1, json_file)
 
         fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_negative_mag.nii")
-        try:
+        with pytest.raises(ValueError, match="Unexpected negative magnitude values"):
             read_nii(fname_b1)
-        except ValueError:
-            return 0


### PR DESCRIPTION
## Description
If missing SliceTiming tag in .json, only inform the user instead of raising an error.
I also refactored some tests to me clearer.

## Linked issues
Resolves #251 
