### PR TITLE
Update prepare_fieldmap CLI/API to accept non siemens data more easily

### DIFF
--- a/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -6,9 +6,12 @@ import os
 import math
 import nibabel as nib
 import json
+import logging
 
 from shimmingtoolbox.load_nifti import read_nii
 from shimmingtoolbox.prepare_fieldmap import prepare_fieldmap
+
+logger = logging.getLogger(__name__)
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -39,7 +42,7 @@ def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, f
 
     PHASE: Input path of phase nifti file(s), in ascending order: echo1, echo2, etc.
     """
-
+    logger.setLevel("INFO")
     # Import phase
     list_phase = []
     echo_times = []

--- a/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -21,16 +21,21 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--unwrapper', type=click.Choice(['prelude']), default='prelude', help="Algorithm for unwrapping")
 @click.option('-o', '--output', 'fname_output', type=click.Path(), default=os.path.join(os.curdir, 'fieldmap.nii.gz'),
               help="Output filename for the fieldmap, supported types : '.nii', '.nii.gz'")
+@click.option('--autoscale-phase', 'autoscale', type=click.BOOL, default=True,
+              help="Tells wheter to auto rescale phase inputs according to manufacturer standards. If you have non "
+                   "standard data, it would be preferable to set this option to False and input your phase data from "
+                   "-pi to pi to avoid unwanted rescaling")
 @click.option('--mask', 'fname_mask', type=click.Path(exists=True), help="Input path for a mask. Used for PRELUDE")
 @click.option('--threshold', 'threshold', type=float, help="Threshold for masking. Used for: PRELUDE")
 @click.option('--gaussian-filter', 'gaussian_filter', type=bool, help="Gaussian filter for B0 map")
 @click.option('--sigma', type=float, default=1, help="Standard deviation of gaussian filter. Used for: gaussian_filter")
-def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, fname_mask, threshold, gaussian_filter, sigma):
+def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, fname_mask, threshold, gaussian_filter, sigma):
     """Creates fieldmap (in Hz) from phase images.
 
     This function accommodates multiple echoes (2 or more) and phase difference. This function also
     accommodates 4D phase inputs, where the 4th dimension represents the time, in case multiple
     field maps are acquired across time for the purpose of real-time shimming experiments.
+    For non standard phase data, see --autoscale-phase option.
 
     PHASE: Input path of phase nifti file(s), in ascending order: echo1, echo2, etc.
     """
@@ -39,7 +44,7 @@ def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, fname_mask, 
     list_phase = []
     echo_times = []
     for i_echo in range(len(phase)):
-        nii_phase, json_phase, phase_img = read_nii(phase[i_echo], auto_scale=True)
+        nii_phase, json_phase, phase_img = read_nii(phase[i_echo], auto_scale=autoscale)
         # Add pi since read_nii returns phase between 0 and 2pi whereas prepare_fieldmap accepts between -pi to pi
         phase_img -= math.pi
 

--- a/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -96,3 +96,5 @@ def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, f
     fname_json = fname_output.rsplit('.nii', 1)[0] + '.json'
     with open(fname_json, 'w') as outfile:
         json.dump(json_fieldmap, outfile, indent=2)
+
+    logger.info(f"Filename of the fieldmap is: {fname_output}")

--- a/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -31,7 +31,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               help="Tells whether to auto rescale phase inputs according to manufacturer standards. If you have non "
                    "standard data, it would be preferable to set this option to False and input your phase data from "
                    "-pi to pi to avoid unwanted rescaling")
-@click.option('--mask', 'fname_mask', type=click.Path(exists=True), help="Input path for a mask. Used for PRELUDE")
+@click.option('--mask', 'fname_mask', type=click.Path(exists=True),
+              help="Input path for a mask. Mask must be the same shape as the array of each PHASE input."
+                   "Used for PRELUDE")
 @click.option('--threshold', 'threshold', type=float, help="Threshold for masking. Used for: PRELUDE")
 @click.option('--gaussian-filter', 'gaussian_filter', type=bool, show_default=True, help="Gaussian filter for B0 map")
 @click.option('--sigma', type=float, default=1, help="Standard deviation of gaussian filter. Used for: gaussian_filter")

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -188,11 +188,11 @@ def read_nii(fname_nifti, auto_scale=True):
         elif ('Manufacturer' in json_data) and (json_data['Manufacturer'] == 'Siemens') \
                 and (('ImageComments' in json_data) and ("*phase*" in json_data['ImageComments'])
                      or ('ImageType' in json_data) and ('P' in json_data['ImageType'])):
-            # Bootstrap
+            # Bootstrap, rescales from -pi to pi
             if np.amin(image) < 0:
-                image = image * (2 * math.pi / (PHASE_SCALING_SIEMENS * 2)) + math.pi
+                image = image * (2 * math.pi / (PHASE_SCALING_SIEMENS * 2))
             else:
-                image = image * (2 * math.pi / PHASE_SCALING_SIEMENS)
+                image = image * (2 * math.pi / PHASE_SCALING_SIEMENS) - math.pi
         else:
             logger.info("Unknown nifti type: No scaling applied")
     else:

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -54,6 +54,7 @@ def load_nifti(path_data, modality='phase'):
         If 'path' is a folder containing niftis, directly output niftis. It 'path' is a folder containing acquisitions,
         ask the user for which acquisition to use.
     """
