### PR TITLE
Added handling of coronal RF nifti + tests for all orientations

### DIFF
--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -15,7 +15,7 @@ from shimmingtoolbox.download import install_data
 
 URL_DICT: Dict[str, Tuple[List[str], str]] = {
     "testing_data": (
-        ["https://github.com/shimming-toolbox/data-testing/archive/r20210217.zip"],
+        ["https://github.com/shimming-toolbox/data-testing/archive/r20211006.zip"],
         "Light-weighted dataset for testing purpose.",
     ),
     "prelude": (

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -203,13 +203,12 @@ def scale_tfl_b1(image, json_data):
     """Rescales the magnitude and phase of complex B1 maps acquired with Siemens' standard B1 mapping sequence. Also
     reorders the data that are shuffled during DICOM to NIfTI conversion.
     Args:
-        image: Array of dimension (x, y, n_slices, 2*n_channels)
-                    First half: magnitude in degree*10
-                    Second half: phase in range [248-3848]
-        json_data: Contains the different fields present in the json file corresponding to the nifti file.
+        image (numpy.ndarray): Array of dimension (x, y, n_slices, 2*n_channels). First half: magnitude in degree*10.
+        Second half: phase in range [248-3848].
+        json_data (dict): Contains the different fields present in the json file corresponding to the nifti file.
 
     Returns:
-        numpy.ndarray: complex rescale B1 maps (x, y, n_slices, n_channels)
+        numpy.ndarray: Complex rescaled B1 maps (x, y, n_slices, n_channels).
 
     """
     if 'ShimSetting' in json_data:

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -18,8 +18,7 @@ SATURATION_FA = 90  # Saturation flip angle hard-coded in TFL B1 mapping sequenc
 
 
 def get_acquisition_times(nii_data, json_data):
-    """
-    Return the acquisition timestamps from a json sidecar. This assumes BIDS convention.
+    """Return the acquisition timestamps from a json sidecar. This assumes BIDS convention.
 
     Args:
         nii_data (nibabel.Nifti1Image): Nibabel object containing the image timeseries.
@@ -40,10 +39,9 @@ def get_acquisition_times(nii_data, json_data):
 
 
 def load_nifti(path_data, modality='phase'):
-    """
-    Load data from a directory containing NIFTI type file with nibabel.
+    """Load data from a directory containing NIFTI type file with nibabel.
     Args:
-        path_data (Path): Path to the directory containing the file(s) to load
+        path_data (str): Path to the directory containing the file(s) to load
         modality (str): Modality to read nifti (can be phase or magnitude)
     Returns:
         nibabel.Nifti1Image.Header: List containing headers for every Nifti file
@@ -155,15 +153,15 @@ def load_nifti(path_data, modality='phase'):
 
 
 def read_nii(fname_nifti, auto_scale=True):
-    """ Reads a nifti file and returns the corresponding image and info. Also returns the associated json data.
+    """Reads a nifti file and returns the corresponding image and info. Also returns the associated json data.
     Args:
-        fname_nifti (Path): direct path to the .nii or .nii.gz file that is going to be read
+        fname_nifti (str): direct path to the .nii or .nii.gz file that is going to be read
         auto_scale (:obj:`bool`, optional): Tells if scaling is done before return
     Returns:
         info (Nifti1Image): Objet containing various data about the nifti file (returned by nibabel.load)
         json_data (dict): Contains the different fields present in the json file corresponding to the nifti file
-        image (ndarray): For B0-maps, image contained in the nifti. Siemens phase images are rescaled between 0 and 2pi.
-        For RF-maps, complex array of dimension (x, y, slice, coil) with phase between -pi and pi.
+        image (numpy.ndarray): For B0-maps, image contained in the nifti. Siemens phase images are rescaled between 0
+        and 2pi. For RF-maps, complex array of dimension (x, y, slice, coil) with phase between -pi and pi.
     """
 
     info = nib.load(fname_nifti)
@@ -202,10 +200,22 @@ def read_nii(fname_nifti, auto_scale=True):
 
 
 def scale_tfl_b1(image, json_data):
+    """Rescales the magnitude and phase of complex B1 maps acquired with Siemens' standard B1 mapping sequence. Also
+    reorders the data that are shuffled during DICOM to NIfTI conversion.
+    Args:
+        image: Array of dimension (x, y, n_slices, 2*n_channels)
+                    First half: magnitude in degree*10
+                    Second half: phase in range [248-3848]
+        json_data: Contains the different fields present in the json file corresponding to the nifti file.
+
+    Returns:
+        numpy.ndarray: complex rescale B1 maps (x, y, n_slices, n_channels)
+
+    """
     if 'ShimSetting' in json_data:
-        n_coils = len(json_data['ShimSetting'])
-        if image.shape[3] != 2 * n_coils:
-            raise ValueError("Wrong array dimension: number of coils not matching")
+        n_channels = len(json_data['ShimSetting'])
+        if image.shape[3] != 2 * n_channels:
+            raise ValueError("Wrong array dimension: number of channels not matching")
     else:
         raise KeyError("Missing json tag: 'ShimSetting'")
 
@@ -226,19 +236,19 @@ def scale_tfl_b1(image, json_data):
     # Phase values are stored in the second half of the 4th dimension. Siemens phase range: [248 - 3848]
     b1_phase = image[:, :, :, image.shape[3] // 2:]
 
-    # Reorder data shuffled by dm2niix into shape (x, y , n_slices*n_coils)
-    b1_mag_vector = np.zeros((image.shape[0], image.shape[1], n_slices * n_coils))
-    b1_phase_vector = np.zeros((image.shape[0], image.shape[1], n_slices * n_coils))
+    # Reorder data shuffled by dm2niix into shape (x, y , n_slices*n_channels)
+    b1_mag_vector = np.zeros((image.shape[0], image.shape[1], n_slices * n_channels))
+    b1_phase_vector = np.zeros((image.shape[0], image.shape[1], n_slices * n_channels))
     if 'ImageOrientationPatientDICOM' in json_data:
         orientation = json_data['ImageOrientationPatientDICOM']
         # Axial or Coronal cases
         if orientation[:3] == [1, 0, 0]:
-            for i in range(n_coils):
+            for i in range(n_channels):
                 b1_mag_vector[:, :, i * n_slices:(i + 1) * n_slices] = b1_mag[:, :, :, i]
                 b1_phase_vector[:, :, i * n_slices:(i + 1) * n_slices] = b1_phase[:, :, :, i]
         # Sagittal case
         elif orientation[:3] == [0, 1, 0] and orientation[5] != 0:
-            for i in range(n_coils):
+            for i in range(n_channels):
                 b1_mag_vector[:, :, i * n_slices:(i + 1) * n_slices] = b1_mag[:, :, ::-1, i]
                 b1_phase_vector[:, :, i * n_slices:(i + 1) * n_slices] = b1_phase[:, :, ::-1, i]
         else:
@@ -246,13 +256,13 @@ def scale_tfl_b1(image, json_data):
     else:
         raise KeyError("Missing json tag: 'ImageOrientationPatientDICOM'")
 
-    # Reorder data shuffled by dm2niix into shape (x, y, n_slices, n_coils)
+    # Reorder data shuffled by dm2niix into shape (x, y, n_slices, n_channels)
     b1_mag_ordered = np.zeros_like(b1_mag)
     b1_phase_ordered = np.zeros_like(b1_phase)
 
     for i in range(n_slices):
-        b1_mag_ordered[:, :, i, :] = b1_mag_vector[:, :, i * n_coils:i * n_coils + n_coils]
-        b1_phase_ordered[:, :, i, :] = b1_phase_vector[:, :, i * n_coils:i * n_coils + n_coils]
+        b1_mag_ordered[:, :, i, :] = b1_mag_vector[:, :, i * n_channels:i * n_channels + n_channels]
+        b1_phase_ordered[:, :, i, :] = b1_phase_vector[:, :, i * n_channels:i * n_channels + n_channels]
 
     # Scale magnitude in nT/V
     b1_mag_ordered = b1_mag_ordered / 10  # Siemens magnitude values are stored in degrees x10

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -379,7 +379,7 @@ class TestCore(object):
         :return:
         """
         with pytest.raises(RuntimeError, match="Directories and files in input path"):
-            load_nifti(self.toolbox_path)
+            load_nifti(str(self.toolbox_path))
 
     def test_load_nifti_folders(self, monkeypatch):
         """
@@ -391,7 +391,7 @@ class TestCore(object):
         os.remove(os.path.join(self.data_path, "dummy2.nii"))
         os.remove(os.path.join(self.data_path, "dummy2.json"))
         monkeypatch.setattr('sys.stdin', StringIO('0\n'))
-        niftis, info, json_info = load_nifti(self.tmp_path)
+        niftis, info, json_info = load_nifti(str(self.tmp_path))
         assert (len(info) == 1), "Wrong number od info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
         assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
@@ -409,7 +409,7 @@ class TestCore(object):
             shutil.rmtree(self.data_path_volume)
         os.remove(os.path.join(self.data_path, "dummy2.nii"))
         os.remove(os.path.join(self.data_path, "dummy2.json"))
-        niftis, info, json_info = load_nifti(self.data_path)
+        niftis, info, json_info = load_nifti(str(self.data_path))
         assert (len(info) == 1), "Wrong number of info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
         assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
@@ -423,7 +423,7 @@ class TestCore(object):
         """
         os.remove(os.path.join(self.data_path, "dummy.json"))
         with pytest.raises(OSError, match="Missing json file"):
-            load_nifti(self.data_path)
+            load_nifti(str(self.data_path))
 
     def test_load_nifti_multiple_echoes(self, monkeypatch):
         """
@@ -433,7 +433,7 @@ class TestCore(object):
         if self.tmp_path.exists():
             shutil.rmtree(self.data_path_volume)
         monkeypatch.setattr('sys.stdin', StringIO('0\n'))
-        niftis, info, json_info = load_nifti(self.tmp_path)
+        niftis, info, json_info = load_nifti(str(self.tmp_path))
         assert (len(info) == 2), "Wrong number od info data 1"
         assert (len(json_info) == 2), "Wrong number of JSON data 1"
         self._json_phase['EchoNumber'] = 1
@@ -445,7 +445,7 @@ class TestCore(object):
         assert (niftis.shape == (3, 3, 3, 2, 1)), "Wrong shape for the Nifti output data 1"
 
         monkeypatch.setattr('sys.stdin', StringIO('1\n'))
-        niftis, info, json_info = load_nifti(self.tmp_path)
+        niftis, info, json_info = load_nifti(str(self.tmp_path))
         assert (len(info) == 2), "Wrong number of info data 2"
         assert (len(json_info) == 2), "Wrong number of JSON data 2"
         self._json_phase['EchoNumber'] = 1
@@ -462,7 +462,7 @@ class TestCore(object):
         :return:
         """
         monkeypatch.setattr('sys.stdin', StringIO('q\n'))
-        ret = load_nifti(self.tmp_path)
+        ret = load_nifti(str(self.tmp_path))
         assert (ret == 0), "Should have returned 0 for quit input"
 
     def test_load_nifti_volume(self):
@@ -474,7 +474,7 @@ class TestCore(object):
             shutil.rmtree(self.data_path_2)
         if self.data_path.exists():
             shutil.rmtree(self.data_path)
-        niftis, info, json_info = load_nifti(self.data_path_volume)
+        niftis, info, json_info = load_nifti(str(self.data_path_volume))
         assert (len(info) == 1), "Wrong number of info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
         assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
@@ -499,7 +499,7 @@ class TestCore(object):
             json.dump(self._json_phase, json_file)
 
         monkeypatch.setattr('sys.stdin', StringIO('1\n'))
-        niftis, info, json_info = load_nifti(self.data_path)
+        niftis, info, json_info = load_nifti(str(self.data_path))
         self._json_phase['AcquisitionNumber'] = 1
         assert (len(info) == 1), "Wrong number od info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
@@ -508,7 +508,7 @@ class TestCore(object):
         assert (niftis.shape == (3, 3, 3, 1, 1)), "Wrong shape for the Nifti output data"
 
         monkeypatch.setattr('sys.stdin', StringIO('2\n'))
-        niftis, info, json_info = load_nifti(self.data_path)
+        niftis, info, json_info = load_nifti(str(self.data_path))
         self._json_phase['AcquisitionNumber'] = 2
         assert (len(info) == 1), "Wrong number od info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
@@ -532,14 +532,14 @@ class TestCore(object):
         nib.save(dummy_data, os.path.join(self.data_path, 'dummy2.nii'))
         with open(os.path.join(self.data_path, 'dummy2.json'), 'w') as json_file:
             json.dump(self._json_mag, json_file)
-        niftis, info, json_info = load_nifti(self.data_path)
+        niftis, info, json_info = load_nifti(str(self.data_path))
         assert (len(info) == 1), "Wrong number od info data 1"
         assert (len(json_info) == 1), "Wrong number of JSON data 1"
         assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded for first JSON1"
         assert (niftis.shape == (3, 3, 3, 1, 1)), "Wrong shape for the Nifti output data 1"
 
-        niftis, info, json_info = load_nifti(self.data_path, "magnitude")
+        niftis, info, json_info = load_nifti(str(self.data_path), "magnitude")
         assert (len(info) == 1), "Wrong number of info data 2"
         assert (len(json_info) == 1), "Wrong number of JSON data 2"
         assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_mag, sort_keys=True)), \
