### PR TITLE
Adapt CI tests to updated testing data organization

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,6 @@ import sys
 import os
 import logging
 from pathlib import Path
-import subprocess
 
 import pytest
 from typing import Mapping
@@ -56,8 +55,8 @@ def test_sct_installation():
 
 
 def pytest_sessionstart():
-    """Download shimmingtoolbox testing_data prior to test collection."""
-    logger.info("Downloading shimmingtoolbox test data")
+    """Download shimming-toolbox testing_data prior to test collection."""
+    logger.info("Downloading shimming-toolbox test data")
     test_data_location = test_data_path()
     try:
         download_data(

--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -15,7 +15,7 @@ from shimmingtoolbox.download import install_data
 
 URL_DICT: Dict[str, Tuple[List[str], str]] = {
     "testing_data": (
-        ["https://github.com/shimming-toolbox/data-testing/archive/r20211006.zip"],
+        ["https://github.com/shimming-toolbox/data-testing/archive/r20211201.zip"],
         "Light-weighted dataset for testing purpose.",
     ),
     "prelude": (

--- a/shimmingtoolbox/download.py
+++ b/shimmingtoolbox/download.py
@@ -16,7 +16,6 @@ from requests.packages.urllib3.util import Retry
 
 from shimmingtoolbox.utils import st_progress_bar
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +61,8 @@ def download_data(urls):
 
             with open(tmp_path, 'wb') as tmp_file:
                 total = int(response.headers.get('content-length', 1))
-                progress_bar = st_progress_bar(total=total, unit='B', unit_scale=True, desc="Status", ascii=False, position=0)
+                progress_bar = st_progress_bar(total=total, unit='B', unit_scale=True, desc="Status", ascii=False,
+                                               position=0)
 
                 for chunk in response.iter_content(chunk_size=8192):
                     if chunk:
@@ -82,8 +82,8 @@ def download_data(urls):
 
 def unzip(compressed, dest_folder):
     """
-    Extract compressed file to the ``dest_folder``. Can handle ``.zip``, ``.tar.gz``. If none of this extension is found, simply
-    copy the file in ``dest_folder``.
+    Extract compressed file to the ``dest_folder``. Can handle ``.zip``, ``.tar.gz``. If none of this extension is
+    found, simply copy the file in ``dest_folder``.
 
     Args:
         compressed: the compressed ``.zip`` or ``.tar.gz`` file
@@ -177,7 +177,7 @@ def install_data(url, dest_folder, keep=False):
     for cwd, ds, fs in os.walk(bundle_folder):
         ds.sort()
         fs.sort()
-        ds[:] = [ d for d in ds if d not in ("__MACOSX",) ]
+        ds[:] = [d for d in ds if d not in ("__MACOSX",)]
         for d in ds:
             srcpath = os.path.join(cwd, d)
             relpath = os.path.relpath(srcpath, bundle_folder)

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -229,13 +229,7 @@ def scale_tfl_b1(image, json_data):
     else:
         raise KeyError("Missing json tag: 'ShimSetting'")
 
-    if 'SliceTiming' in json_data:
-        n_slices = len(json_data['SliceTiming'])
-        if image.shape[2] != n_slices:
-            raise ValueError("Wrong array dimension: number of slices not matching")
-    else:
-        warnings.warn("Missing json tag: 'SliceTiming', slices number cannot be checked.")
-        n_slices = image.shape[2]
+    n_slices = image.shape[2]
 
     # Magnitude values are stored in the first half of the 4th dimension
     b1_mag = image[:, :, :, :image.shape[3] // 2]

--- a/test/cli/test_cli_b1shim.py
+++ b/test/cli/test_cli_b1shim.py
@@ -11,8 +11,9 @@ from shimmingtoolbox.cli.b1shim import b1shim_cli
 from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox import __dir_shimmingtoolbox__
 
-fname_b1_nifti = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'TB1map_axial.nii.gz')
-path_sar_file = os.path.join(__dir_testing__, 'b1_maps', 'vop', 'SarDataUser.mat')
+fname_b1_nifti = os.path.join(__dir_testing__, 'ds_tb1', 'sub-tb1tfl', 'fmap', 'sub-tb1tfl_TB1TFL_axial.nii.gz')
+path_sar_file = os.path.join(__dir_testing__, 'ds_tb1', 'derivatives', 'shimming-toolbox', 'sub-tb1tfl',
+                             'sub-tb1tfl_SarDataUser.mat')
 
 
 def test_b1shim_cli():

--- a/test/cli/test_cli_check_env.py
+++ b/test/cli/test_cli_check_env.py
@@ -4,7 +4,6 @@
 import pytest
 import re
 from click.testing import CliRunner
-import os
 
 import shimmingtoolbox.cli.check_env as st_ce
 

--- a/test/cli/test_cli_image.py
+++ b/test/cli/test_cli_image.py
@@ -14,10 +14,10 @@ from shimmingtoolbox import __dir_testing__
 
 class TestImageConcat(object):
     def setup(self):
-        path_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat')
-        self.list_fname = [os.path.join(path_anat, 'sub-example_unshimmed_e1.nii.gz'),
-                           os.path.join(path_anat, 'sub-example_unshimmed_e2.nii.gz'),
-                           os.path.join(path_anat, 'sub-example_unshimmed_e3.nii.gz')]
+        path_anat = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat')
+        self.list_fname = [os.path.join(path_anat, 'sub-realtime_unshimmed_e1.nii.gz'),
+                           os.path.join(path_anat, 'sub-realtime_unshimmed_e2.nii.gz'),
+                           os.path.join(path_anat, 'sub-realtime_unshimmed_e3.nii.gz')]
 
     def test_cli_concat(self):
         with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:

--- a/test/cli/test_cli_mask.py
+++ b/test/cli/test_cli_mask.py
@@ -10,14 +10,15 @@ import pytest
 from click.testing import CliRunner
 from shimmingtoolbox.cli.mask import mask_cli
 from shimmingtoolbox import __dir_testing__
-# from shimmingtoolbox
+
+inp = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz')
+fname_input = os.path.join(__dir_testing__, 'ds_spine', 'sub-01', 'anat', 'sub-01_t2.nii.gz')
 
 
 def test_cli_mask_box():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 
-        inp = os.path.join(__dir_testing__, 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz')
         out = os.path.join(tmp, 'mask.nii.gz')
         size1 = 10
         size2 = 20
@@ -43,7 +44,6 @@ def test_cli_mask_rect():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 
-        inp = os.path.join(__dir_testing__, 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz')
         out = os.path.join(tmp, 'mask.nii.gz')
         size1 = 10
         size2 = 20
@@ -70,7 +70,6 @@ def test_cli_mask_threshold():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 
-        inp = os.path.join(__dir_testing__, 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz')
         out = os.path.join(tmp, 'mask.nii.gz')
         thr = 780
         result = runner.invoke(mask_cli, ['threshold', '--input', inp, '--output', out, '--thr', thr])
@@ -94,7 +93,6 @@ def test_cli_mask_sct_default():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 
-        fname_input = os.path.join(__dir_testing__, 't2', 't2.nii.gz')
         fname_output = os.path.join(tmp, 'mask.nii.gz')
 
         result = runner.invoke(mask_cli, f"sct --input {fname_input} --output {fname_output} --remove-tmp 0",
@@ -110,7 +108,6 @@ def test_cli_mask_sct_all_flags():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 
-        fname_input = os.path.join(__dir_testing__, 't2', 't2.nii.gz')
         fname_output = os.path.join(tmp, 'mask.nii.gz')
 
         result = runner.invoke(mask_cli, f"sct --input {fname_input} --output {fname_output} --size 11 --shape gaussian"
@@ -127,7 +124,7 @@ def test_cli_mask_sct_4d():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 
-        fname_3d = os.path.join(__dir_testing__, 't2', 't2.nii.gz')
+        fname_3d = os.path.join(__dir_testing__, 'ds_spine', 'sub-01', 'anat', 'sub-01_t2.nii.gz')
         nii_3d = nib.load(fname_3d)
         data_4d = np.expand_dims(nii_3d.get_fdata(), 3)
         data_4d = np.append(data_4d, data_4d, 3)

--- a/test/cli/test_cli_maths.py
+++ b/test/cli/test_cli_maths.py
@@ -10,15 +10,10 @@ from click.testing import CliRunner
 from shimmingtoolbox.cli.maths import maths_cli
 from shimmingtoolbox import __dir_testing__
 
+fname_input = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
+
 
 def test_mean():
-    fname_input = os.path.join(__dir_testing__,
-                               'realtime_zshimming_data',
-                               'nifti',
-                               'sub-example',
-                               'anat',
-                               'sub-example_unshimmed_e1.nii.gz')
-
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
         fname_output = os.path.join(tmp, 'mean.nii.gz')
@@ -32,13 +27,6 @@ def test_mean():
 
 
 def test_mean_axis_out_of_bound():
-    fname_input = os.path.join(__dir_testing__,
-                               'realtime_zshimming_data',
-                               'nifti',
-                               'sub-example',
-                               'anat',
-                               'sub-example_unshimmed_e1.nii.gz')
-
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
         fname_output = os.path.join(tmp, 'mean.nii.gz')

--- a/test/cli/test_cli_realtime_shim.py
+++ b/test/cli/test_cli_realtime_shim.py
@@ -1,11 +1,9 @@
 #!usr/bin/env python3
 # coding: utf-8
-import copy
 import os
 import pathlib
 import tempfile
 import nibabel as nib
-import numpy as np
 import pytest
 import json
 
@@ -16,18 +14,21 @@ from shimmingtoolbox.masking.shapes import shapes
 from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox.cli.realtime_shim import _get_phase_encode_direction_sign
 
+# Path for mag fieldmap
+fname_fieldmap = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_fieldmap.nii.gz')
+# Path for mag anat image
+fname_anat = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
+fname_json = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.json')
+# Path for resp data
+fname_resp = os.path.join(__dir_testing__, 'ds_b0', 'derivatives', 'sub-realtime', 'sub-realtime_PMUresp_signal.resp')
+
 
 def test_cli_realtime_shim():
     """Test CLI for performing realtime shimming experiments"""
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 
-        fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                      'sub-example_fieldmap.nii.gz')
-
         # Path for mag anat image
-        fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                                  'sub-example_unshimmed_e1.nii.gz')
         nii_anat = nib.load(fname_anat)
         anat = nii_anat.get_fdata()
 
@@ -54,9 +55,6 @@ def test_cli_realtime_shim():
         fname_mask_riro = os.path.join(tmp, 'mask.nii.gz')
         nib.save(nii_mask_riro, fname_mask_riro)
 
-        # Path for resp data
-        fname_resp = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
-
         # Specify output for text file and figures
         path_output = os.path.join(tmp, 'test_realtime_shim')
 
@@ -75,15 +73,6 @@ def test_cli_realtime_shim():
 def test_cli_realtime_shim_no_mask():
     runner = CliRunner()
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
-
-        # Path for fieldmap
-        fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                      'sub-example_fieldmap.nii.gz')
-        # Path for mag anat image
-        fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                                  'sub-example_unshimmed_e1.nii.gz')
-        # Path for resp data
-        fname_resp = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
         # Specify output for text file and figures
         path_output = os.path.join(tmp, 'test_realtime_shim')
 
@@ -100,8 +89,7 @@ def test_cli_realtime_shim_no_mask():
 
 def test_phase_encode_sign():
     # Using this acquisition because it has a positive phase encode direction
-    fname_nii = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                             'sub-example_phasediff.nii.gz')
+    fname_nii = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_phasediff.nii.gz')
     phase_encode_is_positive = _get_phase_encode_direction_sign(fname_nii)
 
     assert phase_encode_is_positive is True
@@ -109,11 +97,6 @@ def test_phase_encode_sign():
 
 def test_phase_encode_wrong_dim():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
-        fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                                  'sub-example_unshimmed_e1.nii.gz')
-        fname_json = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                                  'sub-example_unshimmed_e1.json')
-
         nii = nib.load(fname_anat)
         with open(fname_json) as json_file:
             json_data = json.load(json_file)
@@ -133,10 +116,6 @@ def test_phase_encode_wrong_dim():
 
 def test_phase_encode_wrong_tag_value():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
-        fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                                  'sub-example_unshimmed_e1.nii.gz')
-        fname_json = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                                  'sub-example_unshimmed_e1.json')
 
         nii = nib.load(fname_anat)
         with open(fname_json) as json_file:

--- a/test/masking/test_mask_utils.py
+++ b/test/masking/test_mask_utils.py
@@ -86,14 +86,12 @@ class TestDilateBinaryMask(object):
 def test_resample_mask():
     """Test for function that resamples a mask"""
     # Fieldmap
-    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_fieldmap.nii.gz')
+    fname_fieldmap = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_fieldmap.nii.gz')
     nii_fieldmap = nib.load(fname_fieldmap)
     nii_target = nib.Nifti1Image(nii_fieldmap.get_fdata()[..., 0], nii_fieldmap.affine, header=nii_fieldmap.header)
 
     # anat image
-    fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                              'sub-example_unshimmed_e1.nii.gz')
+    fname_anat = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
     nii_anat = nib.load(fname_anat)
 
     # Set up mask

--- a/test/shim/test_b1shim.py
+++ b/test/shim/test_b1shim.py
@@ -12,13 +12,14 @@ from shimmingtoolbox.load_nifti import read_nii
 
 logging.basicConfig(level=logging.INFO)
 
-fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'TB1map_axial.nii.gz')
+fname_b1 = os.path.join(__dir_testing__, 'ds_tb1', 'sub-tb1tfl', 'fmap', 'sub-tb1tfl_TB1TFL_axial.nii.gz')
 _, _, b1_maps = read_nii(fname_b1, auto_scale=True)
 mask = b1_maps.sum(axis=-1) != 0
 cp_weights = np.asarray([0.3536, -0.3527+0.0247j, 0.2748-0.2225j, -0.1926-0.2965j, -0.3535+0.0062j, 0.2931+0.1977j,
                          0.3381+0.1034j, -0.1494+0.3204j])
 
-path_sar_file = os.path.join(__dir_testing__, 'b1_maps', 'vop', 'SarDataUser.mat')
+path_sar_file = os.path.join(__dir_testing__, 'ds_tb1', 'derivatives', 'shimming-toolbox', 'sub-tb1tfl',
+                             'sub-tb1tfl_SarDataUser.mat')
 vop = load_siemens_vop(path_sar_file)
 
 
@@ -195,7 +196,8 @@ def test_load_siemens_vop_wrong_path():
 def test_load_siemens_vop_no_vop():
     data_no_vop = scipy.io.loadmat(path_sar_file)
     data_no_vop.pop('ZZ')
-    path_sar_file_no_vop = os.path.join(__dir_testing__, 'b1_maps', 'vop', 'SarDataUser_no_vop.mat')
+    path_sar_file_no_vop = os.path.join(__dir_testing__, 'ds_tb1', 'derivatives', 'shimming-toolbox', 'sub-tb1tfl',
+                                        'SarDataUser_no_vop.mat')
     scipy.io.savemat(path_sar_file_no_vop, data_no_vop)
     with pytest.raises(ValueError, match='The SAR data does not contain the expected VOP values.'):
         load_siemens_vop(path_sar_file_no_vop)

--- a/test/shim/test_realtime_shim.py
+++ b/test/shim/test_realtime_shim.py
@@ -17,14 +17,12 @@ from shimmingtoolbox.shim.realtime_shim import realtime_shim
 class TestRealtimeShim(object):
     def setup(self):
         # Fieldmap
-        fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                      'sub-example_fieldmap.nii.gz')
+        fname_fieldmap = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_fieldmap.nii.gz')
         nii_fieldmap = nib.load(fname_fieldmap)
         self.nii_fieldmap = nii_fieldmap
 
         # anat image
-        fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                                  'sub-example_unshimmed_e1.nii.gz')
+        fname_anat = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
         nii_anat = nib.load(fname_anat)
         self.nii_anat = nii_anat
 
@@ -49,13 +47,13 @@ class TestRealtimeShim(object):
         self.nii_mask_riro = nii_mask_riro
 
         # Pmu
-        fname_resp = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
+        fname_resp = os.path.join(__dir_testing__, 'ds_b0', 'derivatives', 'sub-realtime',
+                                  'sub-realtime_PMUresp_signal.resp')
         pmu = PmuResp(fname_resp)
         self.pmu = pmu
 
         # Path for json file
-        fname_json = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_magnitude1.json')
+        fname_json = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_magnitude1.json')
         with open(fname_json) as json_file:
             json_data = json.load(json_file)
 

--- a/test/shim/test_sequencer.py
+++ b/test/shim/test_sequencer.py
@@ -304,8 +304,7 @@ def assert_results(nii_fieldmap, nii_anat, nii_mask, coil, currents, slices):
 
 def define_rt_sim_inputs():
     # anat image
-    fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                              'sub-example_unshimmed_e1.nii.gz')
+    fname_anat = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
     nii_anat = nib.load(fname_anat)
 
     # fake[..., 0] contains the original linear fieldmap. This repeats the linear fieldmap over the 3rd dim and scale
@@ -333,7 +332,8 @@ def define_rt_sim_inputs():
     nii_mask_riro = nib.Nifti1Image(riro_mask.astype(int), nii_anat.affine, header=nii_anat.header)
 
     # Pmu
-    fname_resp = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
+    fname_resp = os.path.join(__dir_testing__, 'ds_b0', 'derivatives', 'sub-realtime',
+                              'sub-realtime_PMUresp_signal.resp')
     pmu = PmuResp(fname_resp)
     # Change pmu so that it uses fake data. The fake data is essentially a sinusoid with 4 points
     pmu.data = np.array([3000, 2000, 1000, 2000])
@@ -554,13 +554,11 @@ class TestShimRTpmuSimData(object):
 def test_shim_realtime_pmu_sequencer_rt_zshim_data():
     """Tests for realtime Sequencer with real data"""
     # Fieldmap
-    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_fieldmap.nii.gz')
+    fname_fieldmap = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_fieldmap.nii.gz')
     nii_fieldmap = nib.load(fname_fieldmap)
 
     # anat image
-    fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                              'sub-example_unshimmed_e1.nii.gz')
+    fname_anat = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
     nii_anat = nib.load(fname_anat)
 
     # Set up mask
@@ -573,12 +571,12 @@ def test_shim_realtime_pmu_sequencer_rt_zshim_data():
     nii_mask_riro = nib.Nifti1Image(riro_mask.astype(int), nii_anat.affine, header=nii_anat.header)
 
     # Pmu
-    fname_resp = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'PMUresp_signal.resp')
+    fname_resp = os.path.join(__dir_testing__, 'ds_b0', 'derivatives', 'sub-realtime',
+                              'sub-realtime_PMUresp_signal.resp')
     pmu = PmuResp(fname_resp)
 
     # Path for json file
-    fname_json = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                              'sub-example_magnitude1.json')
+    fname_json = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_magnitude1.json')
     with open(fname_json) as json_file:
         json_data = json.load(json_file)
 

--- a/test/simulate/test_numerical_model.py
+++ b/test/simulate/test_numerical_model.py
@@ -1,10 +1,5 @@
 # coding: utf-8
 
-import pytest
-import os
-from pathlib import Path
-import json
-import numpy as np
 from shimmingtoolbox.simulate import *
 from phantominator import shepp_logan
 
@@ -418,11 +413,7 @@ class TestCore(object):
         deltaB0 = 2
         gamma = 42.58 * 10 ** 6
         handedness = "left"
-
-        if handedness == "left":
-            sign = -1
-        elif handedness == "right":
-            sign = 1
+        sign = -1
 
         actual_signal = NumericalModel.generate_signal(
             proton_density, T2star, FA, TE, deltaB0, gamma, handedness

--- a/test/test_coordinates.py
+++ b/test/test_coordinates.py
@@ -13,6 +13,13 @@ from shimmingtoolbox.coils.coordinates import resample_from_to
 from shimmingtoolbox import __dir_testing__
 
 
+fname_fieldmap = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_fieldmap.nii.gz')
+fname_anat = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
+
+nii_fieldmap = nib.load(fname_fieldmap)
+nii_anat = nib.load(fname_anat)
+
+
 def test_generate_meshgrid():
     """Test to verify generate_meshgrid outputs the correct scanner coordinates from input voxels"""
 
@@ -104,11 +111,6 @@ def test_phys_gradient_reel():
     gradient calculation since they are parallel. The reel data adds a degree of complexity since it is a sagittal image
     """
 
-    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_fieldmap.nii.gz')
-
-    nii_fieldmap = nib.load(fname_fieldmap)
-
     affine = nii_fieldmap.affine
     fmap = nii_fieldmap.get_fdata()
 
@@ -168,11 +170,6 @@ def test_phys_to_vox_gradient_reel():
     gradient calculation since they are parallel. The reel data adds a degree of complexity since it is a sagittal image
     """
 
-    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_fieldmap.nii.gz')
-
-    nii_fieldmap = nib.load(fname_fieldmap)
-
     affine = nii_fieldmap.affine
     fmap = nii_fieldmap.get_fdata()
 
@@ -193,14 +190,7 @@ def test_phys_to_vox_gradient_reel():
 
 def test_resample_from_to_2d():
     """Test resample_from_to with 2d input."""
-    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_fieldmap.nii.gz')
-    fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                              'sub-example_unshimmed_e1.nii.gz')
-
-    nii_fieldmap = nib.load(fname_fieldmap)
     nii_fieldmap_2d = nib.Nifti1Image(nii_fieldmap.get_fdata()[..., 0, 0], nii_fieldmap.affine)
-    nii_anat = nib.load(fname_anat)
 
     nii_resampled = resample_from_to(nii_fieldmap_2d, nii_anat, mode='nearest')
 
@@ -209,14 +199,7 @@ def test_resample_from_to_2d():
 
 def test_resample_from_to_3d():
     """Test resample_from_to with 3d input."""
-    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_fieldmap.nii.gz')
-    fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                              'sub-example_unshimmed_e1.nii.gz')
-
-    nii_fieldmap = nib.load(fname_fieldmap)
     nii_fieldmap_3d = nib.Nifti1Image(nii_fieldmap.get_fdata()[..., 0], nii_fieldmap.affine)
-    nii_anat = nib.load(fname_anat)
 
     nii_resampled = resample_from_to(nii_fieldmap_3d, nii_anat, mode='nearest')
 
@@ -225,14 +208,6 @@ def test_resample_from_to_3d():
 
 def test_resample_from_to_4d():
     """Test resample_from_to with 4d input."""
-    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_fieldmap.nii.gz')
-    fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                              'sub-example_unshimmed_e1.nii.gz')
-
-    nii_fieldmap = nib.load(fname_fieldmap)
-    nii_anat = nib.load(fname_anat)
-
     nii_resampled = resample_from_to(nii_fieldmap, nii_anat, mode='nearest')
 
     assert nii_resampled.shape == (nii_anat.shape + (nii_fieldmap.shape[3],))
@@ -240,18 +215,11 @@ def test_resample_from_to_4d():
 
 def test_resample_from_to_5d():
     """Test resample_from_to with 5d input. Should return an error."""
-    fname_fieldmap = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                  'sub-example_fieldmap.nii.gz')
-    fname_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat',
-                              'sub-example_unshimmed_e1.nii.gz')
-
-    nii_fieldmap = nib.load(fname_fieldmap)
     nii_fieldmap_5d = nib.Nifti1Image(np.expand_dims(nii_fieldmap.get_fdata(), -1), nii_fieldmap.affine)
-    nii_anat = nib.load(fname_anat)
 
     # This should return an error
     try:
-        nii_resampled = resample_from_to(nii_fieldmap_5d, nii_anat, mode='nearest')
+        resample_from_to(nii_fieldmap_5d, nii_anat, mode='nearest')
     except NotImplementedError:
         # If an exception occurs, this is the desired behaviour
         return 0

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -8,13 +8,15 @@ from shimmingtoolbox.dicom_to_nifti import dicom_to_nifti
 from shimmingtoolbox import __dir_testing__
 import pytest
 
+path_dicom_unsorted = os.path.join(__dir_testing__, 'dicom_unsorted')
+
 
 def test_dicom_to_nifti():
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
         dicom_to_nifti(
-            path_dicom=os.path.join(__dir_testing__, 'dicom_unsorted'),
+            path_dicom=path_dicom_unsorted,
             path_nifti=path_nifti,
             subject_id=subject_id
         )
@@ -34,7 +36,7 @@ def test_dicom_to_nifti_realtime_zshim(test_dcm2niix_installation):
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
         dicom_to_nifti(
-            path_dicom=os.path.join(__dir_testing__, 'realtime_zshimming_data'),
+            path_dicom=os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'sourcedata'),
             path_nifti=path_nifti,
             subject_id=subject_id
         )
@@ -71,7 +73,7 @@ def test_dicom_to_nifti_remove_tmp(test_dcm2niix_installation):
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
         dicom_to_nifti(
-            path_dicom=os.path.join(__dir_testing__, 'dicom_unsorted'),
+            path_dicom=path_dicom_unsorted,
             path_nifti=path_nifti,
             subject_id=subject_id,
             remove_tmp=True
@@ -86,11 +88,12 @@ def test_dicom_to_nifti_remove_tmp(test_dcm2niix_installation):
 def test_dicom_to_nifti_path_dicom_invalid(test_dcm2niix_installation):
     """Test the remove_tmp folder"""
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
+        path_dicom = 'dummy_path'
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
         with pytest.raises(FileNotFoundError, match=r"No dicom path found"):
             dicom_to_nifti(
-                path_dicom=os.path.join(__dir_testing__, 'invalid_folder'),
+                path_dicom=path_dicom,
                 path_nifti=path_nifti,
                 subject_id=subject_id
             )
@@ -104,7 +107,7 @@ def test_dicom_to_nifti_path_config_invalid(test_dcm2niix_installation):
         subject_id = 'sub-test'
         with pytest.raises(FileNotFoundError, match=r"No dcm2bids config file found"):
             dicom_to_nifti(
-                path_dicom=os.path.join(__dir_testing__, 'dicom_unsorted'),
+                path_dicom=path_dicom_unsorted,
                 path_nifti=path_nifti,
                 subject_id=subject_id,
                 path_config_dcm2bids=os.path.join(tmp, "invalid_folder")

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -12,10 +12,10 @@ from shimmingtoolbox import __dir_testing__
 class TestImageConcat(object):
 
     def setup(self):
-        path_anat = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'anat')
-        list_fname = [os.path.join(path_anat, 'sub-example_unshimmed_e1.nii.gz'),
-                      os.path.join(path_anat, 'sub-example_unshimmed_e2.nii.gz'),
-                      os.path.join(path_anat, 'sub-example_unshimmed_e3.nii.gz')]
+        path_anat = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat')
+        list_fname = [os.path.join(path_anat, 'sub-realtime_unshimmed_e1.nii.gz'),
+                      os.path.join(path_anat, 'sub-realtime_unshimmed_e2.nii.gz'),
+                      os.path.join(path_anat, 'sub-realtime_unshimmed_e3.nii.gz')]
 
         # Create nii list
         self.list_nii = []

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-import pytest
-
 import shimmingtoolbox
 
 

--- a/test/test_load_nifti.py
+++ b/test/test_load_nifti.py
@@ -163,6 +163,7 @@ class TestCore(object):
         "SAR": 0.00443249,
         "EchoTime": 0.00153,
         "RepetitionTime": 3.76,
+        "SpoilingState": True,
         "FlipAngle": 5,
         "PartialFourier": 1,
         "BaseResolution": 64,
@@ -173,7 +174,9 @@ class TestCore(object):
         "ReceiveCoilActiveElements": "1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H",
         "PulseSequenceDetails": "%SiemensSeq%\\tfl_rfmap",
         "RefLinesPE": 16,
+        "CoilCombinationMethod": "Sum of Squares",
         "ConsistencyInfo": "N4_VE12U_LATEST_20181126",
+        "MatrixCoilMode": "GRAPPA",
         "MultibandAccelerationFactor": 5,
         "PercentPhaseFOV": 68.75,
         "PercentSampling": 100,
@@ -184,12 +187,12 @@ class TestCore(object):
         "PixelBandwidth": 440,
         "DwellTime": 1.78e-05,
         "PhaseEncodingDirection": "j-",
-        "SliceTiming": [0, 0, 0, 0, 0],
         "ImageOrientationPatientDICOM": [1, 0, 0, 0, 1, 0],
+        "ImageOrientationText": "Tra",
         "InPlanePhaseEncodingDirectionDICOM": "COL",
         "ConversionSoftware": "dcm2niix",
-        "ConversionSoftwareVersion": "v1.0.20201102",
-        "Dcm2bidsVersion": "2.1.4"}
+        "ConversionSoftwareVersion": "v1.0.20211006"
+    }
 
     _json_b1_sagittal = {
         "Modality": "MR",
@@ -221,6 +224,7 @@ class TestCore(object):
         "SAR": 0.00464767,
         "EchoTime": 0.00163,
         "RepetitionTime": 3.76,
+        "SpoilingState": True,
         "FlipAngle": 5,
         "PartialFourier": 1,
         "BaseResolution": 64,
@@ -231,7 +235,9 @@ class TestCore(object):
         "ReceiveCoilActiveElements": "1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H",
         "PulseSequenceDetails": "%SiemensSeq%\\tfl_rfmap",
         "RefLinesPE": 16,
+        "CoilCombinationMethod": "Sum of Squares",
         "ConsistencyInfo": "N4_VE12U_LATEST_20181126",
+        "MatrixCoilMode": "GRAPPA",
         "MultibandAccelerationFactor": 5,
         "PercentPhaseFOV": 81.25,
         "PercentSampling": 100,
@@ -242,12 +248,11 @@ class TestCore(object):
         "PixelBandwidth": 440,
         "DwellTime": 1.78e-05,
         "PhaseEncodingDirection": "i",
-        "SliceTiming": [0, 0, 0, 0, 0],
         "ImageOrientationPatientDICOM": [0, 1, 0, 0, 0, -1],
+        "ImageOrientationText": "Sag",
         "InPlanePhaseEncodingDirectionDICOM": "ROW",
         "ConversionSoftware": "dcm2niix",
-        "ConversionSoftwareVersion": "v1.0.20201102",
-        "Dcm2bidsVersion": "2.1.4"
+        "ConversionSoftwareVersion": "v1.0.20211006"
     }
 
     _json_b1_coronal = {
@@ -280,6 +285,7 @@ class TestCore(object):
         "SAR": 0.00701462,
         "EchoTime": 0.00163,
         "RepetitionTime": 3.76,
+        "SpoilingState": True,
         "FlipAngle": 5,
         "PartialFourier": 1,
         "BaseResolution": 64,
@@ -290,7 +296,9 @@ class TestCore(object):
         "ReceiveCoilActiveElements": "1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H;1H",
         "PulseSequenceDetails": "%SiemensSeq%\\tfl_rfmap",
         "RefLinesPE": 16,
+        "CoilCombinationMethod": "Sum of Squares",
         "ConsistencyInfo": "N4_VE12U_LATEST_20181126",
+        "MatrixCoilMode": "GRAPPA",
         "MultibandAccelerationFactor": 5,
         "PercentPhaseFOV": 218.75,
         "PercentSampling": 100,
@@ -301,12 +309,12 @@ class TestCore(object):
         "PixelBandwidth": 440,
         "DwellTime": 1.78e-05,
         "PhaseEncodingDirection": "i",
-        "SliceTiming": [0, 0, 0, 0, 0],
         "ImageOrientationPatientDICOM": [1, 0, 0, 0, 0, -1],
+        "ImageOrientationText": "Cor",
         "InPlanePhaseEncodingDirectionDICOM": "ROW",
         "ConversionSoftware": "dcm2niix",
-        "ConversionSoftwareVersion": "v1.0.20201102",
-        "Dcm2bidsVersion": "2.1.4"}
+        "ConversionSoftwareVersion": "v1.0.20211006"
+    }
 
     def setup_method(self):
         """
@@ -547,8 +555,7 @@ class TestCore(object):
         assert (niftis.shape == (3, 3, 3, 1, 1)), "Wrong shape for the Nifti output data 2"
 
     def test_read_nii_real_data(self):
-        fname_phasediff = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                       'sub-example_phasediff.nii.gz')
+        fname_phasediff = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_phasediff.nii.gz')
         nii, json_info, phasediff = read_nii(fname_phasediff)
 
         assert nii.shape == (64, 96, 1, 10)
@@ -556,7 +563,7 @@ class TestCore(object):
         assert (phasediff.max() <= math.pi) and (phasediff.min() >= -math.pi)
 
     def test_read_nii_b1_axial(self):
-        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'TB1map_axial.nii.gz')
+        fname_b1 = os.path.join(__dir_testing__, 'ds_tb1', 'sub-tb1tfl', 'fmap', 'sub-tb1tfl_TB1TFL_axial.nii.gz')
         nii, json_info, b1 = read_nii(fname_b1)
 
         assert b1.shape == (64, 44, 5, 8), "Wrong rf-map shape"
@@ -573,7 +580,7 @@ class TestCore(object):
             "JSON file is not correctly loaded for first RF JSON"
 
     def test_read_nii_b1_coronal(self):
-        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'TB1map_coronal.nii.gz')
+        fname_b1 = os.path.join(__dir_testing__, 'ds_tb1', 'sub-tb1tfl', 'fmap', 'sub-tb1tfl_TB1TFL_coronal.nii.gz')
         nii, json_info, b1 = read_nii(fname_b1)
 
         assert b1.shape == (140, 64, 5, 8), "Wrong rf-map shape"
