### PR TITLE
Implement order 2 in st_b0shim static and realtime CLI

### DIFF
--- a/examples/realtime_shimming.sh
+++ b/examples/realtime_shimming.sh
@@ -25,8 +25,7 @@ st_mask box --input "../anat/sub-example_unshimmed_e1.nii.gz" --size 40 40 14 --
 
 # Shim
 st_b0shim gradient_realtime --fmap "sub-example_fieldmap.nii.gz" --anat "../anat/sub-example_unshimmed_e1.nii.gz" --resp "${INPUT_PATH}/PMUresp_signal.resp" --mask-static "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --mask-riro "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --output "../../derivatives/sub-example/gradient_realtime" || exit
-st_b0shim realtime --fmap "sub-example_fieldmap.nii.gz" --anat "../anat/sub-example_unshimmed_e1.nii.gz" --mask-static "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --mask-riro "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --resp "${INPUT_PATH}/PMUresp_signal.resp" --scanner-coil-order '1' --output-file-format "slicewise-ch" --verbose "debug" --output "../../derivatives/sub-example/realtime" || exit
-
+st_b0shim realtime --fmap "sub-example_fieldmap.nii.gz" --anat "../anat/sub-example_unshimmed_e1.nii.gz" --mask-static "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --mask-riro "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --resp "${INPUT_PATH}/PMUresp_signal.resp" --scanner-coil-order '1' --output-file-format-scanner "gradient" --output "../../derivatives/sub-example/realtime" || exit
 OUTPUT_PATH="$(dirname "${INPUT_PATH}")/rt_shim_nifti/derivatives/sub-example"
 echo -e "\n\033[0;32mOutput is located here: ${OUTPUT_PATH}"
 

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -226,6 +226,7 @@ def static_cli(fname_fmap, fname_anat, fname_mask_anat, method, slices, slice_fa
                 # _plot_coefs(coil, list_slices, coefs[:, start_channel:end_channel], path_output, i_coil, units=units)
 
             else:
+                logger.debug("Converting scanner coil from Physical CS (RAS) to ShimCS")
                 # Load anat json
                 fname_anat_json = fname_anat.rsplit('.nii', 1)[0] + '.json'
                 with open(fname_anat_json) as json_file:
@@ -574,6 +575,7 @@ def realtime_cli(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_anat
                 #             pres_probe_max=pmu.max - mean_p, pres_probe_min=pmu.min - mean_p, units=units)
 
             else:
+                logger.debug("Converting scanner coil from Physical CS (RAS) to ShimCS")
                 # Load anat json
                 fname_anat_json = fname_anat.rsplit('.nii', 1)[0] + '.json'
                 with open(fname_anat_json) as json_file:

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -236,7 +236,7 @@ def static_cli(fname_fmap, fname_anat, fname_mask_anat, method, slices, slice_fa
                 manufacturer = json_anat_data['Manufacturer']
                 for i_shim in range(coefs.shape[0]):
                     # Convert coefficient
-                    coefs[i_shim, 1:] = phys_to_shim_cs(coefs[i_shim, 1:], manufacturer)
+                    coefs_coil[i_shim, 1:] = phys_to_shim_cs(coefs_coil[i_shim, 1:], manufacturer)
 
                 # Convert bounds
                 bounds_shim_cs = np.array(coil.coef_channel_minmax)
@@ -614,8 +614,8 @@ def realtime_cli(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_anat
                         pres_probe_max=pmu.max - mean_p, pres_probe_min=pmu.min - mean_p,
                         bounds=coil.coef_channel_minmax)
 
-        list_fname_output += _save_to_text_file_rt(coil, coefs_coil_static, coefs_coil_riro, mean_p, list_slices,
-                                                   path_output, o_format_coil, i_coil)
+            list_fname_output += _save_to_text_file_rt(coil, coefs_coil_static, coefs_coil_riro, mean_p, list_slices,
+                                                       path_output, o_format_coil, i_coil)
 
     logger.info(f"Coil txt file(s) are here:\n{os.linesep.join(list_fname_output)}")
 
@@ -629,9 +629,9 @@ def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_sli
 
     # Write a file for each channel
     for i_channel in range(n_channels):
-        fname_output = os.path.join(path_output, f"coefs_coil{coil_number}_ch{i_channel}_{coil.name}.txt")
 
         if o_format == 'chronological-ch':
+            fname_output = os.path.join(path_output, f"coefs_coil{coil_number}_ch{i_channel}_{coil.name}.txt")
             with open(fname_output, 'w', encoding='utf-8') as f:
                 # Each row will have 3 coef representing the static, riro and mean_p in chronological order
                 for i_shim in range(len(list_slices)):
@@ -640,6 +640,7 @@ def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_sli
                     f.write(f"{mean_p:.4f}\n")
 
         elif o_format == 'slicewise-ch':
+            fname_output = os.path.join(path_output, f"coefs_coil{coil_number}_ch{i_channel}_{coil.name}.txt")
             with open(fname_output, 'w', encoding='utf-8') as f:
                 # Each row will have one coef representing the static, riro and mean_p in slicewise order
                 n_slices = np.sum([len(a_tuple) for a_tuple in list_slices])

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -23,7 +23,7 @@ from shimmingtoolbox.pmu import PmuResp
 from shimmingtoolbox.shim.sequencer import shim_sequencer, shim_realtime_pmu_sequencer, new_bounds_from_currents
 from shimmingtoolbox.shim.sequencer import extend_slice, define_slices
 from shimmingtoolbox.utils import create_output_dir, set_all_loggers
-from shimmingtoolbox.shim.shim_utils import phys_to_gradient_cs
+from shimmingtoolbox.shim.shim_utils import phys_to_gradient_cs, phys_to_shim_cs, shim_to_phys_cs
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 logging.basicConfig(level=logging.INFO)
@@ -52,7 +52,7 @@ def b0shim_cli():
 @click.option('--mask', 'fname_mask_anat', type=click.Path(exists=True), required=False,
               help="Mask defining the spatial region to shim."
                    "The coordinate system should be the same as ``anat``'s coordinate system.")
-@click.option('--scanner-coil-order', type=click.Choice(['-1', '0', '1']), default='-1', show_default=True,
+@click.option('--scanner-coil-order', type=click.Choice(['-1', '0', '1', '2']), default='-1', show_default=True,
               help="Maximum order of the shim system. Note that specifying 1 will return "
                    "orders 0 and 1. The 0th order is the f0 frequency.")
 @click.option('--scanner-coil-constraints', 'fname_sph_constr', type=click.Path(exists=True),
@@ -162,7 +162,8 @@ def static_cli(fname_fmap, fname_anat, fname_mask_anat, method, slices, slice_fa
     initial_coefs = [json_coefs[0]] + converted_coefs
 
     # Load the coils
-    list_coils = _load_coils(coils, scanner_coil_order, fname_sph_constr, nii_fmap, initial_coefs)
+    list_coils = _load_coils(coils, scanner_coil_order, fname_sph_constr, nii_fmap, initial_coefs,
+                             json_fm_data['Manufacturer'])
 
     # Get the shim slice ordering
     n_slices = nii_anat.shape[2]
@@ -194,7 +195,7 @@ def static_cli(fname_fmap, fname_anat, fname_mask_anat, method, slices, slice_fa
 
             if output_value_format == 'delta' and scanner_coil_order >= 1:
                 logger.debug("Converting scanner coil from Physical CS (RAS) to Gradient CS")
-                # TODO: Fix for 2nd order (must validate 2nd order siemens basis)
+                # TODO: Gradient CS should only be an output if using the gradient file format
                 # Convert coef of 1st order sph harmonics to Gradient coord system
                 coefs_freq, coefs_phase, coefs_slice = phys_to_gradient_cs(coefs_coil[:, 1],
                                                                            coefs_coil[:, 2],
@@ -209,25 +210,21 @@ def static_cli(fname_fmap, fname_anat, fname_mask_anat, method, slices, slice_fa
                 # _plot_coefs(coil, list_slices, coefs[:, start_channel:end_channel], path_output, i_coil, units=units)
 
             else:  # output_value_format == 'absolute'
+
                 # Load anat json
                 fname_anat_json = fname_anat.rsplit('.nii', 1)[0] + '.json'
                 with open(fname_anat_json) as json_file:
                     json_anat_data = json.load(json_file)
 
-                if json_anat_data['Manufacturer'] == 'Siemens':
-                    # Change from RAS to LAI (ShimCS)
-                    # x
-                    coefs_coil[:, 1] = -coefs_coil[:, 1]
-                    # z
-                    coefs_coil[:, 3] = -coefs_coil[:, 3]
+                # Convert coefficients from RAS to the shim CS of the manufacturer
+                manufacturer = json_anat_data['Manufacturer']
+                for i_shim in range(coefs.shape[0]):
+                    # Convert coefficient
+                    coefs[i_shim, 1:] = phys_to_shim_cs(coefs[i_shim, 1:], manufacturer)
 
-                    # Bounds also change from RAS to LAI
-                    bounds_shim_cs = np.array(coil.coef_channel_minmax)
-                    bounds_shim_cs[1] = -bounds_shim_cs[1]
-                    bounds_shim_cs[3] = -bounds_shim_cs[3]
-                else:
-                    raise NotImplementedError(f"Manufacturer: {json_anat_data['Manufacturer']} not yet implemented for"
-                                              f"absolute format")
+                # Convert bounds
+                bounds_shim_cs = np.array(coil.coef_channel_minmax)
+                bounds_shim_cs[1:] = phys_to_shim_cs(bounds_shim_cs[1:], manufacturer)
 
                 # # Plot a figure of the coefficients (Delta), order 0 is in Hz, order 1 in mt/m, order 2 in mt/m^2
                 # units = "ShimCS [mT/m]"
@@ -329,7 +326,7 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, c
 @click.option('--mask-riro', 'fname_mask_anat_riro', type=click.Path(exists=True), required=False,
               help="Mask defining the time varying (i.e. RIRO, Respiration-Induced Resonance Offset) "
                    "region to shim. The coordinate system should be the same as ``anat``'s coordinate system.")
-@click.option('--scanner-coil-order', type=click.Choice(['-1', '0', '1']), default='-1', show_default=True,
+@click.option('--scanner-coil-order', type=click.Choice(['-1', '0', '1', '2']), default='-1', show_default=True,
               help="Maximum order of the shim system. Note that specifying 1 will return "
                    "orders 0 and 1. The 0th order is the f0 frequency.")
 @click.option('--scanner-coil-constraints', 'fname_sph_constr', type=click.Path(exists=True),
@@ -436,7 +433,8 @@ def realtime_cli(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_anat
     initial_coefs = [json_coefs[0]] + converted_coefs
 
     # Load the coils
-    list_coils = _load_coils(coils, scanner_coil_order, fname_sph_constr, nii_fmap, initial_coefs)
+    list_coils = _load_coils(coils, scanner_coil_order, fname_sph_constr, nii_fmap, initial_coefs,
+                             json_fm_data['Manufacturer'])
 
     if logger.level <= getattr(logging, 'DEBUG'):
         # Save inputs
@@ -477,7 +475,6 @@ def realtime_cli(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_anat
         if type(coil) == ScannerCoil:
 
             if output_value_format == 'delta' and scanner_coil_order >= 1:
-                # TODO: Fix for 2nd order (must validate 2nd order siemens basis)
                 logger.debug("Converting scanner coil from Physical CS (RAS) to Gradient CS")
 
                 coefs_st_freq, coefs_st_phase, coefs_st_slice = phys_to_gradient_cs(
@@ -509,22 +506,16 @@ def realtime_cli(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_anat
                 with open(fname_anat_json) as json_file:
                     json_anat_data = json.load(json_file)
 
-                if json_anat_data['Manufacturer'] == 'Siemens':
-                    # Change from RAS to LAI (ShimCS)
-                    # x
-                    coefs_coil_static[:, 1] = -coefs_coil_static[:, 1]
-                    coefs_coil_riro[:, 1] = -coefs_coil_riro[:, 1]
-                    # z
-                    coefs_coil_static[:, 3] = -coefs_coil_static[:, 3]
-                    coefs_coil_riro[:, 3] = -coefs_coil_riro[:, 3]
+                # Convert coefficients from RAS to the shim CS of the manufacturer
+                manufacturer = json_anat_data['Manufacturer']
+                for i_shim in range(coefs_coil_static.shape[0]):
+                    # Convert coefficient
+                    coefs_coil_static[i_shim, 1:] = phys_to_shim_cs(coefs_coil_static[i_shim, 1:], manufacturer)
+                    coefs_coil_riro[i_shim, 1:] = phys_to_shim_cs(coefs_coil_riro[i_shim, 1:], manufacturer)
 
-                    # Bounds also change from RAS to LAI
-                    bounds_shim_cs = np.array(coil.coef_channel_minmax)
-                    bounds_shim_cs[1] = -bounds_shim_cs[1]
-                    bounds_shim_cs[3] = -bounds_shim_cs[3]
-                else:
-                    raise NotImplementedError(f"Manufacturer: {json_anat_data['Manufacturer']} not yet implemented for"
-                                              f"absolute format")
+                # Convert bounds
+                bounds_shim_cs = np.array(coil.coef_channel_minmax)
+                bounds_shim_cs[1:] = phys_to_shim_cs(coil.coef_channel_minmax[1:], manufacturer)
 
                 # # Plot a figure of the coefficients, order 0 is in Hz, order 1 in mt/m, order 2 in mt/m^2
                 # units = "ShimCS [mT/m]"
@@ -665,7 +656,7 @@ def _load_fmap(fname_fmap, n_dims, dilation_kernel_size, path_output):
     return nii_fmap
 
 
-def _load_coils(coils, order, fname_constraints, nii_fmap, initial_coefs):
+def _load_coils(coils, order, fname_constraints, nii_fmap, initial_coefs, manufacturer):
     """ Loads the Coil objects from filenames
 
     Args:
@@ -674,6 +665,7 @@ def _load_coils(coils, order, fname_constraints, nii_fmap, initial_coefs):
         fname_constraints (str): Filename of the constraints of the scanner coils
         nii_fmap (nib.Nifti1Image): Nibabel object of the fieldmap
         initial_coefs (list): List of coefficients corresponding to the scanner coil.
+        manufacturer (str): Name of the MRI manufacturer
 
     Returns:
         list: List of Coil objects containing the custom coils followed by the scanner coil if requested
@@ -707,6 +699,18 @@ def _load_coils(coils, order, fname_constraints, nii_fmap, initial_coefs):
             # shimming
             sph_contraints['coef_channel_minmax'] = new_bounds_from_currents(np.array([initial_coefs]),
                                                                              sph_contraints['coef_channel_minmax'])[0]
+
+            bounds = np.array(sph_contraints['coef_channel_minmax'][1:])
+            # Convert bounds to RAS, if they were inverted, place min at index 0, max at index 1
+            bounds = shim_to_phys_cs(bounds, manufacturer=manufacturer)
+            for i_channel in range(len(bounds)):
+                bound_0 = bounds[i_channel, 0]
+                bound_1 = bounds[i_channel, 1]
+                if bound_0 > bound_1:
+                    bounds[i_channel, 0] = bound_1
+                    bounds[i_channel, 1] = bound_0
+            sph_contraints['coef_channel_minmax'][1:] = bounds
+
         else:
             raise OSError("Missing json file")
 

--- a/shimmingtoolbox/coils/coil.py
+++ b/shimmingtoolbox/coils/coil.py
@@ -1,11 +1,14 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
+import logging
 
 import numpy as np
 from typing import Tuple
 
 from shimmingtoolbox.coils.siemens_basis import siemens_basis
 from shimmingtoolbox.coils.coordinates import generate_meshgrid
+
+logger = logging.getLogger(__name__)
 
 required_constraints = [
     "name",
@@ -186,6 +189,8 @@ def convert_to_mp(shim_setting, manufacturers_model_name):
             raise ValueError("Multipole values exceed known system limits.")
 
     else:
-        raise NotImplementedError("Manufacturer model not recognized, could not convert units")
+        logger.warning(f"Manufacturer {manufacturers_model_name} not implemented, bounds might not be respected. "
+                       f"Setting initial shim_setting to 0")
+        shim_setting = [0, 0, 0, 0, 0, 0, 0, 0]
 
     return list(shim_setting)

--- a/shimmingtoolbox/shim/shim_utils.py
+++ b/shimmingtoolbox/shim/shim_utils.py
@@ -115,14 +115,14 @@ def phys_to_gradient_cs(coefs_x, coefs_y, coefs_z, fname_anat):
 
 
 def phys_to_shim_cs(coefs, manufacturer):
-    """Convert a list of coefficients from ras to the shim coordinate system
+    """Convert a list of coefficients from RAS to the Shim Coordinate System
 
     Args:
         coefs (np.ndarray): 1d list of coefficients in the physical RAS coordinate system of the manufacturer. The first
                             dimension represents the different channels. (indexes 0, 1, 2 --> x, y, z...). If there are
                             more coefficients, they are of higher order and must correspond to the implementation of the
                             manufacturer. i.e. Siemens: *X, Y, Z, Z2, ZX, ZY, X2-Y2, XY*
-        manufacturer (str): Name of the manufacturer to apply the correct transformation
+        manufacturer (str): Name of the manufacturer
 
     Returns:
         np.ndarray: Coefficients in the shim coordinate system of the manufacturer
@@ -140,12 +140,12 @@ def phys_to_shim_cs(coefs, manufacturer):
 
         # Order 2
         if len(coefs) >= 8:
-            # Invert X and Z --> invert ZY and XY (Z2 is double inverted and X2-Y2 is double inverted)
+            # Invert X and Z --> invert ZY and XY (Z2, XZ and X2-Y2 are double inverted)
             coefs[5] = -coefs[5]  # [ZY]
             coefs[7] = -coefs[7]  # [XY]
 
     else:
-        logger.warning(f"Manufacturer: {manufacturer} not implemented for the shimCS. Coefficients might be wrong.")
+        logger.warning(f"Manufacturer: {manufacturer} not implemented for the Shim CS. Coefficients might be wrong.")
 
     return coefs
 
@@ -154,11 +154,11 @@ def shim_to_phys_cs(coefs, manufacturer):
     """ Convert coefficients from the shim coordinate system to the physical RAS coordinate system
 
     Args:
-        coefs (np.ndarray): 1d list of coefficients in the shim coordinate system of the manufacturer. The first
+        coefs (np.ndarray): 1D list of coefficients in the Shim Coordinate System of the manufacturer. The first
                             dimension represents the different channels. Indexes 0, 1, 2 --> x, y, z... If there are
                             more coefficients, they are of higher order and must correspond to the implementation of the
                             manufacturer. Siemens: *X, Y, Z, Z2, ZX, ZY, X2-Y2, XY*
-        manufacturer (str): Name of the manufacturer to apply the correct transformation
+        manufacturer (str): Name of the manufacturer
 
     Returns:
         np.ndarray: Coefficients in the physical RAS coordinate system

--- a/shimmingtoolbox/shim/shim_utils.py
+++ b/shimmingtoolbox/shim/shim_utils.py
@@ -5,8 +5,12 @@ This file includes utility functions useful for the shimming module
 
 import nibabel as nib
 import json
+import numpy as np
+import logging
 
 from shimmingtoolbox.coils.coordinates import phys_to_vox_coefs, get_main_orientation
+
+logger = logging.getLogger(__name__)
 
 
 def get_phase_encode_direction_sign(fname_nii):
@@ -108,3 +112,58 @@ def phys_to_gradient_cs(coefs_x, coefs_y, coefs_z, fname_anat):
         coefs_phase = -coefs_phase
 
     return coefs_freq, coefs_phase, coefs_slice
+
+
+def phys_to_shim_cs(coefs, manufacturer):
+    """Convert a list of coefficients from ras to the shim coordinate system
+
+    Args:
+        coefs (np.ndarray): 1d list of coefficients in the physical RAS coordinate system of the manufacturer. The first
+                            dimension represents the different channels. (indexes 0, 1, 2 --> x, y, z...). If there are
+                            more coefficients, they are of higher order and must correspond to the implementation of the
+                            manufacturer. i.e. Siemens: *X, Y, Z, Z2, ZX, ZY, X2-Y2, XY*
+        manufacturer (str): Name of the manufacturer to apply the correct transformation
+
+    Returns:
+        np.ndarray: Coefficients in the shim coordinate system of the manufacturer
+    """
+
+    if manufacturer == 'Siemens':
+        # X, Y, Z, Z2, ZX, ZY, X2-Y2, XY
+        # 0, 1, 2, 3,  4,  5,  6,     7
+
+        # Order 1
+        if len(coefs) >= 3:
+            # Change from RAS to LAI (ShimCS)
+            coefs[0] = -coefs[0]  # X
+            coefs[2] = -coefs[2]  # Z
+
+        # Order 2
+        if len(coefs) >= 8:
+            # Invert X and Z --> invert ZY and XY (Z2 is double inverted and X2-Y2 is double inverted)
+            coefs[5] = -coefs[5]  # [ZY]
+            coefs[7] = -coefs[7]  # [XY]
+
+    else:
+        logger.warning(f"Manufacturer: {manufacturer} not implemented for the shimCS. Coefficients might be wrong.")
+
+    return coefs
+
+
+def shim_to_phys_cs(coefs, manufacturer):
+    """ Convert coefficients from the shim coordinate system to the physical RAS coordinate system
+
+    Args:
+        coefs (np.ndarray): 1d list of coefficients in the shim coordinate system of the manufacturer. The first
+                            dimension represents the different channels. Indexes 0, 1, 2 --> x, y, z... If there are
+                            more coefficients, they are of higher order and must correspond to the implementation of the
+                            manufacturer. Siemens: *X, Y, Z, Z2, ZX, ZY, X2-Y2, XY*
+        manufacturer (str): Name of the manufacturer to apply the correct transformation
+
+    Returns:
+        np.ndarray: Coefficients in the physical RAS coordinate system
+    """
+    # It's sign flips so the same function can be used for shimCS <--> phys RAS
+    coefs = phys_to_shim_cs(coefs, manufacturer)
+
+    return coefs

--- a/test/cli/test_cli_b0shim.py
+++ b/test/cli/test_cli_b0shim.py
@@ -85,7 +85,7 @@ class TestCliStatic(object):
                                              '--fmap', fname_fmap,
                                              '--anat', fname_anat,
                                              '--mask', fname_mask,
-                                             '--scanner-coil-order', '1',
+                                             '--scanner-coil-order', '2',
                                              '--output', tmp],
                                 catch_exceptions=False)
 
@@ -341,7 +341,7 @@ class TestCliStatic(object):
                                              '--fmap', fname_fmap,
                                              '--anat', fname_anat,
                                              '--mask', fname_mask,
-                                             '--scanner-coil-order', '1',
+                                             '--scanner-coil-order', '2',
                                              '--output-value-format', 'absolute',
                                              '--output', tmp],
                                 catch_exceptions=False)
@@ -688,7 +688,7 @@ class TestCLIRealtime(object):
                                              '--mask-riro', fname_mask,
                                              '--resp', fname_resp,
                                              '--slice-factor', '2',
-                                             '--scanner-coil-order', '1',
+                                             '--scanner-coil-order', '2',
                                              '--output-value-format', 'absolute',
                                              '--output', tmp],
                                 catch_exceptions=False)

--- a/test/test_coil.py
+++ b/test/test_coil.py
@@ -35,11 +35,12 @@ def test_coil_custom_coil():
     # Define a custom coil in testing_data
 
 
-def test_convert_to_mp_unknowk_scanner():
+def test_convert_to_mp_unknown_scanner(caplog):
     dac_units = [14436, 14265, 14045, 9998, 9998, 9998, 9998, 9998]
 
-    with pytest.raises(NotImplementedError, match="Manufacturer model not recognized, could not convert units"):
-        convert_to_mp(dac_units, 'unknown')
+    convert_to_mp(dac_units, 'unknown')
+    assert "Manufacturer unknown not implemented, bounds might not be respected. Setting initial " \
+           "shim_setting to 0" in caplog.text
 
 
 def test_convert_to_mp_outside_bounds():


### PR DESCRIPTION
## Description
Implement the 2nd order so that it outputs in the appropriate coordinate system. 

More specifically, when selecting to output in the shim coordinate system, the output now converts to the shimCS of the manufacturer (only Siemens is implemented right now) for the 2nd order as well. Siemens ShimCS is LAI therefore a change from RAS to LAI is required. This means inverting X and Z for the first order and inverting  ZY and XY for the 2nd order (Z2 is double inverted and X2-Y2 is double inverted).

The bounds are also converted. This means that we input the bounds of the manufacturer in their original CS (ShimCS for Siemens) in the config file.