@@ -564,17 +564,11 @@ class TestCore(object):
         assert np.angle(b1).max(initial=0) <= np.pi and np.angle(b1).min(initial=0) >= -np.pi, \
             "Phase values out of range"
 
-        # Check masking consistency for all coils at each slice
-        for i in range(b1.shape[2]):
-            for j in range(b1.shape[3] - 1):
-                assert ((b1[:, :, i, j] != 0) == (b1[:, :, i, j + 1] != 0)).any()
-
         test_values = [0.0787205885749701 + 4.099821199410974j,
                        8.426583467014298 + 4.728778099763556j,
                        10.485988324410084 + 4.494300336459402j]
 
         assert np.isclose([b1[35, 35, 0, 0], b1[35, 35, 1, 4], b1[40, 25, 4, 7]], test_values).all()
-
         assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1_axial, sort_keys=True)), \
             "JSON file is not correctly loaded for first RF JSON"
 
@@ -587,15 +581,9 @@ class TestCore(object):
         assert np.angle(b1).max(initial=0) <= np.pi and np.angle(b1).min(initial=0) >= -np.pi, \
             "Phase values out of range"
 
-        # Check masking consistency for all coils at each slice
-        for i in range(b1.shape[2]):
-            for j in range(b1.shape[3] - 1):
-                assert ((b1[:, :, i, j] != 0) == (b1[:, :, i, j + 1] != 0)).any()
-
         test_values = [-18.95330780647338-15.623901256474788j, 0j, -4.017854608159664+14.390338163103701j]
 
         assert np.isclose([b1[35, 35, 0, 0], b1[35, 35, 1, 4], b1[40, 25, 4, 7]], test_values).all()
