### PR TITLE
Correct for possible 2*pi offsets across time points when unwrapping

### DIFF
--- a/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -10,6 +10,7 @@ import logging
 from shimmingtoolbox.load_nifti import read_nii
 from shimmingtoolbox.prepare_fieldmap import prepare_fieldmap
 from shimmingtoolbox.utils import create_fname_from_path
+from shimmingtoolbox.utils import set_all_loggers
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -38,8 +39,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    "than the threshold are set to 0.")
 @click.option('--gaussian-filter', 'gaussian_filter', type=bool, show_default=True, help="Gaussian filter for B0 map")
 @click.option('--sigma', type=float, default=1, help="Standard deviation of gaussian filter. Used for: gaussian_filter")
+@click.option('-v', '--verbose', type=click.Choice(['info', 'debug']), default='info', help="Be more verbose")
 def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, fname_mask, threshold, gaussian_filter,
-                         sigma):
+                         sigma, verbose):
     """Creates fieldmap (in Hz) from phase images.
 
     This function accommodates multiple echoes (2 or more) and phase difference. This function also
@@ -49,6 +51,8 @@ def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, f
 
     PHASE: Input path of phase nifti file(s), in ascending order: echo1, echo2, etc.
     """
+    # Set logger level
+    set_all_loggers(verbose)
 
     # Make sure output filename is valid
     fname_output_v2 = create_fname_from_path(fname_output, FILE_OUTPUT_DEFAULT)

--- a/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -22,7 +22,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
     context_settings=CONTEXT_SETTINGS,
 )
 @click.argument('phase', nargs=-1, type=click.Path(exists=True), required=True)
-@click.option('--mag', 'fname_mag', type=click.Path(exists=True), required=False, help="Input path of mag nifti file")
+@click.option('--mag', 'fname_mag', type=click.Path(exists=True), required=True, help="Input path of mag nifti file")
 @click.option('--unwrapper', type=click.Choice(['prelude']), default='prelude', show_default=True,
               help="Algorithm for unwrapping")
 @click.option('-o', '--output', 'fname_output', type=click.Path(), default=os.path.join(os.curdir, FILE_OUTPUT_DEFAULT),
@@ -32,9 +32,10 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    "standard data, it would be preferable to set this option to False and input your phase data from "
                    "-pi to pi to avoid unwanted rescaling")
 @click.option('--mask', 'fname_mask', type=click.Path(exists=True),
-              help="Input path for a mask. Mask must be the same shape as the array of each PHASE input."
-                   "Used for PRELUDE")
-@click.option('--threshold', 'threshold', type=float, help="Threshold for masking. Used for: PRELUDE")
+              help="Input path for a mask. Mask must be the same shape as the array of each PHASE input.")
+@click.option('--threshold', 'threshold', type=float, show_default=True, default=0.05,
+              help="Threshold for masking if no mask is provided. Allowed range: [0, 1] where all scaled values lower "
+                   "than the threshold are set to 0.")
 @click.option('--gaussian-filter', 'gaussian_filter', type=bool, show_default=True, help="Gaussian filter for B0 map")
 @click.option('--sigma', type=float, default=1, help="Standard deviation of gaussian filter. Used for: gaussian_filter")
 def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, fname_mask, threshold, gaussian_filter,
@@ -76,11 +77,8 @@ def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, f
     # Get affine from nii
     affine = nii_phase.affine
 
-    # If fname_mag is not an input define mag as None
-    if fname_mag is not None:
-        mag = nib.load(fname_mag).get_fdata()
-    else:
-        mag = None
+    # Magnitude image
+    mag = nib.load(fname_mag).get_fdata()
 
     # Import mask
     if fname_mask is not None:

--- a/shimmingtoolbox/prepare_fieldmap.py
+++ b/shimmingtoolbox/prepare_fieldmap.py
@@ -119,7 +119,7 @@ def prepare_fieldmap(list_nii_phase, echo_times, mag, unwrapper='prelude', mask=
 
 
 def correct_2pi_offset(unwrapped, mag, mask, validity_threshold):
-    """ Removes 2*pi offsets from unwrapped for a time series. If there is not offset, it returns the same array.
+    """ Removes 2*pi offsets from `unwrapped` for a time series. If there is no offset, it returns the same array.
 
     Args:
         unwrapped (numpy.ndarray): 4d array of the spatially unwrapped phase

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -56,9 +56,9 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
     nib.save(nii_mag, os.path.join(path_tmp, 'mag.nii'))
 
     # Fill options
-    options = ''
+    options = ""
     if is_unwrapping_in_2d:
-        options = ' -s'
+        options = " -s"
 
     # Add mask data and options if there is a mask provided
     if mask is not None:
@@ -66,21 +66,23 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
             raise ValueError("Mask must be the same shape as wrapped_phase")
         nii_mask = nib.Nifti1Image(mask, nii_wrapped_phase.affine, header=nii_wrapped_phase.header)
 
-        options += ' -m '
+        options += " -m "
         options += os.path.join(path_tmp, 'mask.nii')
         nib.save(nii_mask, os.path.join(path_tmp, 'mask.nii'))
 
     if threshold is not None:
-        options += ' -t {}'.format(threshold)
+        options += f" -t {threshold}"
         if mask is not None:
-            logger.warning('Specifying both a mask and a threshold is not recommended, results might not be what is '
-                           'expected')
+            logger.warning("Specifying both a mask and a threshold is not recommended, results might not be what is "
+                           "expected")
 
     # Unwrap
-    unwrap_command = 'prelude -p {} -a {} -o {}{}'.format(os.path.join(path_tmp, 'rawPhase'),
-                                                          os.path.join(path_tmp, 'mag'),
-                                                          os.path.join(path_tmp, 'rawPhase_unwrapped'), options)
-    logger.debug('Unwrap with prelude')
+    fname_raw_phase = os.path.join(path_tmp, 'rawPhase')
+    fname_mag = os.path.join(path_tmp, 'mag')
+    fname_out = os.path.join(path_tmp, 'rawPhase_unwrapped')
+    unwrap_command = f"prelude -p {fname_raw_phase} -a {fname_mag} -o {fname_out}{options}"
+
+    logger.debug("Unwrap with prelude")
     run_subprocess(unwrap_command)
 
     fname_phase_unwrapped = glob.glob(os.path.join(path_tmp, 'rawPhase_unwrapped*'))[0]

--- a/test/cli/test_cli_prepare_fieldmap.py
+++ b/test/cli/test_cli_prepare_fieldmap.py
@@ -20,6 +20,7 @@ fname_mag_fieldmap = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fma
 fname_phase1 = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_phase1.nii.gz')
 fname_phase2 = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_phase2.nii.gz')
 
+
 @pytest.mark.prelude
 def test_cli_prepare_fieldmap_1_echo():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:

--- a/test/test_prepare_fieldmap.py
+++ b/test/test_prepare_fieldmap.py
@@ -9,6 +9,8 @@ import numpy as np
 
 from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox.prepare_fieldmap import prepare_fieldmap
+from shimmingtoolbox.prepare_fieldmap import correct_2pi_offset
+from shimmingtoolbox.masking.threshold import threshold
 
 
 @pytest.mark.prelude
@@ -43,7 +45,7 @@ class TestPrepareFieldmap(object):
         fname_phase2 = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_phase2.nii.gz')
         nii_phase2 = nib.load(fname_phase2)
         phase2 = (nii_phase2.get_fdata() * 2 * math.pi / 4095) - math.pi
-        nii_phase1_re = nib.Nifti1Image(phase2, nii_phase2.affine, header=nii_phase2.header)
+        nii_phase2_re = nib.Nifti1Image(phase2, nii_phase2.affine, header=nii_phase2.header)
 
         # Load mag data to speed it prelude
         fname_mag = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz')
@@ -51,7 +53,7 @@ class TestPrepareFieldmap(object):
 
         echo_times = [0.0025, 0.0055]
 
-        fieldmap = prepare_fieldmap([nii_phase1_re, nii_phase1_re], echo_times, mag=mag)
+        fieldmap = prepare_fieldmap([nii_phase1_re, nii_phase2_re], echo_times, mag=mag)
 
         assert fieldmap.shape == phase1.shape
 
@@ -104,11 +106,27 @@ class TestPrepareFieldmap(object):
             prepare_fieldmap([self.nii_phase], self.echo_times, self.mag, threshold=2)
 
     def test_prepare_fieldmap_gaussian_filter(self):
-        """ Test output of gaussian filter optional argument"""
+        """Test output of gaussian filter optional argument"""
 
         fieldmap = prepare_fieldmap([self.nii_phase], self.echo_times, self.mag, gaussian_filter=True, sigma=1)
 
         assert fieldmap.shape == self.nii_phase.shape
         # If the behaviour of the called function is modified, this assertion below should capture it:
         assert np.all(np.isclose(fieldmap[30:35, 40, 0, 0],
-                                 np.array([19.46321364, 15.46275223, 11.0505227 ,  6.28134902,  1.30906534])))
+                                 np.array([19.46321364, 15.46275223, 11.0505227,  6.28134902,  1.30906534])))
+
+
+def test_correct_2pi_offset():
+    """Test if it corrects a 2pi offset"""
+    fname_mag = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'sub-realtime_magnitude1.nii.gz')
+    mag = nib.load(fname_mag).get_fdata()
+    fmap = np.zeros_like(mag)
+
+    # Add 2pi to one timepoint
+    mask = threshold(mag)
+    fmap_rad_with_offset = fmap
+    fmap_rad_with_offset[..., 2] += mask[..., 2] * 2 * np.pi
+
+    fmap_corrected = correct_2pi_offset(fmap, mag, mask, validity_threshold=0.2)
+
+    assert np.all(np.isclose(fmap_corrected, fmap))


### PR DESCRIPTION
## Description
As described in #327, there can be a n*2*pi offset when unwrapping a time series (n is an integer). This PR fixes that by:
- Calculating a shared roi where timepoints x and x+1 are well defined.
- Calculating the mean of both volumes in the roi and looking for n in n*2*pi offset.
- Corrects it by adding the proper offset to timepoints x+1.
- Restarts this algorithm but with the next time point

## Linked issues
Fixes #327 