+
     if not os.path.exists(path_data):
         raise RuntimeError("Not an existing NIFTI path")
 
@@ -66,9 +67,9 @@ def load_nifti(path_data, modality='phase'):
     # Check for incompatible acquisition source path
     if all([os.path.isdir(f) for f in file_list]):
         acquisitions = [f for f in file_list if os.path.isdir(f)]
-        logging.info("Multiple acquisition directories in path. Choosing only one.")
+        logger.info("Multiple acquisition directories in path. Choosing only one.")
     elif all([os.path.isfile(f) for f in file_list]):
-        logging.info("Acquisition directory given. Using acquisitions.")
+        logger.info("Acquisition directory given. Using acquisitions.")
         nifti_path = path_data
     else:
         raise RuntimeError("Directories and files in input path")
@@ -89,7 +90,7 @@ def load_nifti(path_data, modality='phase'):
             if select_acquisition in range(len(acquisitions)):
                 break
             else:
-                logging.error(f"Input must be linked to an acquisition folder. {input_resp} is out of range")
+                logger.error(f"Input must be linked to an acquisition folder. {input_resp} is out of range")
 
         nifti_path = os.path.abspath(file_list[select_acquisition])
 
@@ -126,10 +127,10 @@ def load_nifti(path_data, modality='phase'):
             if select_run in list(run_list.keys()):
                 break
             else:
-                logging.error(f"Input must be linked to a run number. {input_resp} is out of range")
+                logger.error(f"Input must be linked to a run number. {input_resp} is out of range")
     else:
         select_run = list(run_list.keys())[0]
-        logging.info(f"Reading acquisitions for run {list(run_list.keys())[0]}")
+        logger.info(f"Reading acquisitions for run {list(run_list.keys())[0]}")
 
     # Create output array and headers
     nifti_pos = 0
@@ -178,7 +179,7 @@ def read_nii(fname_nifti, auto_scale=True):
     image = np.asarray(info.dataobj)
 
     if auto_scale:
-        logging.info("Scaling the selected nifti")
+        logger.info("Scaling the selected nifti")
         # If Siemens' TurboFLASH B1 mapping (dcm2niix cannot separate phase and magnitude for this sequence)
         if ('SequenceName' in json_data) and 'tfl2d1_16' in json_data['SequenceName']:
             image = scale_tfl_b1(image, json_data)
@@ -193,9 +194,9 @@ def read_nii(fname_nifti, auto_scale=True):
             else:
                 image = image * (2 * math.pi / PHASE_SCALING_SIEMENS)
         else:
-            logging.info("Unknown nifti type: No scaling applied")
+            logger.info("Unknown nifti type: No scaling applied")
     else:
-        logging.info("No scaling applied to selected nifti")
+        logger.info("No scaling applied to selected nifti")
 
     return info, json_data, image
 

