### PR TITLE
Change command that checks for sct installation

### DIFF
--- a/shimmingtoolbox/cli/check_env.py
+++ b/shimmingtoolbox/cli/check_env.py
@@ -122,7 +122,8 @@ def check_sct_installation():
         bool: True if sct is installed, False if not.
     """
     try:
-        subprocess.check_call(['which', 'sct_check_dependencies'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.check_call(['sct_check_dependencies', '-short'], stdout=subprocess.DEVNULL,
+                              stderr=subprocess.DEVNULL)
     except subprocess.CalledProcessError as error:
         print_fail()
         print(f"Error {error.returncode}: Spinal Cord Toolbox is not installed or not in your PATH.")

--- a/shimmingtoolbox/cli/check_env.py
+++ b/shimmingtoolbox/cli/check_env.py
@@ -123,7 +123,7 @@ def check_sct_installation():
     """
     try:
         subprocess.check_call(['sct_check_dependencies', '-short'], stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL)
+                              stderr=subprocess.DEVNULL, shell=True)
     except subprocess.CalledProcessError as error:
         print_fail()
         print(f"Error {error.returncode}: Spinal Cord Toolbox is not installed or not in your PATH.")


### PR DESCRIPTION
## Description
SCT can be installed at different places in the OS and removed which can lead to `which sct_scheck_dependencies` to display a path but actually using sct_check_dependencies will return an error since sct is not installed anymore. This outputs an error on the terminal which is not the correct behaviour. This can be solved by using `sct_check_dependencies` instead of the `which`.
