### PR TITLE
Move images to new repo

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 Welcome to shimming-toolbox!
 ============================
 
-.. figure:: ./_static/shimming_toolbox_logo.png
+.. figure:: https://raw.githubusercontent.com/shimming-toolbox/doc-figures/master/logo/shimming_toolbox_logo.png
    :alt: logo
 
 .. NOTE ::


### PR DESCRIPTION
Migrate images to repo: https://github.com/shimming-toolbox/doc-figures

Documentation built is here: https://shimming-toolbox-py--255.org.readthedocs.build/en/255/