@@ -581,14 +588,14 @@ class TestCore(object):
         assert np.angle(b1).max(initial=0) <= np.pi and np.angle(b1).min(initial=0) >= -np.pi, \
             "Phase values out of range"
 
-        test_values = [-18.95330780647338-15.623901256474788j, 0j, -4.017854608159664+14.390338163103701j]
+        test_values = [-18.95330780647338 - 15.623901256474788j, 0j, -4.017854608159664 + 14.390338163103701j]
 
         assert np.isclose([b1[35, 35, 0, 0], b1[35, 35, 1, 4], b1[40, 25, 4, 7]], test_values).all()
         assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1_coronal, sort_keys=True)), \
             "JSON file is not correctly loaded for first RF JSON"
 
     def test_read_nii_b1_sagittal(self):
-        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'TB1map_sagittal.nii.gz')
+        fname_b1 = os.path.join(__dir_testing__, 'ds_tb1', 'sub-tb1tfl', 'fmap', 'sub-tb1tfl_TB1TFL_sagittal.nii.gz')
         nii, json_info, b1 = read_nii(fname_b1)
 
         assert b1.shape == (52, 64, 5, 8), "Wrong rf-map shape"
@@ -596,9 +603,9 @@ class TestCore(object):
         assert np.angle(b1).max(initial=0) <= np.pi and np.angle(b1).min(initial=0) >= -np.pi, \
             "Phase values out of range"
 
