### PR TITLE
Refactored prelude and dcm2niix to avoid bug when not on PATH

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           curl -JLO https://github.com/rordenlab/dcm2niix/releases/latest/download/dcm2niix_lnx.zip
           unzip -o dcm2niix_lnx.zip
-          sudo install dcm2nii* /usr/bin/
+          sudo install dcm2nii* /usr/local/bin/
 
       - name: Spinal Cord Toolbox clone
         run: |

--- a/conftest.py
+++ b/conftest.py
@@ -39,17 +39,13 @@ def test_data_path_fixture():
 
 @pytest.fixture(params=[pytest.param(0, marks=pytest.mark.prelude)])
 def test_prelude_installation():
-    # note that check_prelude_installation() returns 0 on success, so it must
-    # be negated for the assertion.
-    assert not check_prelude_installation()
+    assert check_prelude_installation()
     return
 
 
 @pytest.fixture(params=[pytest.param(0, marks=pytest.mark.dcm2niix)])
 def test_dcm2niix_installation():
-    # note that check_dcm2niix_installation() returns 0 on success, so it must
-    # be negated for the assertion.
-    assert not check_dcm2niix_installation()
+    assert check_dcm2niix_installation()
     return
 
 

--- a/shimmingtoolbox/cli/check_env.py
+++ b/shimmingtoolbox/cli/check_env.py
@@ -57,28 +57,12 @@ def check_dependencies():
     # Prelude
     prelude_check_msg = check_name.format("prelude")
     print_line(prelude_check_msg)
-    # 0 indicates prelude is installed.
-    prelude_exit_code: int = check_prelude_installation()
-    # negating condition because 0 indicates prelude is installed.
-    if not prelude_exit_code:
-        print_ok()
-        print("    " + get_prelude_version().replace("\n", "\n    "))
-    else:
-        print_fail()
-        print(f"Error {prelude_exit_code}: prelude is not installed or not in your PATH.")
+    check_prelude_installation()
 
     # dcm2niix
     dcm2niix_check_msg = check_name.format("dcm2niix")
     print_line(dcm2niix_check_msg)
-    # 0 indicates dcm2niix is installed.
-    dcm2niix_exit_code: int = check_dcm2niix_installation()
-    # negating condition because 0 indicates dcm2niix is installed.
-    if not dcm2niix_exit_code:
-        print_ok()
-        print("    " + get_dcm2niix_version().replace("\n", "\n    "))
-    else:
-        print_fail()
-        print(f"Error {dcm2niix_exit_code}: dcm2niix is not installed or not in your PATH.")
+    check_dcm2niix_installation()
 
     # SCT
     sct_check_msg = check_name.format("Spinal Cord Toolbox")
@@ -88,43 +72,57 @@ def check_dependencies():
     return
 
 
-def check_prelude_installation() -> int:
+def check_prelude_installation():
     """Checks that ``prelude`` is installed.
 
-    This function calls ``which prelude`` and checks the exit code to verify
-    that ``prelude`` is installed.
+    This function calls ``which prelude`` and checks the exit code to verify that ``prelude`` is installed.
 
     Returns:
-        int: Exit code. 0 on success, nonzero on failure.
+        bool: True if prelude is installed, False if not.
     """
+    try:
+        subprocess.check_call(['which', 'prelude'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except subprocess.CalledProcessError as error:
+        print_fail()
+        print(f"Error {error.returncode}: prelude is not installed or not in your PATH.")
+        return False
+    else:
+        print_ok()
+        print("    " + get_prelude_version().replace("\n", "\n    "))
+        return True
 
-    return subprocess.check_call(['which', 'prelude'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-
-def check_dcm2niix_installation() -> int:
+def check_dcm2niix_installation():
     """Checks that ``dcm2niix`` is installed.
 
-    This function calls ``which dcm2niix`` and checks the exit code to verify
-    that ``dcm2niix`` is installed.
+    This function calls ``which dcm2niix`` and checks the exit code to verify that ``dcm2niix`` is installed.
 
     Returns:
-        int: Exit code. 0 on success, nonzero on failure.
+        bool: True if dcm2niix is installed, False if not.
     """
-    return subprocess.check_call(['which', 'dcm2niix'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        subprocess.check_call(['which', 'dcm2niix'], stdout=subprocess.DEVNULL,
+                              stderr=subprocess.DEVNULL)
+    except subprocess.CalledProcessError as error:
+        print_fail()
+        print(f"Error {error.returncode}: dcm2niix is not installed or not in your PATH.")
+        return False
+    else:
+        print_ok()
+        print("    " + get_dcm2niix_version().replace("\n", "\n    "))
+        return True
 
 
-def check_sct_installation() -> int:
+def check_sct_installation():
     """Checks that ``SCT`` is installed.
 
-    This function calls ``which sct_check_dependencies`` and checks the exit code to verify
-    that ``sct`` is installed.
+    This function calls ``which sct_check_dependencies`` and checks the exit code to verify that ``sct`` is installed.
 
     Returns:
         bool: True if sct is installed, False if not.
     """
     try:
-        subprocess.check_call(['which', 'sct_check_dependencies'], stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL)
+        subprocess.check_call(['which', 'sct_check_dependencies'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except subprocess.CalledProcessError as error:
         print_fail()
         print(f"Error {error.returncode}: Spinal Cord Toolbox is not installed or not in your PATH.")
@@ -153,7 +151,7 @@ def get_prelude_version() -> str:
     # we're capturing stderr instead of stdout
     help_output: str = prelude_help.stderr.rstrip()
     # remove beginning newline and drop help info to keep version info
-    version: str = help_output.split("\n\n")[0].replace("\n","", 1)
+    version: str = help_output.split("\n\n")[0].replace("\n", "", 1)
     return version
 
 

--- a/test/cli/test_check_env.py
+++ b/test/cli/test_check_env.py
@@ -29,25 +29,7 @@ def test_dump_env_info():
 def test_check_installation_errors():
     """Tests that the function returns False as expected
     """
-    my_env = os.environ.copy()
-    paths = my_env['PATH']
-
-    def remove_a_path(paths: str, keyword):
-        pos = paths.find(keyword)
-        last_index = paths.find(':', pos)
-        if last_index == -1:
-            last_index = len(paths)
-        first_index = paths.rfind(':', 0, pos)
-        if first_index == -1:
-            return paths[0:0] + paths[last_index + 1:len(paths)]
-
-        return paths[0:first_index] + paths[last_index:len(paths)]
-
-    keywords = ('/dcm2niix/', '/fsl/', '/spinalcordtoolbox/')
-    for keyword in keywords:
-        paths = remove_a_path(paths, keyword)
-
-    runner = CliRunner(env={'PATH': paths})
+    runner = CliRunner(env={'PATH': '/usr/bin'})
 
     result = runner.invoke(st_ce.check_dependencies, catch_exceptions=False)
     assert result.exit_code == 0


### PR DESCRIPTION
## Description
When prelude or dcm2niix was not on the PATH, it threw an error instead of displaying our pretty output. A simple `try, catch` statement fixes the error.

Here is the output I get if I remove prelude from my PATH:
![Screen Shot 2021-06-01 at 01 42 40](https://user-images.githubusercontent.com/47249340/120273710-dcbc6700-c27c-11eb-8eec-5b01f4e7ba88.png)
The previous output can be seen in the screenshots of #268 

## Linked issues
Fixed #268 
