### PR TITLE
Update st_dicom_to_nifti help

### DIFF
--- a/shimmingtoolbox/cli/dicom_to_nifti.py
+++ b/shimmingtoolbox/cli/dicom_to_nifti.py
@@ -10,18 +10,15 @@ from shimmingtoolbox import __dir_config_dcm2bids__
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
-@click.command(
-    context_settings=CONTEXT_SETTINGS,
-)
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-i', '--input', 'path_dicom', type=click.Path(), required=True, help="Input path to DICOM folder")
-@click.option('-o', '--output', 'path_nifti', type=click.Path(), default=os.curdir, help="Output path to BIDS folder")
 @click.option('--subject', required=True, help="Name of the imaged subject")
-@click.option('--config', 'fname_config', type=click.Path(), default=__dir_config_dcm2bids__,
-              help="Path to the BIDS config file")
-@click.option('--remove-tmp/--dont-remove-tmp', default=False,
-              help="Remove / keep tmp folder after processing")
-def dicom_to_nifti_cli(path_dicom, path_nifti, subject, fname_config, remove_tmp):
-    """Converts dicom files into nifti files by calling ``dcm2bids``."""
+@click.option('-o', '--output', 'path_nifti', type=click.Path(), default=os.curdir, help="Output path to BIDS folder")
+@click.option('--config', 'fname_config', type=click.Path(), default=__dir_config_dcm2bids__, show_default=True,
+              help="Path to dcm2bids config file")
+@click.option('--rm-tmp/--keep-tmp', 'remove_tmp', show_default=True, help="Remove / keep tmp folder")
+def dicom_to_nifti_cli(path_dicom, subject, path_nifti, fname_config, remove_tmp):
+    """Converts DICOM files into NIfTI files by calling ``dcm2bids``."""
 
     dicom_to_nifti(path_dicom=path_dicom,
                    path_nifti=path_nifti,

--- a/shimmingtoolbox/cli/dicom_to_nifti.py
+++ b/shimmingtoolbox/cli/dicom_to_nifti.py
@@ -16,7 +16,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('-o', '--output', 'path_nifti', type=click.Path(), default=os.curdir, help="Output path to BIDS folder")
 @click.option('--config', 'fname_config', type=click.Path(), default=__dir_config_dcm2bids__, show_default=True,
               help="Path to dcm2bids config file")
-@click.option('--rm-tmp/--keep-tmp', 'remove_tmp', show_default=True, help="Remove / keep tmp folder")
+@click.option('--rm-tmp', 'remove_tmp', is_flag=True, help="Remove tmp folder")
 def dicom_to_nifti_cli(path_dicom, subject, path_nifti, fname_config, remove_tmp):
     """Converts DICOM files into NIfTI files by calling ``dcm2bids``."""
 

--- a/shimmingtoolbox/cli/dicom_to_nifti.py
+++ b/shimmingtoolbox/cli/dicom_to_nifti.py
@@ -13,11 +13,11 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(
     context_settings=CONTEXT_SETTINGS,
 )
-@click.option('-i', '--input', 'path_dicom', type=click.Path(), required=True, help="Input path of dicom folder")
-@click.option('-o', '--output', 'path_nifti', type=click.Path(), default=os.curdir, help="Output path for niftis")
-@click.option('--subject', required=True, help="Name of the patient")
+@click.option('-i', '--input', 'path_dicom', type=click.Path(), required=True, help="Input path to DICOM folder")
+@click.option('-o', '--output', 'path_nifti', type=click.Path(), default=os.curdir, help="Output path to BIDS folder")
+@click.option('--subject', required=True, help="Name of the imaged subject")
 @click.option('--config', 'fname_config', type=click.Path(), default=__dir_config_dcm2bids__,
-              help="Full file path and name of the bids config file")
+              help="Path to the BIDS config file")
 @click.option('--remove-tmp/--dont-remove-tmp', default=False,
               help="Specifies if tmp folder will be deleted after processing")
 def dicom_to_nifti_cli(path_dicom, path_nifti, subject, fname_config, remove_tmp):

