### PR TITLE
Add norm constraint to shim-weights when not SAR constrained

### DIFF
--- a/shimmingtoolbox/shim/b1shim.py
+++ b/shimmingtoolbox/shim/b1shim.py
@@ -108,8 +108,10 @@ def b1shim(b1_maps, mask=None, cp_weights=None, algorithm=1, target=None,  q_mat
         sar_constraint = ({'type': 'ineq', 'fun': lambda w: -max_sar(vector_to_complex(w), q_matrix) + sar_limit})
         shim_weights = vector_to_complex(scipy.optimize.minimize(cost, weights_init, constraints=sar_constraint).x)
     else:
-        logger.info(f"No Q matrix provided, performing unconstrained optimization.")
-        shim_weights = vector_to_complex(scipy.optimize.minimize(cost, weights_init).x)
+        norm_cons = ({'type': 'eq', 'fun': lambda x: np.linalg.norm(vector_to_complex(x)) - 1})  # Norm constraint
+        logger.info(f"No Q matrix provided, performing SAR unconstrained optimization while keeping the RF shim-weighs "
+                    f"normalized.")
+        shim_weights = vector_to_complex(scipy.optimize.minimize(cost, weights_init, constraints=norm_cons).x)
 
     # Plot RF shimming results
     if path_output is not None:

--- a/test/shim/test_b1shim.py
+++ b/test/shim/test_b1shim.py
@@ -24,14 +24,16 @@ vop = load_siemens_vop(path_sar_file)
 
 def test_b1shim(caplog):
     shim_weights = b1shim(b1_maps)
-    assert r"No Q matrix provided, performing unconstrained optimization." in caplog.text
+    assert r"No Q matrix provided, performing SAR unconstrained optimization while keeping the RF shim-weighs " \
+           r"normalized." in caplog.text
     assert r"No mask provided, masking all zero-valued pixels." in caplog.text
     assert len(shim_weights) == b1_maps.shape[3], "The number of shim weights does not match the number of coils"
 
 
 def test_b1shim_algo_2(caplog):
     shim_weights = b1shim(b1_maps, mask, algorithm=2, target=20)
-    assert r"No Q matrix provided, performing unconstrained optimization." in caplog.text
+    assert r"No Q matrix provided, performing SAR unconstrained optimization while keeping the RF shim-weighs " \
+           r"normalized." in caplog.text
     assert len(shim_weights) == b1_maps.shape[3], "The number of shim weights does not match the number of coils"
 
 
@@ -42,7 +44,8 @@ def test_b1shim_algo_2_no_target():
 
 def test_b1shim_algo_3(caplog):
     shim_weights = b1shim(b1_maps, mask, algorithm=3)
-    assert r"No Q matrix provided, performing unconstrained optimization." in caplog.text
+    assert r"No Q matrix provided, performing SAR unconstrained optimization while keeping the RF shim-weighs " \
+           r"normalized." in caplog.text
     assert len(shim_weights) == b1_maps.shape[3], "The number of shim weights does not match the number of coils"
 
 


### PR DESCRIPTION
## Description
I encountered a RF-shimming scenario where performing SAR unconstrained optimization resulted in very large shim-weights magnitude (which is not surprising if the optimization process finds a local minimum corresponding to large shim weights value). In this particular case, this makes the RF-shimming functionality useless at the scanner as the odds for these shim weights to not excess the SAR limit are very low. 

I thus decided to add a constraint on the norm of the shim weights (it must always remain 1) during the optimization process. This will make sure that the total RF power used by the scanner is the same as for the CP mode (but the power distribution among the different channels may vary). This solution does not assert that we won't excess the SAR limit, but it highly reduces the odds. 