### PR TITLE
Fix realtime shimming mask resampling modes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "phantominator~=0.6.4",
         "nibabel~=3.1.1",
         "requests",
-        "scipy~=1.5.0",
+        "scipy~=1.6.0",
         "tqdm",
         "matplotlib~=3.1.2",
         "psutil~=5.7.3",

--- a/shimmingtoolbox/shim/realtime_shim.py
+++ b/shimmingtoolbox/shim/realtime_shim.py
@@ -74,7 +74,7 @@ def realtime_shim(nii_fieldmap, nii_anat, pmu, json_fmap, nii_mask_anat_riro=Non
                 not np.all(nii_mask_anat_riro.shape == nii_anat.shape):
             raise RuntimeError("Mask must have the same shape and affine transformation as anat")
         nii_fmap_3d_temp = nib.Nifti1Image(fieldmap[..., 0], nii_fieldmap.affine)
-        nii_mask_fmap_riro = resample_from_to(nii_mask_anat_riro, nii_fmap_3d_temp)
+        nii_mask_fmap_riro = resample_from_to(nii_mask_anat_riro, nii_fmap_3d_temp, mode='constant')
         mask_fmap_riro = nii_mask_fmap_riro.get_fdata()
     else:
         mask_fmap_riro = np.ones_like(fieldmap[..., 0])
@@ -87,7 +87,7 @@ def realtime_shim(nii_fieldmap, nii_anat, pmu, json_fmap, nii_mask_anat_riro=Non
                 not np.all(nii_mask_anat_static.shape == nii_anat.shape):
             raise RuntimeError("Mask must have the same shape and affine transformation as anat")
         nii_fmap_3d_temp = nib.Nifti1Image(fieldmap[..., 0], nii_fieldmap.affine)
-        nii_mask_fmap_static = resample_from_to(nii_mask_anat_static, nii_fmap_3d_temp)
+        nii_mask_fmap_static = resample_from_to(nii_mask_anat_static, nii_fmap_3d_temp, mode='constant')
         mask_fmap_static = nii_mask_fmap_static.get_fdata()
     else:
         mask_fmap_static = np.ones_like(fieldmap[..., 0])
@@ -148,7 +148,7 @@ def realtime_shim(nii_fieldmap, nii_anat, pmu, json_fmap, nii_mask_anat_riro=Non
     resampled_static = np.array([np.zeros_like(anat), np.zeros_like(anat), np.zeros_like(anat)])
     for g_axis in range(3):
         nii_static = nib.Nifti1Image(static[g_axis], nii_fieldmap.affine)
-        nii_resampled_static = resample_from_to(nii_static, nii_anat)
+        nii_resampled_static = resample_from_to(nii_static, nii_anat, mode='nearest')
         resampled_static[g_axis] = nii_resampled_static.get_fdata()
 
     # Since this is xyzshimming, left-right (x), ant-post (y) and foot-head (z) components are used.
@@ -176,7 +176,7 @@ def realtime_shim(nii_fieldmap, nii_anat, pmu, json_fmap, nii_mask_anat_riro=Non
     resampled_riro = np.array([np.zeros_like(anat), np.zeros_like(anat), np.zeros_like(anat)])
     for g_axis in range(3):
         nii_riro = nib.Nifti1Image(riro[g_axis], nii_fieldmap.affine)
-        nii_resampled_riro = resample_from_to(nii_riro, nii_anat)
+        nii_resampled_riro = resample_from_to(nii_riro, nii_anat, mode='nearest')
         resampled_riro[g_axis] = nii_resampled_riro.get_fdata()
 
     # Since this is xyzshimming, left-right (x), ant-post (y) and foot-head (z) components are used.

--- a/shimmingtoolbox/shim/realtime_shim.py
+++ b/shimmingtoolbox/shim/realtime_shim.py
@@ -74,7 +74,7 @@ def realtime_shim(nii_fieldmap, nii_anat, pmu, json_fmap, nii_mask_anat_riro=Non
                 not np.all(nii_mask_anat_riro.shape == nii_anat.shape):
             raise RuntimeError("Mask must have the same shape and affine transformation as anat")
         nii_fmap_3d_temp = nib.Nifti1Image(fieldmap[..., 0], nii_fieldmap.affine)
-        nii_mask_fmap_riro = resample_from_to(nii_mask_anat_riro, nii_fmap_3d_temp, mode='constant')
+        nii_mask_fmap_riro = resample_from_to(nii_mask_anat_riro, nii_fmap_3d_temp, mode='grid-constant')
         mask_fmap_riro = nii_mask_fmap_riro.get_fdata()
     else:
         mask_fmap_riro = np.ones_like(fieldmap[..., 0])
@@ -87,7 +87,7 @@ def realtime_shim(nii_fieldmap, nii_anat, pmu, json_fmap, nii_mask_anat_riro=Non
                 not np.all(nii_mask_anat_static.shape == nii_anat.shape):
             raise RuntimeError("Mask must have the same shape and affine transformation as anat")
         nii_fmap_3d_temp = nib.Nifti1Image(fieldmap[..., 0], nii_fieldmap.affine)
-        nii_mask_fmap_static = resample_from_to(nii_mask_anat_static, nii_fmap_3d_temp, mode='constant')
+        nii_mask_fmap_static = resample_from_to(nii_mask_anat_static, nii_fmap_3d_temp, mode='grid-constant')
         mask_fmap_static = nii_mask_fmap_static.get_fdata()
     else:
         mask_fmap_static = np.ones_like(fieldmap[..., 0])

--- a/test/shim/test_realtime_shim.py
+++ b/test/shim/test_realtime_shim.py
@@ -36,7 +36,7 @@ class TestRealtimeShim(object):
                       center_dim2=int(ny / 2),
                       len_dim1=30, len_dim2=30, len_dim3=nz)
 
-        nii_mask_static = nib.Nifti1Image(mask.astype(int), nii_anat.affine)
+        nii_mask_static = nib.Nifti1Image(mask.astype(int), nii_anat.affine, header=nii_anat.header)
         self.nii_mask_static = nii_mask_static
 
         # Riro
@@ -45,7 +45,7 @@ class TestRealtimeShim(object):
                       center_dim2=int(ny / 2),
                       len_dim1=30, len_dim2=30, len_dim3=nz)
 
-        nii_mask_riro = nib.Nifti1Image(mask.astype(int), nii_anat.affine)
+        nii_mask_riro = nib.Nifti1Image(mask.astype(int), nii_anat.affine, header=nii_anat.header)
         self.nii_mask_riro = nii_mask_riro
 
         # Pmu
@@ -110,7 +110,7 @@ class TestRealtimeShim(object):
         """Wrong number of fieldmap dimensions."""
 
         fieldmap = self.nii_fieldmap.get_fdata()
-        nii_fieldmap_3d = nib.Nifti1Image(fieldmap[..., 0], self.nii_fieldmap.affine)
+        nii_fieldmap_3d = nib.Nifti1Image(fieldmap[..., 0], self.nii_anat.affine, header=self.nii_anat.header)
 
         # This should return an error
         try:
@@ -127,7 +127,7 @@ class TestRealtimeShim(object):
         """Wrong number of anat dimensions."""
 
         anat = self.nii_anat.get_fdata()
-        nii_anat_2d = nib.Nifti1Image(anat[..., 0], self.nii_fieldmap.affine)
+        nii_anat_2d = nib.Nifti1Image(anat[..., 0], self.nii_anat.affine, header=self.nii_anat.header)
 
         # This should return an error
         try:
@@ -144,7 +144,7 @@ class TestRealtimeShim(object):
         """Wrong number of static mask dimensions."""
 
         mask = self.nii_mask_static.get_fdata()
-        nii_mask_2d = nib.Nifti1Image(mask[..., 0], self.nii_fieldmap.affine)
+        nii_mask_2d = nib.Nifti1Image(mask[..., 0], self.nii_anat.affine, header=self.nii_anat.header)
 
         # This should return an error
         try:
@@ -161,7 +161,7 @@ class TestRealtimeShim(object):
         """Wrong number of riro mask dimensions."""
 
         mask = self.nii_mask_riro.get_fdata()
-        nii_mask_2d = nib.Nifti1Image(mask[..., 0], self.nii_fieldmap.affine)
+        nii_mask_2d = nib.Nifti1Image(mask[..., 0], self.nii_anat.affine, header=self.nii_anat.header)
 
         # This should return an error
         try:

--- a/test/shim/test_realtime_shim.py
+++ b/test/shim/test_realtime_shim.py
@@ -70,8 +70,8 @@ class TestRealtimeShim(object):
                                                  self.pmu,
                                                  self.json)
 
-        assert np.isclose(static_zcorrection[0], 0.1291926595061463,)
-        assert np.isclose(riro_zcorrection[0], -0.00802980555042238)
+        assert np.isclose(static_zcorrection[0], 0.12928646689120157)
+        assert np.isclose(riro_zcorrection[0], -0.007959437710556651)
         assert np.isclose(mean_p, 1326.3179660207873)
         assert np.isclose(pressure_rms, 1493.9468284155396)
 
@@ -100,6 +100,10 @@ class TestRealtimeShim(object):
                           path_output=tmp)
 
             assert len(os.listdir(tmp)) != 0
+
+            nib.save(self.nii_mask_static, os.path.join(tmp, 'fig_mask_static.nii.gz'))
+            nib.save(self.nii_mask_riro, os.path.join(tmp, 'fig_mask_riro.nii.gz'))
+            nib.save(self.nii_anat, os.path.join(tmp, 'fig_anat.nii.gz'))
 
     # Tests that should throw errors
     def test_wrong_dim_fieldmap(self):


### PR DESCRIPTION
## Description
This PR addresses issue #288 where the resampled mask could include a bigger region than masked in the anatomical image. The reason is that the mode `nearest` was used when resampling to the fieldmap as it is the default value in `shimming_toolbox/coils/coordinates.resample_from_to()`. The mode `nearest` is required for the resampling back to the anatomical so it is added to be more explicit.

This does not change any output as described in the issue since resampling back on the anatomical image removes this part added. This PR addresses this for consistency and so that the masked fieldmap can be relevant.

## To reproduce
In test/shim/test_realtime_shim:test_output_figure
Run the test in debug and look at the `tmp` folder at the last line of the test
Compare `fig_anat`, `fig_mask_static` and `fig_mask_fmap_static`

## More context

- realtime_zshim requires a mask in the anat space
- the mask is resampled in the fieldmap space
  - the resampled mask is _currently_ only used for the purpose of visualization.

However, beyond the visualization purpose, our plan is to _also_ use the mask in the fieldmap space for performing shimming experiments #280. This is the motivation to get this done properly.

## Linked issues
Fixes #288 