-
         assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1_coronal, sort_keys=True)), \
             "JSON file is not correctly loaded for first RF JSON"
 
@@ -608,17 +596,11 @@ class TestCore(object):
         assert np.angle(b1).max(initial=0) <= np.pi and np.angle(b1).min(initial=0) >= -np.pi, \
             "Phase values out of range"
 
-        # Check masking consistency for all coils at each slice
-        for i in range(b1.shape[2]):
-            for j in range(b1.shape[3] - 1):
-                assert ((b1[:, :, i, j] != 0) == (b1[:, :, i, j + 1] != 0)).any()
-
         test_values = [-2.3972261793386425-2.757693261674301j,
                        12.039283903012375+4.549266291277882j,
                        7.2905022476747625+8.240413764304524j]
 
         assert np.isclose([b1[35, 35, 0, 0], b1[35, 35, 1, 4], b1[40, 25, 4, 7]], test_values).all()
-
         assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1_sagittal, sort_keys=True)), \
             "JSON file is not correctly loaded for first RF JSON"
 
@@ -662,7 +644,7 @@ class TestCore(object):
             json.dump(self._json_b1_wrong_shimsetting, json_file)
 
         fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_wrong_shimsetting.nii")
-        with pytest.raises(ValueError, match="Wrong array dimension: number of coils not matching"):
+        with pytest.raises(ValueError, match="Wrong array dimension: number of channels not matching"):
             read_nii(fname_b1)
 
     def test_read_nii_b1_no_shimsetting(self):

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -25,7 +25,7 @@ class TestCore(object):
                               [[16, 16], [17, 17], [18, 18]]],
                              [[[19, 19], [20, 20], [21, 21]], [[22, 22], [23, 23], [24, 24]],
                               [[25, 25], [26, 26], [27, 27]]]])
