### PR TITLE
Add unit test for unknown RF shimming algorithm

### DIFF
--- a/shimmingtoolbox/shim/b1shim.py
+++ b/shimmingtoolbox/shim/b1shim.py
@@ -96,7 +96,7 @@ def b1shim(b1_maps, mask=None, cp_weights=None, algorithm=1, target=None,  q_mat
             return 1 / np.min(b1_abs)
 
     else:
-        raise ValueError(f"The specified algorithm does not exist. It must be an integer between 1 and 5.")
+        raise ValueError(f"The specified algorithm does not exist. It must be an integer between 1 and 3.")
 
     # Q matrices to compute the local SAR values for each 10g of tissue (or subgroups of pixels if VOP are used).
     # If no Q matrix is provided, unconstrained optimization is performed

--- a/test/shim/test_b1shim.py
+++ b/test/shim/test_b1shim.py
@@ -46,6 +46,12 @@ def test_b1shim_algo_3(caplog):
     assert len(shim_weights) == b1_maps.shape[3], "The number of shim weights does not match the number of coils"
 
 
+def test_b1shim_algo_wrong_algo():
+    with pytest.raises(ValueError, match=r"The specified algorithm does not exist. It must be an integer between 1 "
+                                         r"and 3."):
+        b1shim(b1_maps, mask, algorithm=4)
+
+
 def test_b1shim_constrained():
     shim_weights = b1shim(b1_maps, mask, q_matrix=vop)
     assert len(shim_weights) == b1_maps.shape[3], "The number of shim weights does not match the number of coils"
@@ -172,7 +178,6 @@ def test_calc_approx_cp():
 
 
 def test_load_siemens_vop():
-    vop = load_siemens_vop(path_sar_file)
     assert np.isclose(vop[:, 4, 55], [0.00028431 - 2.33700119e-04j,  0.00039449 - 3.11945268e-04j,
                                       0.00052208 - 1.17153693e-03j,  0.00104146 - 1.76284793e-03j,
                                       0.00169108 + 2.29006638e-21j,  0.00051032 + 4.99291087e-04j,


### PR DESCRIPTION
## Description

Adds unit test (`test/test_b1_shim/test_b1shim_wrong_algo`) for when an unknown RF shimming algorithm is specified by the user. The test simply asserts that the correct error is raised.