--- a/shimmingtoolbox/prepare_fieldmap.py
+++ b/shimmingtoolbox/prepare_fieldmap.py
@@ -33,7 +33,14 @@ def prepare_fieldmap(phase, echo_times, affine, unwrapper='prelude', mag=None, m
     for i_echo in range(len(phase)):
         # Check that the output phase is in radian (Note: the test below is not 100% bullet proof)
         if (phase[i_echo].max() > math.pi) or (phase[i_echo].min() < -math.pi):
-            raise RuntimeError("read_nii must range from -pi to pi.")
+
+            # If this is a rounding error from saving niftis, let it go, the algorithm can handle the difference.
+            if (phase[i_echo].max() > math.pi + 1e-6) or (phase[i_echo].min() < -math.pi - 1e-6):
+                raise RuntimeError("read_nii must range from -pi to pi.")
+            else:
+                pass
+                # phase[i_echo][phase[i_echo] > math.pi] = math.pi
+                # phase[i_echo][phase[i_echo] < -math.pi] = -math.pi
 
     # Check that the input echotimes are the appropriate size by looking at phase
     is_phasediff = (len(phase) == 1 and len(echo_times) == 2)

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -14,6 +14,8 @@ import numpy as np
 
 from shimmingtoolbox.utils import run_subprocess
 
+logger = logging.getLogger(__name__)
+
 
 def prelude(wrapped_phase, affine, mag=None, mask=None, threshold=None, is_unwrapping_in_2d=False):
     """wrapper to FSL prelude
@@ -72,14 +74,14 @@ def prelude(wrapped_phase, affine, mag=None, mask=None, threshold=None, is_unwra
     if threshold is not None:
         options += ' -t {}'.format(threshold)
         if mask is not None:
-            logging.warning('Specifying both a mask and a threshold is not recommended, results might not be what is '
-                            'expected')
+            logger.warning('Specifying both a mask and a threshold is not recommended, results might not be what is '
+                           'expected')
 
     # Unwrap
     unwrap_command = 'prelude -p {} -a {} -o {}{}'.format(os.path.join(path_tmp, 'rawPhase'),
                                                           os.path.join(path_tmp, 'mag'),
                                                           os.path.join(path_tmp, 'rawPhase_unwrapped'), options)
-    logging.info('Unwrap with prelude')
+    logger.debug('Unwrap with prelude')
     run_subprocess(unwrap_command)
 
     fname_phase_unwrapped = glob.glob(os.path.join(path_tmp, 'rawPhase_unwrapped*'))[0]

--- a/shimmingtoolbox/unwrap/unwrap_phase.py
+++ b/shimmingtoolbox/unwrap/unwrap_phase.py
@@ -3,7 +3,11 @@
 """ Wrapper to different unwrapping algorithms. """
 
 import numpy as np
+import logging
+
 from shimmingtoolbox.unwrap.prelude import prelude
+
+logger = logging.getLogger(__name__)
 
 
 def unwrap_phase(phase, affine, unwrapper='prelude', mag=None, mask=None, threshold=None):
@@ -39,14 +43,18 @@ def unwrap_phase(phase, affine, unwrapper='prelude', mag=None, mask=None, thresh
             mag = mag4d
             mask = mask4d
 
+            logger.info(f"Unwrapping 1 volume")
             phase3d_unwrapped = prelude(phase4d, affine, mag=mag, mask=mask, threshold=threshold)
 
             phase_unwrapped = phase3d_unwrapped[..., 0]
 
         elif phase.ndim == 3:
+            logger.info("Unwrapping 1 volume")
             phase_unwrapped = prelude(phase, affine, mag=mag, mask=mask, threshold=threshold)
 
         elif phase.ndim == 4:
+
+            logger.info(f"Unwrapping {phase.shape[3]} volumes")
             phase_unwrapped = np.zeros_like(phase)
             for i_t in range(phase.shape[3]):
                 mask3d = None

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -126,3 +126,24 @@ def create_output_dir(path_output, is_file=False, output_folder_name="output"):
         path_output_folder = path_output
     if not os.path.exists(path_output_folder):
         os.makedirs(path_output_folder)
+
+
+def create_fname_from_path(path, file_default):
+    """Given a path, make sure it is not a directory, if it is add the default filename, if not, return the path
+
+    Args:
+        path (str): filename or path to add the `file_default` to.
+        file_default (str): Name of the file + ext (example.nii.gz) to add to the path if the path is a directory.
+
+    Returns:
+        str: Absolute path of a file
+    """
+
+    is_dir = os.path.splitext(path)[-1] == ''
+
+    if is_dir:
+        fname = os.path.join(path, file_default)
+    else:
+        fname = path
+
+    return os.path.abspath(fname)

--- a/test/cli/test_cli_prepare_fieldmap.py
+++ b/test/cli/test_cli_prepare_fieldmap.py
@@ -126,3 +126,36 @@ def test_cli_prepare_fieldmap_autoscale():
         assert result.exit_code == 0
         assert os.path.isfile(fname_output)
         assert os.path.isfile(os.path.join(tmp, 'fieldmap.json'))
+
+
+def test_cli_prepare_fieldmap_wrong_ext():
+
+    runner = CliRunner()
+
+    fname_phasediff = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                                   'sub-example_phasediff.nii.gz')
+    fname_mag = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                             'sub-example_magnitude1.nii.gz')
+    fname_output = 'fieldmap.txt'
+
+    with pytest.raises(ValueError, match="Output filename must have one of the following extensions: '.nii', '.nii.gz'"):
+        runner.invoke(prepare_fieldmap_cli, [fname_phasediff, '--mag', fname_mag, '--output', fname_output],
+                      catch_exceptions=False)
+
+
+@pytest.mark.prelude
+def test_cli_prepare_fieldmap_default_fname_output():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        fname_phasediff = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                                       'sub-example_phasediff.nii.gz')
+        fname_mag = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                                 'sub-example_magnitude1.nii.gz')
+
+        result = runner.invoke(prepare_fieldmap_cli, [fname_phasediff, '--mag', fname_mag, '--output', tmp],
+                               catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(os.path.join(tmp, 'fieldmap.nii.gz'))
+        assert os.path.isfile(os.path.join(tmp, 'fieldmap.json'))

--- a/test/cli/test_cli_prepare_fieldmap.py
+++ b/test/cli/test_cli_prepare_fieldmap.py
@@ -6,9 +6,14 @@ import os
 import pathlib
 import tempfile
 import pytest
+import nibabel as nib
+import numpy as np
+from shutil import copyfile
 
 from shimmingtoolbox.cli.prepare_fieldmap import prepare_fieldmap_cli
 from shimmingtoolbox import __dir_testing__
+
+PHASE_SCALING_SIEMENS = 4095
 
 
 @pytest.mark.prelude
@@ -82,6 +87,41 @@ def test_cli_prepare_fieldmap_gaussian():
         result = runner.invoke(prepare_fieldmap_cli, [fname_phasediff, '--mag', fname_mag, '--output', fname_output,
                                                       '--gaussian-filter', 'True', '--sigma', 1],
                                catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output)
+        assert os.path.isfile(os.path.join(tmp, 'fieldmap.json'))
+
+
+@pytest.mark.prelude
+def test_cli_prepare_fieldmap_autoscale():
+    """Tests the CLI with autoscale False"""
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        # Rescale input data to -pi to pi and save in tmp directory
+        fname_phasediff = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                                       'sub-example_phasediff.nii.gz')
+        nii_phasediff = nib.load(fname_phasediff)
+        phasediff = nii_phasediff.get_fdata()
+        rescaled = phasediff * (2 * np.pi / PHASE_SCALING_SIEMENS) - np.pi
+        nii_rescaled = nib.Nifti1Image(rescaled, nii_phasediff.affine, header=nii_phasediff.header)
+        fname_rescaled = os.path.join(tmp, 'rescaled_phasediff.nii.gz')
+        nib.save(nii_rescaled, fname_rescaled)
+
+        # Copy the json file next to the new phase data (required by read_nii)
+        fname_json = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                                  'sub-example_phasediff.json')
+        fname_json_tmp = os.path.join(tmp, 'rescaled_phasediff.json')
+        copyfile(fname_json, fname_json_tmp)
+
+        # Set up other paths
+        fname_mag = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
+                                 'sub-example_magnitude1.nii.gz')
+        fname_output = os.path.join(tmp, 'fieldmap.nii.gz')
+
+        result = runner.invoke(prepare_fieldmap_cli, [fname_rescaled, '--mag', fname_mag, '--output', fname_output,
+                                                      '--autoscale-phase', 'False'], catch_exceptions=False)
 
         assert result.exit_code == 0
         assert os.path.isfile(fname_output)

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -435,7 +435,7 @@ class TestCore(object):
 
         assert nii.shape == (64, 96, 1, 10)
         assert ('P' in json_info['ImageType'])
-        assert (phasediff.max() <= 2 * math.pi) and (phasediff.min() >= 0)
+        assert (phasediff.max() <= math.pi) and (phasediff.min() >= -math.pi)
 
     def test_read_nii_b1(self):
         fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'sub-01_run-10_TB1map.nii.gz')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,9 @@
 import tempfile
 import pathlib
 import os
+
 from shimmingtoolbox.utils import create_output_dir
+from shimmingtoolbox.utils import create_fname_from_path
 
 
 def test_create_output_dir_folder():
@@ -27,3 +29,30 @@ def test_create_output_dir_folder_exists():
         assert os.path.exists(path_output)
         create_output_dir(path_output, is_file=False)
         assert os.path.exists(path_output)
+
+
+def test_create_fname_from_path():
+    path = 'a/b/c'
+    file = 'file.nii'
+
+    fname = create_fname_from_path(path, file)
+
+    assert fname == os.path.abspath("a/b/c/file.nii")
+
+
+def test_create_fname_from_path_fname():
+    path = 'a/b/c/file.nii'
+    file = 'file2.nii'
+
+    fname = create_fname_from_path(path, file)
+
+    assert fname == os.path.abspath("a/b/c/file.nii")
+
+
+def test_create_fname_from_path_2():
+    path = '.'
+    file = 'file.nii'
+
+    fname = create_fname_from_path(path, file)
+
+    assert fname == os.path.abspath("./file.nii")


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

## Description
The current implementation of `st_prepare_fieldmap` easily accommodates siemens data that comes from the scanner. However, it is not obvious what the input should be for non siemens data. This PR aims to remedy that.

More precisely, this PR 
- Updates the CLI description to provide insights on the input units. 
- Includes an option to rescale or not rescale the input data.
- Makes read_nii and prepare_fieldmap consistent for the phase units output/input respectively (-pi to pi)
- Updates the logger to display relevant information on the terminal

## Linked issues
Fixes #293