-    _data_b1 = np.zeros([64, 64, 16, 16])
+    _data_b1 = np.zeros([64, 64, 5, 16])
     _aff = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
     _json_phase = {"Modality": "MR",
                    "ImageComments": "phase",
@@ -133,62 +133,180 @@ class TestCore(object):
                  "ConversionSoftwareVersion": "v1.0.20181125  (JP2:OpenJPEG) GCC9.3.0",
                  "Dcm2bidsVersion": "2.1.4"}
 
-    _json_b1 = {"Modality": "MR",
-                "MagneticFieldStrength": 7,
-                "ImagingFrequency": 297.197,
-                "Manufacturer": "Siemens",
-                "ManufacturersModelName": "Investigational_Device_7T",
-                "InstitutionName": "Hospital",
-                "InstitutionalDepartmentName": "Department",
-                "InstitutionAddress": "Street StreetNo,City,District,CA,ZIP",
-                "DeviceSerialNumber": "79017",
-                "StationName": "AWP79017",
-                "BodyPartExamined": "BRAIN",
-                "PatientPosition": "HFS",
-                "ProcedureStepDescription": "Development^Dr. Cohen-Adad",
-                "SoftwareVersions": "syngo MR E12",
-                "MRAcquisitionType": "2D",
-                "SeriesDescription": "tfl_rfmap_B1shim_flip20_5mm",
-                "ProtocolName": "tfl_rfmap_B1shim_flip20_5mm",
-                "ScanningSequence": "GR",
-                "SequenceVariant": "SK\\SP",
-                "SequenceName": "tfl2d1_16",
-                "SeriesNumber": 67,
-                "AcquisitionTime": "14:21:12.127500",
-                "AcquisitionNumber": 1,
-                "ImageComments": "flip angle map, TraRefAmpl: 225.0 V",
-                "SliceThickness": 5,
-                "SpacingBetweenSlices": 6,
-                "SAR": 0.0250297,
-                "EchoTime": 0.00148,
-                "RepetitionTime": 4,
-                "FlipAngle": 20,
-                "PartialFourier": 1,
-                "Interpolation2D": 1,
-                "BaseResolution": 32,
-                "ShimSetting": [133, 30, 22, -80, 27, -130, -112, -234],
-                "TxRefAmp": 225,
-                "PhaseResolution": 1,
-                "ReceiveCoilName": "NP11_ACDC_SPINE",
-                "ReceiveCoilActiveElements": "1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H",
-                "PulseSequenceDetails": "%SiemensSeq%\\tfl_rfmap",
-                "ConsistencyInfo": "N4_VE12U_LATEST_20181126",
-                "MultibandAccelerationFactor": 8,
-                "PercentPhaseFOV": 100,
-                "PercentSampling": 100,
-                "PhaseEncodingSteps": 32,
-                "AcquisitionMatrixPE": 32,
-                "ReconMatrixPE": 64,
-                "PixelBandwidth": 450,
-                "DwellTime": 3.48e-05,
-                "PhaseEncodingDirection": "j-",
-                "SliceTiming": [0.96875, 0.96875, 0.96875, 0.96875, 0.96875, 0.96875, 0.96875, 0.96875, 0, 0, 0, 0, 0,
-                                0, 0, 0],
-                "ImageOrientationPatientDICOM": [1, 0, 0, 0, 1, 0],
-                "InPlanePhaseEncodingDirectionDICOM": "COL",
-                "ConversionSoftware": "dcm2niix",
-                "ConversionSoftwareVersion": "v1.0.20201102",
-                "Dcm2bidsVersion": "2.1.4"}
+    _json_b1_axial = {
+        "Modality": "MR",
+        "MagneticFieldStrength": 7,
+        "ImagingFrequency": 297.2,
+        "Manufacturer": "Siemens",
+        "ManufacturersModelName": "Investigational_Device_7T",
+        "InstitutionName": "Hospital",
+        "InstitutionalDepartmentName": "Department",
+        "InstitutionAddress": "Street StreetNo,City,District,CA,ZIP",
+        "DeviceSerialNumber": "79017",
+        "StationName": "AWP79017",
+        "BodyPartExamined": "CSPINE",
+        "PatientPosition": "HFS",
+        "ProcedureStepDescription": "Development^Dr. Cohen-Adad",
+        "SoftwareVersions": "syngo MR E12",
+        "MRAcquisitionType": "2D",
+        "SeriesDescription": "standard_tra",
+        "ProtocolName": "standard_tra",
+        "ScanningSequence": "GR",
+        "SequenceVariant": "SK\\SP",
+        "SequenceName": "*tfl2d1_16",
+        "SeriesNumber": 53,
+        "AcquisitionTime": "12:16:59.472500",
+        "AcquisitionNumber": 1,
+        "ImageComments": "flip angle map, TraRefAmpl: 400.0 V",
+        "SliceThickness": 7,
+        "SpacingBetweenSlices": 14,
+        "SAR": 0.00443249,
+        "EchoTime": 0.00153,
+        "RepetitionTime": 3.76,
+        "FlipAngle": 5,
+        "PartialFourier": 1,
+        "BaseResolution": 64,
+        "ShimSetting": [133, -20, 10, -75, 9, -147, -112, -224],
+        "TxRefAmp": 400,
+        "PhaseResolution": 1,
+        "ReceiveCoilName": "NP11_ACDC_SPINE",
+        "ReceiveCoilActiveElements": "1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H",
+        "PulseSequenceDetails": "%SiemensSeq%\\tfl_rfmap",
+        "RefLinesPE": 16,
+        "ConsistencyInfo": "N4_VE12U_LATEST_20181126",
+        "MultibandAccelerationFactor": 5,
+        "PercentPhaseFOV": 68.75,
+        "PercentSampling": 100,
+        "PhaseEncodingSteps": 44,
+        "AcquisitionMatrixPE": 44,
+        "ReconMatrixPE": 44,
+        "ParallelReductionFactorInPlane": 2,
+        "PixelBandwidth": 440,
+        "DwellTime": 1.78e-05,
+        "PhaseEncodingDirection": "j-",
+        "SliceTiming": [0, 0, 0, 0, 0],
+        "ImageOrientationPatientDICOM": [1, 0, 0, 0, 1, 0],
+        "InPlanePhaseEncodingDirectionDICOM": "COL",
+        "ConversionSoftware": "dcm2niix",
+        "ConversionSoftwareVersion": "v1.0.20201102",
+        "Dcm2bidsVersion": "2.1.4"}
+
+    _json_b1_sagittal = {
+        "Modality": "MR",
+        "MagneticFieldStrength": 7,
+        "ImagingFrequency": 297.2,
+        "Manufacturer": "Siemens",
+        "ManufacturersModelName": "Investigational_Device_7T",
+        "InstitutionName": "Hospital",
+        "InstitutionalDepartmentName": "Department",
+        "InstitutionAddress": "Street StreetNo,City,District,CA,ZIP",
+        "DeviceSerialNumber": "79017",
+        "StationName": "AWP79017",
+        "BodyPartExamined": "CSPINE",
+        "PatientPosition": "HFS",
+        "ProcedureStepDescription": "Development^Dr. Cohen-Adad",
+        "SoftwareVersions": "syngo MR E12",
+        "MRAcquisitionType": "2D",
+        "SeriesDescription": "standard_sag",
+        "ProtocolName": "standard_sag",
+        "ScanningSequence": "GR",
+        "SequenceVariant": "SK\\SP",
+        "SequenceName": "*tfl2d1_16",
+        "SeriesNumber": 55,
+        "AcquisitionTime": "12:21:7.597500",
+        "AcquisitionNumber": 1,
+        "ImageComments": "flip angle map, TraRefAmpl: 400.0 V",
+        "SliceThickness": 5,
+        "SpacingBetweenSlices": 10,
+        "SAR": 0.00464767,
+        "EchoTime": 0.00163,
+        "RepetitionTime": 3.76,
+        "FlipAngle": 5,
+        "PartialFourier": 1,
+        "BaseResolution": 64,
+        "ShimSetting": [133, -20, 10, -75, 9, -147, -112, -224],
+        "TxRefAmp": 400,
+        "PhaseResolution": 1,
+        "ReceiveCoilName": "NP11_ACDC_SPINE",
+        "ReceiveCoilActiveElements": "1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H",
+        "PulseSequenceDetails": "%SiemensSeq%\\tfl_rfmap",
+        "RefLinesPE": 16,
+        "ConsistencyInfo": "N4_VE12U_LATEST_20181126",
+        "MultibandAccelerationFactor": 5,
+        "PercentPhaseFOV": 81.25,
+        "PercentSampling": 100,
+        "PhaseEncodingSteps": 52,
+        "AcquisitionMatrixPE": 52,
+        "ReconMatrixPE": 52,
+        "ParallelReductionFactorInPlane": 2,
+        "PixelBandwidth": 440,
+        "DwellTime": 1.78e-05,
+        "PhaseEncodingDirection": "i",
+        "SliceTiming": [0, 0, 0, 0, 0],
+        "ImageOrientationPatientDICOM": [0, 1, 0, 0, 0, -1],
+        "InPlanePhaseEncodingDirectionDICOM": "ROW",
+        "ConversionSoftware": "dcm2niix",
+        "ConversionSoftwareVersion": "v1.0.20201102",
+        "Dcm2bidsVersion": "2.1.4"
+    }
+
+    _json_b1_coronal = {
+        "Modality": "MR",
+        "MagneticFieldStrength": 7,
+        "ImagingFrequency": 297.2,
+        "Manufacturer": "Siemens",
+        "ManufacturersModelName": "Investigational_Device_7T",
+        "InstitutionName": "Hospital",
+        "InstitutionalDepartmentName": "Department",
+        "InstitutionAddress": "Street StreetNo,City,District,CA,ZIP",
+        "DeviceSerialNumber": "79017",
+        "StationName": "AWP79017",
+        "BodyPartExamined": "CSPINE",
+        "PatientPosition": "HFS",
+        "ProcedureStepDescription": "Development^Dr. Cohen-Adad",
+        "SoftwareVersions": "syngo MR E12",
+        "MRAcquisitionType": "2D",
+        "SeriesDescription": "standard_cor",
+        "ProtocolName": "standard_cor",
+        "ScanningSequence": "GR",
+        "SequenceVariant": "SK\\SP",
+        "SequenceName": "*tfl2d1_16",
+        "SeriesNumber": 54,
+        "AcquisitionTime": "12:19:4.552500",
+        "AcquisitionNumber": 1,
+        "ImageComments": "flip angle map, TraRefAmpl: 400.0 V",
+        "SliceThickness": 5,
+        "SpacingBetweenSlices": 10,
+        "SAR": 0.00701462,
+        "EchoTime": 0.00163,
+        "RepetitionTime": 3.76,
+        "FlipAngle": 5,
+        "PartialFourier": 1,
+        "BaseResolution": 64,
+        "ShimSetting": [133, -20, 10, -75, 9, -147, -112, -224],
+        "TxRefAmp": 400,
+        "PhaseResolution": 1,
+        "ReceiveCoilName": "NP11_ACDC_SPINE",
+        "ReceiveCoilActiveElements": "1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H",
+        "PulseSequenceDetails": "%SiemensSeq%\\tfl_rfmap",
+        "RefLinesPE": 16,
+        "ConsistencyInfo": "N4_VE12U_LATEST_20181126",
+        "MultibandAccelerationFactor": 5,
+        "PercentPhaseFOV": 218.75,
+        "PercentSampling": 100,
+        "PhaseEncodingSteps": 140,
+        "AcquisitionMatrixPE": 140,
+        "ReconMatrixPE": 140,
+        "ParallelReductionFactorInPlane": 2,
+        "PixelBandwidth": 440,
+        "DwellTime": 1.78e-05,
+        "PhaseEncodingDirection": "i",
+        "SliceTiming": [0, 0, 0, 0, 0],
+        "ImageOrientationPatientDICOM": [1, 0, 0, 0, 0, -1],
+        "InPlanePhaseEncodingDirectionDICOM": "ROW",
+        "ConversionSoftware": "dcm2niix",
+        "ConversionSoftwareVersion": "v1.0.20201102",
+        "Dcm2bidsVersion": "2.1.4"}
 
     def setup_method(self):
         """
@@ -276,7 +394,7 @@ class TestCore(object):
         niftis, info, json_info = load_nifti(self.tmp_path)
         assert (len(info) == 1), "Wrong number od info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
-        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)),\
+        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded"
         assert (niftis.shape == (3, 3, 3, 1, 1)), "Wrong shape for the Nifti output data"
 
@@ -294,7 +412,7 @@ class TestCore(object):
         niftis, info, json_info = load_nifti(self.data_path)
         assert (len(info) == 1), "Wrong number of info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
-        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)),\
+        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded"
         assert (niftis.shape == (3, 3, 3, 1, 1)), "Wrong shape for the Nifti output data"
 
@@ -359,7 +477,7 @@ class TestCore(object):
         niftis, info, json_info = load_nifti(self.data_path_volume)
         assert (len(info) == 1), "Wrong number of info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
-        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)),\
+        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded"
         assert (niftis.shape == (3, 3, 3, 1, 2)), "Wrong shape for the Nifti output data"
 
@@ -385,7 +503,7 @@ class TestCore(object):
         self._json_phase['AcquisitionNumber'] = 1
         assert (len(info) == 1), "Wrong number od info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
-        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)),\
+        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded"
         assert (niftis.shape == (3, 3, 3, 1, 1)), "Wrong shape for the Nifti output data"
 
@@ -394,7 +512,7 @@ class TestCore(object):
         self._json_phase['AcquisitionNumber'] = 2
         assert (len(info) == 1), "Wrong number od info data"
         assert (len(json_info) == 1), "Wrong number of JSON data"
-        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)),\
+        assert (json.dumps(json_info[0], sort_keys=True) == json.dumps(self._json_phase, sort_keys=True)), \
             "JSON file is not correctly loaded"
         assert (niftis.shape == (3, 3, 3, 1, 1)), "Wrong shape for the Nifti output data"
         self._json_phase['AcquisitionNumber'] = 1
@@ -437,13 +555,13 @@ class TestCore(object):
         assert ('P' in json_info['ImageType'])
         assert (phasediff.max() <= math.pi) and (phasediff.min() >= -math.pi)
 
-    def test_read_nii_b1(self):
-        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'sub-01_run-10_TB1map.nii.gz')
+    def test_read_nii_b1_axial(self):
+        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'TB1map_axial.nii.gz')
         nii, json_info, b1 = read_nii(fname_b1)
 
-        assert b1.shape == (64, 64, 16, 8), "Wrong rf-map shape"
+        assert b1.shape == (64, 44, 5, 8), "Wrong rf-map shape"
         assert np.abs(b1).max() <= 180 and np.abs(b1).min() >= 0, "Magnitude values out of range"
-        assert np.angle(b1).max(initial=0) <= np.pi and np.angle(b1).min(initial=0) >= -np.pi,\
+        assert np.angle(b1).max(initial=0) <= np.pi and np.angle(b1).min(initial=0) >= -np.pi, \
             "Phase values out of range"
 
         # Check masking consistency for all coils at each slice
@@ -451,51 +569,95 @@ class TestCore(object):
             for j in range(b1.shape[3] - 1):
                 assert ((b1[:, :, i, j] != 0) == (b1[:, :, i, j + 1] != 0)).any()
 
-        test_values = [-4.274539911369111 + 4.599952786001116j,
-                       -5.8027003257021725 + 2.2042390773527423j,
-                       -2.1929304691258276 + 1.5241263801971388j]
+        test_values = [0.0787205885749701 + 4.099821199410974j,
+                       8.426583467014298 + 4.728778099763556j,
+                       10.485988324410084 + 4.494300336459402j]
 
-        assert np.isclose([b1[35, 35, 0, 0], b1[35, 35, 6, 7], b1[40, 25, 15, 7]], test_values).all()
+        assert np.isclose([b1[35, 35, 0, 0], b1[35, 35, 1, 4], b1[40, 25, 4, 7]], test_values).all()
 
-        assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1, sort_keys=True)),\
+        assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1_axial, sort_keys=True)), \
             "JSON file is not correctly loaded for first RF JSON"
 
-    def test_read_nii_b1_wrong_direction(self):
-        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
-        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_wrong_direction'))
-        self._json_b1_wrong_direction = self._json_b1.copy()
-        self._json_b1_wrong_direction['ImageOrientationPatientDICOM'] = [0, 0, 0, 0, 0, 0]
-        with open(os.path.join(self.data_path_b1, 'dummy_b1_wrong_direction.json'), 'w') as json_file:
-            json.dump(self._json_b1_wrong_direction, json_file)
+    def test_read_nii_b1_coronal(self):
+        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'TB1map_coronal.nii.gz')
+        nii, json_info, b1 = read_nii(fname_b1)
 
-        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_wrong_direction.nii')
+        assert b1.shape == (140, 64, 5, 8), "Wrong rf-map shape"
+        assert np.abs(b1).max() <= 180 and np.abs(b1).min() >= 0, "Magnitude values out of range"
+        assert np.angle(b1).max(initial=0) <= np.pi and np.angle(b1).min(initial=0) >= -np.pi, \
+            "Phase values out of range"
+
+        # Check masking consistency for all coils at each slice
+        for i in range(b1.shape[2]):
+            for j in range(b1.shape[3] - 1):
+                assert ((b1[:, :, i, j] != 0) == (b1[:, :, i, j + 1] != 0)).any()
+
+        test_values = [-18.95330780647338-15.623901256474788j, 0j, -4.017854608159664+14.390338163103701j]
+
+        assert np.isclose([b1[35, 35, 0, 0], b1[35, 35, 1, 4], b1[40, 25, 4, 7]], test_values).all()
+
+        assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1_coronal, sort_keys=True)), \
+            "JSON file is not correctly loaded for first RF JSON"
+
+    def test_read_nii_b1_sagittal(self):
+        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'TB1map_sagittal.nii.gz')
+        nii, json_info, b1 = read_nii(fname_b1)
+
+        assert b1.shape == (52, 64, 5, 8), "Wrong rf-map shape"
+        assert np.abs(b1).max() <= 180 and np.abs(b1).min() >= 0, "Magnitude values out of range"
+        assert np.angle(b1).max(initial=0) <= np.pi and np.angle(b1).min(initial=0) >= -np.pi, \
+            "Phase values out of range"
+
+        # Check masking consistency for all coils at each slice
+        for i in range(b1.shape[2]):
+            for j in range(b1.shape[3] - 1):
+                assert ((b1[:, :, i, j] != 0) == (b1[:, :, i, j + 1] != 0)).any()
+
+        test_values = [-2.3972261793386425-2.757693261674301j,
+                       12.039283903012375+4.549266291277882j,
+                       7.2905022476747625+8.240413764304524j]
+
+        assert np.isclose([b1[35, 35, 0, 0], b1[35, 35, 1, 4], b1[40, 25, 4, 7]], test_values).all()
+
+        assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1_sagittal, sort_keys=True)), \
+            "JSON file is not correctly loaded for first RF JSON"
+
+    def test_read_nii_b1_wrong_orientation(self):
+        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
+        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_wrong_orientation'))
+        self._json_b1_wrong_orientation = self._json_b1_axial.copy()
+        self._json_b1_wrong_orientation['ImageOrientationPatientDICOM'] = [0, 0, 0, 0, 0, 0]
+        with open(os.path.join(self.data_path_b1, 'dummy_b1_wrong_orientation.json'), 'w') as json_file:
+            json.dump(self._json_b1_wrong_orientation, json_file)
+
+        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_wrong_orientation.nii')
         with pytest.raises(ValueError, match="Unknown slice orientation"):
             read_nii(fname_b1)
 
-    def test_read_nii_b1_no_direction(self):
+    def test_read_nii_b1_no_orientation(self):
         dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
-        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_direction'))
-        self._json_b1_no_direction = self._json_b1.copy()
-        del self._json_b1_no_direction['ImageOrientationPatientDICOM']
-        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_direction.json'), 'w') as json_file:
-            json.dump(self._json_b1_no_direction, json_file)
+        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_orientation'))
+        self._json_b1_no_orientation = self._json_b1_axial.copy()
+        del self._json_b1_no_orientation['ImageOrientationPatientDICOM']
+        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_orientation.json'), 'w') as json_file:
+            json.dump(self._json_b1_no_orientation, json_file)
 
-        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_no_direction.nii')
+        fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_no_orientation.nii')
         with pytest.raises(KeyError, match="Missing json tag: 'ImageOrientationPatientDICOM'"):
             read_nii(fname_b1)
 
     def test_read_nii_b1_no_scaling(self):
-        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'sub-01_run-10_TB1map.nii.gz')
+        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'TB1map_axial.nii.gz')
         _, _, b1 = read_nii(fname_b1, auto_scale=False)
-        assert b1.shape == (64, 64, 16, 16), "Wrong rf-map shape"
-        test_values = [87.0, 1890.0, 37.0]
-        assert [b1[35, 35, 0, 0], b1[35, 35, 6, 13], b1[40, 25, 15, 7]] == test_values
+        assert b1.shape == (64, 44, 5, 16), "Wrong rf-map shape"
+        test_values = [101, 2266, 281]
+        assert [b1[35, 35, 0, 0], b1[35, 35, 2, 13], b1[40, 25, 4, 7]] == test_values
 
     def test_read_nii_b1_wrong_shimsetting(self):
         dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
         nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_wrong_shimsetting'))
         with open(os.path.join(self.data_path_b1, 'dummy_b1_wrong_shimsetting.json'), 'w') as json_file:
-            self._json_b1_wrong_shimsetting = self._json_b1.copy()
+            self._json_b1_wrong_shimsetting = self._json_b1_axial.copy()
             self._json_b1_wrong_shimsetting['ShimSetting'] = str(np.zeros([15]))
             json.dump(self._json_b1_wrong_shimsetting, json_file)
 
@@ -507,7 +669,7 @@ class TestCore(object):
         dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
         nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting'))
         with open(os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting.json'), 'w') as json_file:
-            self._json_b1_no_shimsetting = self._json_b1.copy()
+            self._json_b1_no_shimsetting = self._json_b1_axial.copy()
             del self._json_b1_no_shimsetting['ShimSetting']
             json.dump(self._json_b1_no_shimsetting, json_file)
 
@@ -519,7 +681,7 @@ class TestCore(object):
         dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
         nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_wrong_slicetiming'))
         with open(os.path.join(self.data_path_b1, 'dummy_b1_wrong_slicetiming.json'), 'w') as json_file:
-            self._json_b1_wrong_slicetiming = self._json_b1.copy()
+            self._json_b1_wrong_slicetiming = self._json_b1_axial.copy()
             self._json_b1_wrong_slicetiming['SliceTiming'] = str(np.zeros([15]))
             json.dump(self._json_b1_wrong_slicetiming, json_file)
 
@@ -531,7 +693,7 @@ class TestCore(object):
         dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
         nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming'))
         with open(os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming.json'), 'w') as json_file:
-            self._json_b1_no_slicetiming = self._json_b1.copy()
+            self._json_b1_no_slicetiming = self._json_b1_axial.copy()
             del self._json_b1_no_slicetiming['SliceTiming']
             json.dump(self._json_b1_no_slicetiming, json_file)
 
@@ -545,7 +707,7 @@ class TestCore(object):
         dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=data_negative_mag, affine=self._aff)
         nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_negative_mag'))
         with open(os.path.join(self.data_path_b1, 'dummy_b1_negative_mag.json'), 'w') as json_file:
-            json.dump(self._json_b1, json_file)
+            json.dump(self._json_b1_axial, json_file)
 
         fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_negative_mag.nii")
         with pytest.raises(ValueError, match="Unexpected negative magnitude values"):


### PR DESCRIPTION
## Description
Now that we have sagittal/axial and coronal RF niftis, I was able to implement the handling of all cases in ST. I also implemented the corresponding unit test.

## Linked issues
Closes #290 
