### PR TITLE
Add output of phase for anat images in dcm2bids

### DIFF
--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -194,6 +194,7 @@
             "modalityLabel": "unshimmed_e1",
             "criteria": {
                 "SeriesDescription": "*gre*realtime*",
+                "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "1"
             }
         },
@@ -202,6 +203,7 @@
             "modalityLabel": "unshimmed_e2",
             "criteria": {
                 "SeriesDescription": "*gre*realtime*",
+                "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "2"
             }
         },
@@ -210,6 +212,34 @@
             "modalityLabel": "unshimmed_e3",
             "criteria": {
                 "SeriesDescription": "*gre*realtime*",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "3"
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "unshimmed_phase_e1",
+            "criteria": {
+                "SeriesDescription": "*gre*realtime*",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "1"
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "unshimmed_phase_e2",
+            "criteria": {
+                "SeriesDescription": "*gre*realtime*",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "2"
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "unshimmed_phase_e3",
+            "criteria": {
+                "SeriesDescription": "*gre*realtime*",
+                "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "3"
             }
         },


### PR DESCRIPTION
## Description
This PR adds the ability to output phase anatomical images when using `st_dicom_to_nifti`. This required to add lines in the dcm2bids config file. 

Reason: The change was required since outputting both the phase and magnitude from the scanner would convert both mag and phase to the same file names. Now they have different names.