-        test_values = [-2.3972261793386425-2.757693261674301j,
-                       12.039283903012375+4.549266291277882j,
-                       7.2905022476747625+8.240413764304524j]
+        test_values = [-2.3972261793386425 - 2.757693261674301j,
+                       12.039283903012375 + 4.549266291277882j,
+                       7.2905022476747625 + 8.240413764304524j]
 
         assert np.isclose([b1[35, 35, 0, 0], b1[35, 35, 1, 4], b1[40, 25, 4, 7]], test_values).all()
         assert (json.dumps(json_info, sort_keys=True) == json.dumps(self._json_b1_sagittal, sort_keys=True)), \
@@ -629,7 +636,7 @@ class TestCore(object):
             read_nii(fname_b1)
 
     def test_read_nii_b1_no_scaling(self):
-        fname_b1 = os.path.join(__dir_testing__, 'b1_maps', 'nifti', 'TB1map_axial.nii.gz')
+        fname_b1 = os.path.join(__dir_testing__, 'ds_tb1', 'sub-tb1tfl', 'fmap', 'sub-tb1tfl_TB1TFL_axial.nii.gz')
         _, _, b1 = read_nii(fname_b1, auto_scale=False)
         assert b1.shape == (64, 44, 5, 16), "Wrong rf-map shape"
         test_values = [101, 2266, 281]
