### PR TITLE
Updates fieldmapping APIs/CLIs to output proper NIfTI

### DIFF
--- a/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -88,7 +88,7 @@ def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, f
     else:
         mask = None
 
-    fieldmap_hz = prepare_fieldmap(list_phase, echo_times, mag=mag, unwrapper=unwrapper,
+    fieldmap_hz = prepare_fieldmap(list_nii_phase, echo_times, mag=mag, unwrapper=unwrapper,
                                    mask=mask, threshold=threshold, gaussian_filter=gaussian_filter,
                                    sigma=sigma)
 

--- a/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -55,12 +55,12 @@ def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, f
         raise ValueError("Output filename must have one of the following extensions: '.nii', '.nii.gz'")
 
     # Import phase
-    list_phase = []
+    list_nii_phase = []
     echo_times = []
     for i_echo in range(len(phase)):
         nii_phase, json_phase, phase_img = read_nii(phase[i_echo], auto_scale=autoscale)
 
-        list_phase.append(phase_img)
+        list_nii_phase.append(nii_phase)
         # Special case for echo_times if input is a phasediff
         if len(phase) == 1:
             # Check that the input phase is indeed a phasediff, by checking the existence of two echo times in the
@@ -88,7 +88,7 @@ def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, f
     else:
         mask = None
 
-    fieldmap_hz = prepare_fieldmap(list_phase, echo_times, affine, mag=mag, unwrapper=unwrapper,
+    fieldmap_hz = prepare_fieldmap(list_phase, echo_times, mag=mag, unwrapper=unwrapper,
                                    mask=mask, threshold=threshold, gaussian_filter=gaussian_filter,
                                    sigma=sigma)
 

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -193,9 +193,12 @@ def read_nii(fname_nifti, auto_scale=True):
                 image = image * (2 * math.pi / (PHASE_SCALING_SIEMENS * 2))
             else:
                 image = image * (2 * math.pi / PHASE_SCALING_SIEMENS) - math.pi
-            nii = nib.Nifti1Image(image, nii.affine, header=nii.header)
         else:
             logger.info("Unknown nifti type: No scaling applied")
+
+        # Create new nibabel object with updated image
+        nii = nib.Nifti1Image(image, nii.affine, header=nii.header)
+
     else:
         logger.info("No scaling applied to selected nifti")
 

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -166,7 +166,7 @@ def read_nii(fname_nifti, auto_scale=True):
         For RF-maps, complex array of dimension (x, y, slice, coil) with phase between -pi and pi.
     """
 
-    info = nib.load(fname_nifti)
+    nii = nib.load(fname_nifti)
     # `extractBefore` should get the correct filename in both.nii and.nii.gz cases
     json_path = fname_nifti.split('.nii')[0] + '.json'
 
@@ -176,7 +176,7 @@ def read_nii(fname_nifti, auto_scale=True):
         raise OSError("Missing json file")
 
     # Store nifti image in a numpy array
-    image = np.asarray(info.dataobj)
+    image = np.asarray(nii.dataobj)
 
     if auto_scale:
         logger.info("Scaling the selected nifti")
@@ -193,12 +193,13 @@ def read_nii(fname_nifti, auto_scale=True):
                 image = image * (2 * math.pi / (PHASE_SCALING_SIEMENS * 2))
             else:
                 image = image * (2 * math.pi / PHASE_SCALING_SIEMENS) - math.pi
+            nii = nib.Nifti1Image(image, nii.affine, header=nii.header)
         else:
             logger.info("Unknown nifti type: No scaling applied")
     else:
         logger.info("No scaling applied to selected nifti")
 
-    return info, json_data, image
+    return nii, json_data, image
 
 
 def scale_tfl_b1(image, json_data):

--- a/shimmingtoolbox/prepare_fieldmap.py
+++ b/shimmingtoolbox/prepare_fieldmap.py
@@ -39,7 +39,7 @@ def prepare_fieldmap(list_nii_phase, echo_times, unwrapper='prelude', mag=None, 
 
             # If this is a rounding error from saving niftis, let it go, the algorithm can handle the difference.
             if (phase[i_echo].max() > math.pi + 1e-6) or (phase[i_echo].min() < -math.pi - 1e-6):
-                raise RuntimeError("read_nii must range from -pi to pi.")
+                raise ValueError("Values must range from -pi to pi.")
             else:
                 pass
                 # phase[i_echo][phase[i_echo] > math.pi] = math.pi
@@ -49,18 +49,18 @@ def prepare_fieldmap(list_nii_phase, echo_times, unwrapper='prelude', mag=None, 
     is_phasediff = (len(phase) == 1 and len(echo_times) == 2)
     if not is_phasediff:
         if len(phase) != len(echo_times) or (len(phase) == 1 and len(echo_times) == 1):
-            raise RuntimeError("Phasediff must have 2 echotime points. Otherwise the number of echoes must match the"
-                               " number of echo times.")
+            raise ValueError("The number of echoes must match the number of echo times unless there is 1 echo, which "
+                             "requires 2 echo_times")
 
     # Make sure mag is the right shape
     if mag is not None:
         if mag.shape != phase[0].shape:
-            raise RuntimeError("mag and phase must have the same dimensions.")
+            raise ValueError("mag and phase must have the same dimensions.")
 
     # Make sure mask has the right shape
     if mask is not None:
         if mask.shape != phase[0].shape:
-            raise RuntimeError("Shape of mask and phase must match.")
+            raise ValueError("Shape of mask and phase must match.")
 
     # Get the time between echoes and calculate phase difference depending on number of echoes
     if len(phase) == 1:

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -50,7 +50,9 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
 
     # Save phase and mag images
     nib.save(nii_wrapped_phase, os.path.join(path_tmp, 'rawPhase.nii'))
-    nii_mag = nib.Nifti1Image(mag, nii_wrapped_phase.affine, header=nii_wrapped_phase.header)
+    header = nii_wrapped_phase.header
+    header['descrip'] = "mag"
+    nii_mag = nib.Nifti1Image(mag, nii_wrapped_phase.affine, header=header)
     nib.save(nii_mag, os.path.join(path_tmp, 'mag.nii'))
 
     # Fill options

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -17,7 +17,7 @@ from shimmingtoolbox.utils import run_subprocess
 logger = logging.getLogger(__name__)
 
 
-def prelude(wrapped_phase, affine, mag=None, mask=None, threshold=None, is_unwrapping_in_2d=False):
+def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrapping_in_2d=False):
     """wrapper to FSL prelude
 
     This function enables phase unwrapping by calling FSL prelude on the command line. A mask can be provided to mask
@@ -25,10 +25,7 @@ def prelude(wrapped_phase, affine, mag=None, mask=None, threshold=None, is_unwra
     can optionally be saved.
 
     Args:
-        wrapped_phase (numpy.ndarray): 2D or 3D radian numpy array to perform phase unwrapping. (2 pi interval)
-        affine (numpy.ndarray): 2D array containing the transformation coefficients. Can be calculated by using:
-            nii = nib.load("nii_path")
-            affine = nii.affine
+        nii_wrapped_phase (nib.Nifti1Image): 2D or 3D radian numpy array to perform phase unwrapping. (2 pi interval)
         mag (numpy.ndarray): 2D or 3D magnitude numpy array corresponding to the phase array
         mask (numpy.ndarray, optional): numpy array of booleans with shape of `complex_array` to mask during phase
                                         unwrapping
@@ -38,6 +35,7 @@ def prelude(wrapped_phase, affine, mag=None, mask=None, threshold=None, is_unwra
     Returns:
         numpy.ndarray: 3D array with the shape of `complex_array` of the unwrapped phase output from prelude
     """
+    wrapped_phase = nii_wrapped_phase.get_fdata()
     # Make sure phase and mag are the right shape
     if wrapped_phase.ndim not in [2, 3]:
         raise RuntimeError("Wrapped_phase must be 2d or 3d")
@@ -51,9 +49,8 @@ def prelude(wrapped_phase, affine, mag=None, mask=None, threshold=None, is_unwra
     path_tmp = tmp.name
 
     # Save phase and mag images
-    nii_phase = nib.Nifti1Image(wrapped_phase, affine)
-    nib.save(nii_phase, os.path.join(path_tmp, 'rawPhase.nii'))
-    nii_mag = nib.Nifti1Image(mag, affine)
+    nib.save(nii_wrapped_phase, os.path.join(path_tmp, 'rawPhase.nii'))
+    nii_mag = nib.Nifti1Image(mag, nii_wrapped_phase.affine, header=nii_wrapped_phase.header)
     nib.save(nii_mag, os.path.join(path_tmp, 'mag.nii'))
 
     # Fill options
@@ -65,7 +62,7 @@ def prelude(wrapped_phase, affine, mag=None, mask=None, threshold=None, is_unwra
     if mask is not None:
         if mask.shape != wrapped_phase.shape:
             raise RuntimeError("Mask must be the same shape as wrapped_phase")
-        nii_mask = nib.Nifti1Image(mask, affine)
+        nii_mask = nib.Nifti1Image(mask, nii_wrapped_phase.affine, header=nii_wrapped_phase.header)
 
         options += ' -m '
         options += os.path.join(path_tmp, 'mask.nii')

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -38,10 +38,10 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
     wrapped_phase = nii_wrapped_phase.get_fdata()
     # Make sure phase and mag are the right shape
     if wrapped_phase.ndim not in [2, 3]:
-        raise RuntimeError("Wrapped_phase must be 2d or 3d")
+        raise ValueError("Wrapped_phase must be 2d or 3d")
     if mag is not None:
         if wrapped_phase.shape != mag.shape:
-            raise RuntimeError("The magnitude image (mag) must be the same shape as wrapped_phase")
+            raise ValueError("The magnitude image (mag) must be the same shape as wrapped_phase")
     else:
         mag = np.zeros_like(wrapped_phase)
 
@@ -61,7 +61,7 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
     # Add mask data and options if there is a mask provided
     if mask is not None:
         if mask.shape != wrapped_phase.shape:
-            raise RuntimeError("Mask must be the same shape as wrapped_phase")
+            raise ValueError("Mask must be the same shape as wrapped_phase")
         nii_mask = nib.Nifti1Image(mask, nii_wrapped_phase.affine, header=nii_wrapped_phase.header)
 
         options += ' -m '

--- a/shimmingtoolbox/unwrap/unwrap_phase.py
+++ b/shimmingtoolbox/unwrap/unwrap_phase.py
@@ -75,7 +75,7 @@ def unwrap_phase(nii_phase_wrapped, unwrapper='prelude', mag=None, mask=None, th
                 phase_unwrapped[..., i_t] = prelude(nii_4d, mag=mag_input, mask=mask_input, threshold=threshold)
 
         else:
-            raise RuntimeError("Shape of input phase is not supported.")
+            raise ValueError("Shape of input phase is not supported.")
 
     else:
         raise NotImplementedError(f'The unwrap function {unwrapper} is not implemented.')

--- a/shimmingtoolbox/unwrap/unwrap_phase.py
+++ b/shimmingtoolbox/unwrap/unwrap_phase.py
@@ -4,22 +4,20 @@
 
 import numpy as np
 import logging
+import nibabel as nib
 
 from shimmingtoolbox.unwrap.prelude import prelude
 
 logger = logging.getLogger(__name__)
 
 
-def unwrap_phase(phase, affine, unwrapper='prelude', mag=None, mask=None, threshold=None):
+def unwrap_phase(nii_phase_wrapped, unwrapper='prelude', mag=None, mask=None, threshold=None):
     """ Calls different unwrapping algorithms according to the specified `unwrapper` parameter. The function also
     allows to call the different unwrappers with more flexibility regarding input shape.
 
     Args:
-        phase (numpy.ndarray): 2D, 3D or 4D radian values [-pi to pi] to perform phase unwrapping.
-                               Supported shapes: [x, y], [x, y, z] or [x, y, z, t].
-        affine (numpy.ndarray): 2D array (4x4) containing the transformation coefficients. Can be acquired by :
-            nii = nib.load("nii_path")
-            affine = nii.affine
+        nii_phase_wrapped (nib.Nifti1Image): 2D, 3D or 4D radian values [-pi to pi] to perform phase unwrapping.
+                                             Supported shapes: [x, y], [x, y, z] or [x, y, z, t].
         unwrapper (str, optional): Unwrapper algorithm name. Possible values: ``prelude``.
         mag (numpy.ndarray): 2D, 3D or 4D magnitude data corresponding to phase data. Shape must be the same as
                      ``phase``.
@@ -30,46 +28,51 @@ def unwrap_phase(phase, affine, unwrapper='prelude', mag=None, mask=None, thresh
         numpy.ndarray: Unwrapped phase image.
     """
 
-    if unwrapper == 'prelude':
-        mag4d = None
-        mask4d = None
-        if phase.ndim == 2:
-            phase4d = np.expand_dims(phase, -1)
-            if mag is not None:
-                mag4d = np.expand_dims(mag, -1)
-            if mask is not None:
-                mask4d = np.expand_dims(mask, -1)
+    phase = nii_phase_wrapped.get_fdata()
 
-            mag = mag4d
-            mask = mask4d
+    if unwrapper == 'prelude':
+        mag2d = None
+        mask2d = None
+        if phase.ndim == 2:
+            phase2d = np.expand_dims(phase, -1)
+            if mag is not None:
+                mag2d = np.expand_dims(mag, -1)
+            if mask is not None:
+                mask2d = np.expand_dims(mask, -1)
+
+            mag = mag2d
+            mask = mask2d
+            nii_2d = nib.Nifti1Image(phase2d, nii_phase_wrapped.affine, header=nii_phase_wrapped.header)
 
             logger.info(f"Unwrapping 1 volume")
-            phase3d_unwrapped = prelude(phase4d, affine, mag=mag, mask=mask, threshold=threshold)
+            phase3d_unwrapped = prelude(nii_2d, mag=mag, mask=mask, threshold=threshold)
 
             phase_unwrapped = phase3d_unwrapped[..., 0]
 
         elif phase.ndim == 3:
             logger.info("Unwrapping 1 volume")
-            phase_unwrapped = prelude(phase, affine, mag=mag, mask=mask, threshold=threshold)
+            phase_unwrapped = prelude(nii_phase_wrapped, mag=mag, mask=mask, threshold=threshold)
 
         elif phase.ndim == 4:
 
             logger.info(f"Unwrapping {phase.shape[3]} volumes")
             phase_unwrapped = np.zeros_like(phase)
             for i_t in range(phase.shape[3]):
-                mask3d = None
-                mag3d = None
+                mask4d = None
+                mag4d = None
 
-                phase3d = phase[..., i_t]
+                phase4d = phase[..., i_t]
+                nii_4d = nib.Nifti1Image(phase4d, nii_phase_wrapped.affine, header=nii_phase_wrapped.header)
+
                 if mag is not None:
-                    mag3d = mag[..., i_t]
+                    mag4d = mag[..., i_t]
                 if mask is not None:
-                    mask3d = mask[..., i_t]
+                    mask4d = mask[..., i_t]
 
-                mask_input = mask3d
-                mag_input = mag3d
+                mask_input = mask4d
+                mag_input = mag4d
 
-                phase_unwrapped[..., i_t] = prelude(phase3d, affine, mag=mag_input, mask=mask_input, threshold=threshold)
+                phase_unwrapped[..., i_t] = prelude(nii_4d, mag=mag_input, mask=mask_input, threshold=threshold)
 
         else:
             raise RuntimeError("Shape of input phase is not supported.")

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -45,24 +45,25 @@ def add_suffix(fname, suffix):
     - ``add_suffix(t2.nii.gz, a)`` -> ``t2a.nii.gz``
     """
 
-    def _splitext(fname):
-        """
-        Split a fname (folder/file + ext) into a folder/file and extension.
-
-        Note: for .nii.gz the extension is understandably .nii.gz, not .gz
-        (``os.path.splitext()`` would want to do the latter, hence the special case).
-        """
-        dir, filename = os.path.split(fname)
-        for special_ext in ['.nii.gz', '.tar.gz']:
-            if filename.endswith(special_ext):
-                stem, ext = filename[:-len(special_ext)], special_ext
-                return os.path.join(dir, stem), ext
-        # If no special case, behaves like the regular splitext
-        stem, ext = os.path.splitext(filename)
-        return os.path.join(dir, stem), ext
-
-    stem, ext = _splitext(fname)
+    stem, ext = splitext(fname)
     return os.path.join(stem + suffix + ext)
+
+
+def splitext(fname):
+    """
+    Split a fname (folder/file + ext) into a folder/file and extension.
+
+    Note: for .nii.gz the extension is understandably .nii.gz, not .gz
+    (``os.path.splitext()`` would want to do the latter, hence the special case).
+    """
+    dir, filename = os.path.split(fname)
+    for special_ext in ['.nii.gz', '.tar.gz']:
+        if filename.endswith(special_ext):
+            stem, ext = filename[:-len(special_ext)], special_ext
+            return os.path.join(dir, stem), ext
+    # If no special case, behaves like the regular splitext
+    stem, ext = os.path.splitext(filename)
+    return os.path.join(dir, stem), ext
 
 
 def iso_times_to_ms(iso_times):

--- a/test/test_unwrap_phase.py
+++ b/test/test_unwrap_phase.py
@@ -17,8 +17,8 @@ class TestUnwrapPhase(object):
         fname_phase = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
                                    'sub-example_phasediff.nii.gz')
         nii_phase = nib.load(fname_phase)
-        self.phase = (nii_phase.get_fdata() * 2 * math.pi / 4095) - math.pi  # [-pi, pi]
-        self.affine = nii_phase.affine
+        phase = (nii_phase.get_fdata() * 2 * math.pi / 4095) - math.pi  # [-pi, pi]
+        self.nii_phase = nib.Nifti1Image(phase, nii_phase.affine, header=nii_phase.header)
         fname_mag = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
                                  'sub-example_magnitude1.nii.gz')
         nii_mag = nib.load(fname_mag)
@@ -26,65 +26,57 @@ class TestUnwrapPhase(object):
 
     def test_unwrap_phase_prelude_4d(self):
         """Test prelude with 4d input data."""
-        unwrapped = unwrap_phase(self.phase, self.affine, unwrapper='prelude', mag=self.mag)
-        assert unwrapped.shape == self.phase.shape
+        unwrapped = unwrap_phase(self.nii_phase, unwrapper='prelude', mag=self.mag)
+        assert unwrapped.shape == self.nii_phase.shape
 
     def test_unwrap_phase_prelude_3d(self):
         """Test prelude with 3d input data."""
-        phase = self.phase[..., 0]
+        phase = self.nii_phase.get_fdata()[..., 0]
+        nii = nib.Nifti1Image(phase, self.nii_phase.affine, header=self.nii_phase.header)
         mag = self.mag[..., 0]
-        unwrapped = unwrap_phase(phase, self.affine, unwrapper='prelude', mag=mag)
+
+        unwrapped = unwrap_phase(nii, unwrapper='prelude', mag=mag)
         assert unwrapped.shape == phase.shape
 
     def test_unwrap_phase_prelude_2d(self):
         """Test prelude with 2d input data."""
-        phase = self.phase[..., 0, 0]
+        phase = self.nii_phase.get_fdata()[..., 0, 0]
+        nii = nib.Nifti1Image(phase, self.nii_phase.affine, header=self.nii_phase.header)
         mag = self.mag[..., 0, 0]
-        unwrapped = unwrap_phase(phase, self.affine, unwrapper='prelude', mag=mag)
+
+        unwrapped = unwrap_phase(nii, unwrapper='prelude', mag=mag)
         assert unwrapped.shape == phase.shape
 
     def test_unwrap_phase_prelude_threshold(self):
         """Test prelude with threshold parameter."""
-        unwrapped = unwrap_phase(self.phase, self.affine, unwrapper='prelude', mag=self.mag, threshold=0.1)
-        assert unwrapped.shape == self.phase.shape
+        unwrapped = unwrap_phase(self.nii_phase, unwrapper='prelude', mag=self.mag, threshold=0.1)
+        assert unwrapped.shape == self.nii_phase.shape
 
     def test_unwrap_phase_prelude_4d_mask(self):
         """Test prelude with mask parameter."""
-        unwrapped = unwrap_phase(self.phase, self.affine, unwrapper='prelude', mag=self.mag,
-                                 mask=np.ones_like(self.phase))
-        assert unwrapped.shape == self.phase.shape
+        unwrapped = unwrap_phase(self.nii_phase, unwrapper='prelude', mag=self.mag,
+                                 mask=np.ones(self.nii_phase.shape))
+        assert unwrapped.shape == self.nii_phase.shape
 
     def test_unwrap_phase_prelude_2d_mask(self):
         """Test prelude with 2d mask parameter."""
-        phase = self.phase[..., 0, 0]
+        phase = self.nii_phase.get_fdata()[..., 0, 0]
+        nii = nib.Nifti1Image(phase, self.nii_phase.affine, header=self.nii_phase.header)
         mag = self.mag[..., 0, 0]
-        unwrapped = unwrap_phase(phase, self.affine, unwrapper='prelude', mag=mag, mask=np.ones_like(phase))
+
+        unwrapped = unwrap_phase(nii, unwrapper='prelude', mag=mag, mask=np.ones_like(phase))
         assert unwrapped.shape == phase.shape
 
     def test_unwrap_phase_wrong_unwrapper(self):
         """Input wrong unwrapper."""
 
-        # This should return an error
-        try:
-            unwrap_phase(self.phase, self.affine, mag=self.mag, unwrapper='Not yet implemented.')
-        except NotImplementedError:
-            # If an exception occurs, this is the desired behaviour
-            return 0
-
-        # If there isn't an error, then there is a problem
-        print('\nNot supported unwrapper but does not throw an error.')
-        assert False
+        with pytest.raises(NotImplementedError, match="The unwrap function"):
+            unwrap_phase(self.nii_phase, mag=self.mag, unwrapper='Not yet implemented.')
 
     def test_unwrap_phase_wrong_shape(self):
         """Input wrong shape."""
+        phase = np.expand_dims(self.nii_phase.get_fdata(), -1)
+        nii = nib.Nifti1Image(phase, self.nii_phase.affine, header=self.nii_phase.header)
 
-        # This should return an error
-        try:
-            unwrap_phase(np.expand_dims(self.phase, -1), self.affine, mag=self.mag)
-        except RuntimeError:
-            # If an exception occurs, this is the desired behaviour
-            return 0
-
-        # If there isn't an error, then there is a problem
-        print('\nWrong dimensions but does not throw an error.')
-        assert False
+        with pytest.raises(ValueError, match="Shape of input phase is not supported."):
+            unwrap_phase(nii, mag=self.mag)


### PR DESCRIPTION
## Description
While working on a script to process a lot of unwrapping, I found inefficiencies. This PR adresses those:

- Outputs the proper header when creating a NIfTI
- Changes the unwrapping APIs to input a single nibabel object instead of 3 separate inputs (array, affine, header)
- Updates the tests and general demo to validate everything works