### PR TITLE
Fix hanging tests in CI

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,9 @@
 ###############################################################################
 #                           configure testing suite                           #
 ###############################################################################
+from multiprocessing import set_start_method
+set_start_method("spawn")
+
 import sys
 import os
 import logging

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ import sys
 import os
 import logging
 from pathlib import Path
+import multiprocessing
 
 import pytest
 from typing import Mapping

--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,10 @@
 ###############################################################################
 #                           configure testing suite                           #
 ###############################################################################
-from multiprocessing import set_start_method
-set_start_method("spawn")
-
 import sys
 import os
 import logging
 from pathlib import Path
-import multiprocessing
 
 import pytest
 from typing import Mapping

--- a/shimmingtoolbox/coils/coordinates.py
+++ b/shimmingtoolbox/coils/coordinates.py
@@ -7,7 +7,7 @@ from nibabel.affines import apply_affine
 import math
 import nibabel as nib
 from nibabel.processing import resample_from_to as nib_resample_from_to
-import multiprocessing as mp
+# import multiprocessing as mp
 
 
 def generate_meshgrid(dim, affine):
@@ -170,27 +170,27 @@ def resample_from_to(nii_from_img, nii_to_vox_map, order=2, mode='nearest', cval
 
         # Speed things up with multiprocessing.
 
-        mp.set_start_method('spawn', force=True)
-        cpus = mp.cpu_count()
-        if cpus == 1:
-            for it in range(nt):
-                nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
-                nii_resampled_3d = nib_resample_from_to(nii_from_img_3d, nii_to_vox_map, order=order, mode=mode,
-                                                        cval=cval, out_class=out_class)
-                resampled_4d[..., it] = nii_resampled_3d.get_fdata()
-        else:
-            # Create inputs for multiprocessing
-            inputs = []
-            for it in range(nt):
-                nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
-                inputs.append((nii_from_img_3d, nii_to_vox_map, order, mode, cval, out_class))
-
-            with mp.Pool(cpus - 1) as pool:
-                output = pool.starmap(_resample_3d, inputs)
-
-            # Recombine 4d array
-            for it in range(from_img.shape[3]):
-                resampled_4d[..., it] = output[it]
+        # mp.set_start_method('spawn', force=True)
+        # cpus = mp.cpu_count()
+        # if cpus == 1:
+        for it in range(nt):
+            nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
+            nii_resampled_3d = nib_resample_from_to(nii_from_img_3d, nii_to_vox_map, order=order, mode=mode,
+                                                    cval=cval, out_class=out_class)
+            resampled_4d[..., it] = nii_resampled_3d.get_fdata()
+        # else:
+        #     # Create inputs for multiprocessing
+        #     inputs = []
+        #     for it in range(nt):
+        #         nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
+        #         inputs.append((nii_from_img_3d, nii_to_vox_map, order, mode, cval, out_class))
+        #
+        #     with mp.Pool(cpus - 1) as pool:
+        #         output = pool.starmap(_resample_3d, inputs)
+        #
+        #     # Recombine 4d array
+        #     for it in range(from_img.shape[3]):
+        #         resampled_4d[..., it] = output[it]
 
         nii_resampled = nib.Nifti1Image(resampled_4d, nii_to_vox_map.affine, header=nii_to_vox_map.header)
 

--- a/shimmingtoolbox/coils/coordinates.py
+++ b/shimmingtoolbox/coils/coordinates.py
@@ -7,7 +7,7 @@ from nibabel.affines import apply_affine
 import math
 import nibabel as nib
 from nibabel.processing import resample_from_to as nib_resample_from_to
-# import multiprocessing as mp
+import multiprocessing as mp
 
 
 def generate_meshgrid(dim, affine):
@@ -170,27 +170,27 @@ def resample_from_to(nii_from_img, nii_to_vox_map, order=2, mode='nearest', cval
 
         # Speed things up with multiprocessing.
 
-        # mp.set_start_method('spawn', force=True)
-        # cpus = mp.cpu_count()
-        # if cpus == 1:
-        for it in range(nt):
-            nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
-            nii_resampled_3d = nib_resample_from_to(nii_from_img_3d, nii_to_vox_map, order=order, mode=mode,
-                                                    cval=cval, out_class=out_class)
-            resampled_4d[..., it] = nii_resampled_3d.get_fdata()
-        # else:
-        #     # Create inputs for multiprocessing
-        #     inputs = []
-        #     for it in range(nt):
-        #         nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
-        #         inputs.append((nii_from_img_3d, nii_to_vox_map, order, mode, cval, out_class))
-        #
-        #     with mp.Pool(cpus - 1) as pool:
-        #         output = pool.starmap(_resample_3d, inputs)
-        #
-        #     # Recombine 4d array
-        #     for it in range(from_img.shape[3]):
-        #         resampled_4d[..., it] = output[it]
+        mp.set_start_method('spawn', force=True)
+        cpus = mp.cpu_count()
+        if cpus == 1:
+            for it in range(nt):
+                nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
+                nii_resampled_3d = nib_resample_from_to(nii_from_img_3d, nii_to_vox_map, order=order, mode=mode,
+                                                        cval=cval, out_class=out_class)
+                resampled_4d[..., it] = nii_resampled_3d.get_fdata()
+        else:
+            # Create inputs for multiprocessing
+            inputs = []
+            for it in range(nt):
+                nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
+                inputs.append((nii_from_img_3d, nii_to_vox_map, order, mode, cval, out_class))
+
+            with mp.Pool(cpus - 1) as pool:
+                output = pool.starmap(_resample_3d, inputs)
+
+            # Recombine 4d array
+            for it in range(from_img.shape[3]):
+                resampled_4d[..., it] = output[it]
 
         nii_resampled = nib.Nifti1Image(resampled_4d, nii_to_vox_map.affine, header=nii_to_vox_map.header)
 

--- a/shimmingtoolbox/coils/coordinates.py
+++ b/shimmingtoolbox/coils/coordinates.py
@@ -7,7 +7,6 @@ from nibabel.affines import apply_affine
 import math
 import nibabel as nib
 from nibabel.processing import resample_from_to as nib_resample_from_to
-import multiprocessing as mp
 
 
 def generate_meshgrid(dim, affine):
@@ -168,29 +167,11 @@ def resample_from_to(nii_from_img, nii_to_vox_map, order=2, mode='nearest', cval
         nt = from_img.shape[3]
         resampled_4d = np.zeros(nii_to_vox_map.shape + (nt,))
 
-        # Speed things up with multiprocessing.
-
-        mp.set_start_method('spawn', force=True)
-        cpus = mp.cpu_count()
-        if cpus == 1:
-            for it in range(nt):
-                nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
-                nii_resampled_3d = nib_resample_from_to(nii_from_img_3d, nii_to_vox_map, order=order, mode=mode,
-                                                        cval=cval, out_class=out_class)
-                resampled_4d[..., it] = nii_resampled_3d.get_fdata()
-        else:
-            # Create inputs for multiprocessing
-            inputs = []
-            for it in range(nt):
-                nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
-                inputs.append((nii_from_img_3d, nii_to_vox_map, order, mode, cval, out_class))
-
-            with mp.Pool(cpus - 1) as pool:
-                output = pool.starmap(_resample_3d, inputs)
-
-            # Recombine 4d array
-            for it in range(from_img.shape[3]):
-                resampled_4d[..., it] = output[it]
+        for it in range(nt):
+            nii_from_img_3d = nib.Nifti1Image(from_img[..., it], nii_from_img.affine, header=nii_from_img.header)
+            nii_resampled_3d = nib_resample_from_to(nii_from_img_3d, nii_to_vox_map, order=order, mode=mode,
+                                                    cval=cval, out_class=out_class)
+            resampled_4d[..., it] = nii_resampled_3d.get_fdata()
 
         nii_resampled = nib.Nifti1Image(resampled_4d, nii_to_vox_map.affine, header=nii_to_vox_map.header)
 


### PR DESCRIPTION
## Description
Investigated tests that hang in the CI. The tests that were hanging all used the `resample_from_to()` that used multiprocessing. Removing the multiprocessing solves the problem. 

This PR removes that code which was not saving that much time. The test I did locally (running test_cli_b0shim.py) actually ran faster without multiprocessing. The CI also improved by ~40 seconds when running the unit tests.

## Linked issues
Fixes #329 