@@ -657,30 +664,6 @@ class TestCore(object):
 
         fname_b1 = os.path.join(self.data_path_b1, 'dummy_b1_no_shimsetting.nii')
         with pytest.raises(KeyError, match="Missing json tag: 'ShimSetting'"):
-            read_nii(fname_b1)
-
-    def test_read_nii_b1_wrong_slicetiming(self):
-        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
-        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_wrong_slicetiming'))
-        with open(os.path.join(self.data_path_b1, 'dummy_b1_wrong_slicetiming.json'), 'w') as json_file:
-            self._json_b1_wrong_slicetiming = self._json_b1_axial.copy()
-            self._json_b1_wrong_slicetiming['SliceTiming'] = str(np.zeros([15]))
-            json.dump(self._json_b1_wrong_slicetiming, json_file)
-
-        fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_wrong_slicetiming.nii")
-        with pytest.raises(ValueError, match="Wrong array dimension: number of slices not matching"):
-            read_nii(fname_b1)
-
-    def test_read_nii_b1_no_slicetiming(self):
-        dummy_data_b1 = nib.nifti1.Nifti1Image(dataobj=self._data_b1, affine=self._aff)
-        nib.save(dummy_data_b1, os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming'))
-        with open(os.path.join(self.data_path_b1, 'dummy_b1_no_slicetiming.json'), 'w') as json_file:
-            self._json_b1_no_slicetiming = self._json_b1_axial.copy()
-            del self._json_b1_no_slicetiming['SliceTiming']
-            json.dump(self._json_b1_no_slicetiming, json_file)
-
-        fname_b1 = os.path.join(self.data_path_b1, "dummy_b1_no_slicetiming.nii")
-        with pytest.warns(UserWarning, match="Missing json tag: 'SliceTiming', slices number cannot be checked."):
             read_nii(fname_b1)
 
     def test_read_nii_b1_negative_mag(self):

--- a/test/test_prelude.py
+++ b/test/test_prelude.py
@@ -6,7 +6,6 @@ import os
 import glob
 import nibabel as nib
 import numpy as np
-import logging
 import pytest
 
 from shimmingtoolbox.unwrap import prelude
@@ -44,7 +43,7 @@ class TestCore(object):
         path_data = glob.glob(os.path.join(self.toolbox_path, 'testing_data*'))[0]
 
         # Open phase data
-        fname_phases = glob.glob(os.path.join(path_data, 'sub-fieldmap', 'fmap', '*phase*.nii.gz'))
+        fname_phases = glob.glob(os.path.join(path_data, 'ds_b0', 'sub-fieldmap', 'fmap', '*phase*.nii.gz'))
         if len(fname_phases) > 2:
             raise IndexError('Phase data parsing is wrongly parsed')
 
@@ -56,7 +55,7 @@ class TestCore(object):
         phase_e2 = np.interp(nii_phase_e2.get_fdata(), [0, 4096], [-np.pi, np.pi])
 
         # Open mag data
-        fname_mags = glob.glob(os.path.join(path_data, 'sub-fieldmap', 'fmap', '*magnitude*.nii.gz'))
+        fname_mags = glob.glob(os.path.join(path_data, 'ds_b0', 'sub-fieldmap', 'fmap', '*magnitude*.nii.gz'))
 
         if len(fname_mags) > 2:
             raise IndexError('Mag data parsing is wrongly parsed')

--- a/test/test_prepare_fieldmap.py
+++ b/test/test_prepare_fieldmap.py
@@ -14,13 +14,11 @@ from shimmingtoolbox.prepare_fieldmap import prepare_fieldmap
 @pytest.mark.prelude
 class TestPrepareFieldmap(object):
     def setup(self):
-        fname_phase = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                   'sub-example_phasediff.nii.gz')
+        fname_phase = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_phasediff.nii.gz')
         nii_phase = nib.load(fname_phase)
         phase = (nii_phase.get_fdata() * 2 * math.pi / 4095) - math.pi  # [-pi, pi]
         self.nii_phase = nib.Nifti1Image(phase, nii_phase.affine, header=nii_phase.header)