--- a/shimmingtoolbox/cli/dicom_to_nifti.py
+++ b/shimmingtoolbox/cli/dicom_to_nifti.py
@@ -19,7 +19,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--config', 'fname_config', type=click.Path(), default=__dir_config_dcm2bids__,
               help="Path to the BIDS config file")
 @click.option('--remove-tmp/--dont-remove-tmp', default=False,
-              help="Specifies if tmp folder will be deleted after processing")
+              help="Remove / keep tmp folder after processing")
 def dicom_to_nifti_cli(path_dicom, path_nifti, subject, fname_config, remove_tmp):
     """Converts dicom files into nifti files by calling ``dcm2bids``."""
 

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -12,10 +12,14 @@ from shimmingtoolbox import __dir_config_dcm2bids__
 from shimmingtoolbox.utils import create_output_dir
 
 
-def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__, remove_tmp=False):
+def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2bids=__dir_config_dcm2bids__,
+                   remove_tmp=False):
     """ Converts dicom files into nifti files by calling dcm2bids
 
     Args:
+        path_config_dcm2bids:
+        subject_id:
+        remove_tmp:
         path_dicom (str): path to the input dicom folder
         path_nifti (str): path to the output nifti folder
 

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -17,12 +17,11 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', path_config_dcm2
     """ Converts dicom files into nifti files by calling dcm2bids
 
     Args:
-        path_config_dcm2bids:
-        subject_id:
-        remove_tmp:
-        path_dicom (str): path to the input dicom folder
-        path_nifti (str): path to the output nifti folder
-
+        path_dicom (str): Path to the input DICOM folder.
+        path_nifti (str): Path to the output NIfTI folder.
+        subject_id (str): Name of the imaged subject.
+        path_config_dcm2bids (str): Path to the dcm2bids config JSON file.
+        remove_tmp (bool): If True, removes the tmp folder containing the NIfTI files created by dcm2niix.
     """
 
     # Create the folder where the nifti files will be stored

--- a/test/cli/test_cli_dicom_to_nifti.py
+++ b/test/cli/test_cli_dicom_to_nifti.py
@@ -19,7 +19,8 @@ def test_cli_dicom_to_nifti(test_dcm2niix_installation):
         path_dicoms = os.path.join(__dir_testing__, 'dicom_unsorted')
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        result = runner.invoke(dicom_to_nifti_cli, ['-i', path_dicoms, '-o', path_nifti, '--subject', subject_id])
+        result = runner.invoke(dicom_to_nifti_cli, ['-i', path_dicoms, '-o', path_nifti, '--subject', subject_id],
+                               catch_exceptions=False)
 
         assert result.exit_code == 0
         # Check that dicom_to_nifti was invoked, not if files were actually created (API test already looks for that)

--- a/test/cli/test_cli_dicom_to_nifti.py
+++ b/test/cli/test_cli_dicom_to_nifti.py
@@ -19,8 +19,7 @@ def test_cli_dicom_to_nifti(test_dcm2niix_installation):
         path_dicoms = os.path.join(__dir_testing__, 'dicom_unsorted')
         path_nifti = os.path.join(tmp, 'nifti')
         subject_id = 'sub-test'
-        result = runner.invoke(dicom_to_nifti_cli, ['--input', path_dicoms, '--output', path_nifti,
-                                                    '--subject', subject_id])
+        result = runner.invoke(dicom_to_nifti_cli, ['-i', path_dicoms, '-o', path_nifti, '--subject', subject_id])
 
         assert result.exit_code == 0
         # Check that dicom_to_nifti was invoked, not if files were actually created (API test already looks for that)


### PR DESCRIPTION
## Description
I find the current help returned by `st_dicom_to_nifti` a bit confusing so I wanted to think of ways to improve it together. 

### Current displayed help

![image](https://user-images.githubusercontent.com/54723104/153449130-06376bb8-0993-41b7-975f-ca6aa07fa34a.png)

### Proposed help

![image](https://user-images.githubusercontent.com/54723104/153452000-a11e2ab7-7e9b-47ef-9f7e-85803910c1af.png)

## Additional remarks
- I think the `--remove-tmp / dont-remove-tmp` flag is a bit long, we could maybe consider replacing 'remove' by 'rm' as it is a common shortcut among the CLI community.
- Should `dont-remove-tmp` be the default ? I personally think the BIDS structure is already dense enough and I don't really see the point in keeping it but maybe there is a reason to this. 
- Maybe all the [required] flags should be listed first as they are essential 

@po09i let me know what you think.