### PR TITLE
removed ubuntu 16 from test.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,6 @@ jobs:
           # - 'macos-11.0'
           - 'ubuntu-18.04'
           - 'ubuntu-20.04'
-          - 'ubuntu-16.04'
         python-version:
           - '3.7'
           - '3.8'


### PR DESCRIPTION
## Description
Ubuntu 16.04 will be deprecated as of 2021-09-20 so it should not be tested anymore in our CI workflow.

## Linked issues
#300 