-        fname_mag = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                 'sub-example_magnitude1.nii.gz')
+        fname_mag = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_magnitude1.nii.gz')
         nii_mag = nib.load(fname_mag)
         self.mag = nii_mag.get_fdata()
         self.echo_times = [0.00246, 0.00492]
@@ -44,17 +42,17 @@ class TestPrepareFieldmap(object):
         """Test 2 echoes works."""
 
         # Import 2 echoes and rescale
-        fname_phase1 = os.path.join(__dir_testing__, 'sub-fieldmap', 'fmap', 'sub-fieldmap_phase1.nii.gz')
+        fname_phase1 = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_phase1.nii.gz')
         nii_phase1 = nib.load(fname_phase1)
         phase1 = (nii_phase1.get_fdata() * 2 * math.pi / 4095) - math.pi
         nii_phase1_re = nib.Nifti1Image(phase1, nii_phase1.affine, header=nii_phase1.header)
-        fname_phase2 = os.path.join(__dir_testing__, 'sub-fieldmap', 'fmap', 'sub-fieldmap_phase2.nii.gz')
+        fname_phase2 = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_phase2.nii.gz')
         nii_phase2 = nib.load(fname_phase2)
         phase2 = (nii_phase2.get_fdata() * 2 * math.pi / 4095) - math.pi
         nii_phase1_re = nib.Nifti1Image(phase2, nii_phase2.affine, header=nii_phase2.header)
 
         # Load mag data to speed it prelude
