### PR TITLE
Handling of different slice orientation when reading b1 maps

### DIFF
--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -248,11 +248,12 @@ def scale_tfl_b1(image, json_data):
     # Reorder data shuffled by dm2niix into shape (x, y, n_slices, n_coils)
     b1_mag_ordered = np.zeros_like(b1_mag)
     b1_phase_ordered = np.zeros_like(b1_phase)
+
     for i in range(n_slices):
         b1_mag_ordered[:, :, i, :] = b1_mag_vector[:, :, i * n_coils:i * n_coils + n_coils]
         b1_phase_ordered[:, :, i, :] = b1_phase_vector[:, :, i * n_coils:i * n_coils + n_coils]
 
-    # TODO: assert mask consistency within slices
+    # TODO: Find a way to assert mask consistency within slices
 
     # Scale magnitude in nT/V
     b1_mag_ordered = b1_mag_ordered / 10  # Siemens magnitude values are stored in degrees x10

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -460,6 +460,30 @@ class TestCore(object):
         assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1, sort_keys=True)),\
             "JSON file is not correctly loaded for first RF JSON"
 
+    def test_read_nii_b1_wrong_direction(self):
+        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
+        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_wrong_direction'))
+        self._json_b1_wrong_direction = self._json_b1.copy()
+        self._json_b1_wrong_direction['ImageOrientationPatientDICOM'] = [0, 0, 0, 0, 0, 0]
+        with open(os.path.join(self.data_path_b1, 'dummy_b1_wrong_direction.json'), 'w') as json_file:
+            json.dump(self._json_b1_wrong_direction, json_file)
+
+        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_wrong_direction.nii')
+        with pytest.raises(ValueError, match="Unknown slice orientation"):
+            read_nii(fname_b1)
+
+    def test_read_nii_b1_no_direction(self):
+        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
+        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_direction'))
+        self._json_b1_no_direction = self._json_b1.copy()
+        del self._json_b1_no_direction['ImageOrientationPatientDICOM']
+        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_direction.json'), 'w') as json_file:
+            json.dump(self._json_b1_no_direction, json_file)
+
+        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_no_direction.nii')
+        with pytest.raises(KeyError, match="Missing json tag: 'ImageOrientationPatientDICOM'"):
+            read_nii(fname_b1)
+
     def test_read_nii_b1_no_scaling(self):
         fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'sub-01_run-10_TB1map.nii.gz')
         _, _, b1 = read_nii(fname_b1, auto_scale=False)


### PR DESCRIPTION
## Description
I found out that dcm2niix's inconsistent shuffling of B1 maps (mentioned in #281 )was due to the orientation of the slices:
* axial imaging --> Coils are in correct order 
* sagittal imaging --> Coils are inverted

I added a `if` statement based on the nifti tag `ImageOrientationPatientDICOM` in order to apply the correct reordering. However, I don't have any coronal acquisitions yet so this case will have to be handled later. 

## Next steps
- [ ] Implement handling of coronal slices case
- [ ] Find a way to assert masking consistency within the slices
- [ ] Add nifti files in [testing_data](https://github.com/shimming-toolbox/data-testing) to test sagittal and coronal cases (we need to perform a new acquisition for coronal images)
- [ ] Test all scenarios

## Linked issues
Resolves #281 