### PR TITLE
Add gradient shimming output file format to the b0 static CLI

### DIFF
--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -98,7 +98,8 @@ def b0shim_cli():
                                       "file per coil channel (coil1_ch1.txt, coil1_ch2.txt, etc.). Use 'coil' to "
                                       "output one file per coil system (coil1.txt, coil2.txt). In the latter case, "
                                       "all coil channels are encoded across multiple columns in the text file. Use "
-                                      "'gradient' to output the 1st order in the Gradient CS.")
+                                      "'gradient' to output the 1st order in the Gradient CS, otherwise, it outputs in "
+                                      "the Shim CS.")
 @click.option('--output-value-format', 'output_value_format', type=click.Choice(['delta', 'absolute']), default='delta',
               show_default=True,
               help="Coefficient values for the scanner coil. delta: Outputs the change of shim coefficients. "
@@ -410,19 +411,21 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, c
                    "Use 'slicewise' to output in row 1, 2, 3, etc. the shim coefficients for slice "
                    "1, 2, 3, etc. Use 'chronological' to output in row 1, 2, 3, etc. the shim value "
                    "for trigger 1, 2, 3, etc. The trigger is an event sent by the scanner and "
-                   "captured by the controller of the shim amplifier. There will be one output "
+                   "captured by the controller of the shim amplifier. In both cases, there will be one output "
                    "file per coil channel (coil1_ch1.txt, coil1_ch2.txt, etc.). The static, "
                    "time-varying and mean pressure are encoded in the columns of each file.")
 @click.option('--output-file-format-scanner', 'o_format_sph',
               type=click.Choice(['slicewise-ch', 'chronological-ch', 'gradient']), default='slicewise-ch',
-              show_default=True, help="Syntax used to describe the sequence of shim events. "
-                                      "Use 'slicewise' to output in row 1, 2, 3, etc. the shim coefficients for slice "
-                                      "1, 2, 3, etc. Use 'chronological' to output in row 1, 2, 3, etc. the shim value "
-                                      "for trigger 1, 2, 3, etc. The trigger is an event sent by the scanner and "
-                                      "captured by the controller of the shim amplifier. There will be one output "
-                                      "file per coil channel (coil1_ch1.txt, coil1_ch2.txt, etc.). The static, "
-                                      "time-varying and mean pressure are encoded in the columns of each file. Use "
-                                      "'gradient' to output the scanner 1st order in the Gradient CS.")
+              show_default=True,
+              help="Syntax used to describe the sequence of shim events. "
+                   "Use 'slicewise' to output in row 1, 2, 3, etc. the shim coefficients for slice "
+                   "1, 2, 3, etc. Use 'chronological' to output in row 1, 2, 3, etc. the shim value "
+                   "for trigger 1, 2, 3, etc. The trigger is an event sent by the scanner and "
+                   "captured by the controller of the shim amplifier. In both cases, there will be one output "
+                   "file per coil channel (coil1_ch1.txt, coil1_ch2.txt, etc.). The static, "
+                   "time-varying and mean pressure are encoded in the columns of each file. Use "
+                   "'gradient' to output the scanner 1st order in the Gradient CS, otherwise, it outputs "
+                   "in the Shim CS.")
 @click.option('--output-value-format', 'output_value_format', type=click.Choice(['delta', 'absolute']),
               default='delta', show_default=True,
               help="Coefficient values for the scanner coil. delta: Outputs the change of shim coefficients. "

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -335,12 +335,14 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, c
                         f.write(f"corr_vec[0][{i_slice}]= "
                                 f"{coefs[i_shim, i_channel]:.6f}\n")
                     else:
-                        # For Gx, Gy, Gz: Divide by 1000 for mt/m
+                        # For Gx, Gy, Gz: Divide by 1000 for mT/m
                         f.write(f"corr_vec[0][{i_slice}]= "
                                 f"{coefs[i_shim, i_channel] / 1000:.6f}\n")
 
+                    # Static shimming does not have a a riro component
                     f.write(f"corr_vec[1][{i_slice}]= "
                             f"{0:.12f}\n")
+                    # Arbitrarily chose a mean pressure of 2000 to satisfy the sequence
                     f.write(f"corr_vec[2][{i_slice}]= {2000:.3f}\n")
 
             list_fname_output.append(os.path.abspath(fname_output))
@@ -596,7 +598,6 @@ def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_sli
     list_fname_output = []
     n_channels = coil.dim[3]
 
-    # o_format[-3:] == '-ch':
     # Write a file for each channel
     for i_channel in range(n_channels):
         fname_output = os.path.join(path_output, f"coefs_coil{coil_number}_ch{i_channel}_{coil.name}.txt")
@@ -646,7 +647,7 @@ def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_sli
                         f.write(f"corr_vec[2][{i_slice}]= {mean_p:.3f}\n")
 
                     else:
-                        # For Gx, Gy, Gz: Divide by 1000 for mt/m
+                        # For Gx, Gy, Gz: Divide by 1000 for mT/m
                         f.write(f"corr_vec[0][{i_slice}]= "
                                 f"{currents_static[i_shim, i_channel] / 1000:.6f}\n")
                         f.write(f"corr_vec[1][{i_slice}]= "

--- a/test/cli/test_cli_b0shim.py
+++ b/test/cli/test_cli_b0shim.py
@@ -193,7 +193,7 @@ class TestCliStatic(object):
             assert os.path.isfile(os.path.join(tmp, "coefs_coil1_Prisma_fit_gradient_coil.txt"))
 
     def test_cli_static_format_chronological_coil(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
-        """Test cli with scanner coil with chronological-coil oformat"""
+        """Test cli with scanner coil with chronological-coil o_format"""
         with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
             # Save the inputs to the new directory
             fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
@@ -223,7 +223,7 @@ class TestCliStatic(object):
             # There should be 10 x 4 values
 
     def test_cli_static_format_chronological_ch(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
-        """Test cli with scanner coil with hronological_ch o_format"""
+        """Test cli with scanner coil with chronological_ch o_format"""
         with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
             # Save the inputs to the new directory
             fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
@@ -256,7 +256,7 @@ class TestCliStatic(object):
             # There should be 4 x 10 x 1 value
 
     def test_cli_static_format_slicewise_ch(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
-        """Test cli with scanner coil with slicewise_ch oformat"""
+        """Test cli with scanner coil with slicewise_ch o_format"""
         with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
             # Save the inputs to the new directory
             fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
@@ -286,6 +286,38 @@ class TestCliStatic(object):
             assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch1_Prisma_fit_gradient_coil.txt"))
             assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch2_Prisma_fit_gradient_coil.txt"))
             assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch3_Prisma_fit_gradient_coil.txt"))
+
+    def test_cli_static_format_gradient(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
+        """Test cli with scanner coil with gradient o_format"""
+        with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+            # Save the inputs to the new directory
+            fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
+            fname_fm_json = os.path.join(tmp, 'fmap.json')
+            fname_mask = os.path.join(tmp, 'mask.nii.gz')
+            fname_anat = os.path.join(tmp, 'anat.nii.gz')
+            fname_anat_json = os.path.join(tmp, 'anat.json')
+            _save_inputs(nii_fmap=nii_fmap, fname_fmap=fname_fmap,
+                         nii_anat=nii_anat, fname_anat=fname_anat,
+                         nii_mask=nii_mask, fname_mask=fname_mask,
+                         fm_data=fm_data, fname_fm_json=fname_fm_json,
+                         anat_data=anat_data, fname_anat_json=fname_anat_json)
+
+            runner = CliRunner()
+            res = runner.invoke(b0shim_cli, ['static',
+                                             '--fmap', fname_fmap,
+                                             '--anat', fname_anat,
+                                             '--mask', fname_mask,
+                                             '--scanner-coil-order', '1',
+                                             '--slice-factor', '2',
+                                             '--output-file-format-scanner', 'gradient',
+                                             '--output', tmp],
+                                catch_exceptions=False)
+
+            assert res.exit_code == 0
+            assert os.path.isfile(os.path.join(tmp, "f0shim_gradients.txt"))
+            assert os.path.isfile(os.path.join(tmp, "xshim_gradients.txt"))
+            assert os.path.isfile(os.path.join(tmp, "yshim_gradients.txt"))
+            assert os.path.isfile(os.path.join(tmp, "zshim_gradients.txt"))
 
     def test_cli_static_debug_verbose(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
         """Test cli with scanner coil profiles of order 1 with default constraints"""
@@ -625,7 +657,7 @@ class TestCLIRealtime(object):
             assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch2_Prisma_fit_gradient_coil.txt"))
             assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch3_Prisma_fit_gradient_coil.txt"))
 
-    def test_cli_rt_eva(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
+    def test_cli_rt_gradient(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
         with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
             # Save the inputs to the new directory
             fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
@@ -652,7 +684,7 @@ class TestCLIRealtime(object):
                                              '--resp', fname_resp,
                                              '--slice-factor', '2',
                                              '--scanner-coil-order', '1',
-                                             '--output-file-format', 'eva',
+                                             '--output-file-format', 'gradient',
                                              '--output', tmp],
                                 catch_exceptions=False)
 

--- a/test/cli/test_cli_b0shim.py
+++ b/test/cli/test_cli_b0shim.py
@@ -647,7 +647,7 @@ class TestCLIRealtime(object):
                                              '--resp', fname_resp,
                                              '--slice-factor', '2',
                                              '--scanner-coil-order', '1',
-                                             '--output-file-format', 'chronological-ch',
+                                             '--output-file-format-scanner', 'chronological-ch',
                                              '--output', tmp],
                                 catch_exceptions=False)
 
@@ -684,7 +684,7 @@ class TestCLIRealtime(object):
                                              '--resp', fname_resp,
                                              '--slice-factor', '2',
                                              '--scanner-coil-order', '1',
-                                             '--output-file-format', 'gradient',
+                                             '--output-file-format-scanner', 'gradient',
                                              '--output', tmp],
                                 catch_exceptions=False)
 


### PR DESCRIPTION
## Description
Adds the ability to use static shimming and output the coefficients according to the realtime shimming file format. This allows static shimming to be used with the xyz dynamic shimming sequence.

More specifically, static shimming now has the `gradient` option when choosing an output format for the scanner coil `--output-file-format-scanner`. 

It fills in the static component with the coefficients and set the riro component to 0. A mean pressure of 2000 was arbitrarily chosen.

In the realtime CLI, the output-file-format was separated in 2 to allow to change the scanner file format independently from the custom coils