-        fname_mag = os.path.join(__dir_testing__, 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz')
+        fname_mag = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz')
         mag = nib.load(fname_mag).get_fdata()
 
         echo_times = [0.0025, 0.0055]

--- a/test/test_siemens_basis.py
+++ b/test/test_siemens_basis.py
@@ -35,7 +35,7 @@ def test_siemens_basis_resample():
     """
     Output spherical harmonics in a discrete space corresponding to an image
     """
-    fname = os.path.join(__dir_testing__, 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz')
+    fname = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz')
     nii = nibabel.load(fname)
     # affine = np.linalg.inv(nib.affine)
     affine = nii.affine

--- a/test/test_unwrap_phase.py
+++ b/test/test_unwrap_phase.py
@@ -14,13 +14,11 @@ from shimmingtoolbox import __dir_testing__
 @pytest.mark.prelude
 class TestUnwrapPhase(object):
     def setup(self):
-        fname_phase = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                   'sub-example_phasediff.nii.gz')
+        fname_phase = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_phasediff.nii.gz')
         nii_phase = nib.load(fname_phase)
         phase = (nii_phase.get_fdata() * 2 * math.pi / 4095) - math.pi  # [-pi, pi]
         self.nii_phase = nib.Nifti1Image(phase, nii_phase.affine, header=nii_phase.header)
-        fname_mag = os.path.join(__dir_testing__, 'realtime_zshimming_data', 'nifti', 'sub-example', 'fmap',
-                                 'sub-example_magnitude1.nii.gz')
+        fname_mag = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_magnitude1.nii.gz')
         nii_mag = nib.load(fname_mag)
         self.mag = nii_mag.get_fdata()
 


### PR DESCRIPTION
We recently updated the structure of our [testing data](https://github.com/shimming-toolbox/data-testing/tree/gc/patch_bids/ds_b0/sub-fieldmap/fmap). 

This PR updates the testing paths to the new ones. 

I also cleaned up some unused imports/variables. 