### PR TITLE
Solve launchers needing to be launched from the ST venv

### DIFF
--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -36,8 +36,8 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
     """
 
     # Create the folder where the nifti files will be stored
-    # if not os.path.exists(path_dicom):
-    #     raise FileNotFoundError("No dicom path found")
+    if not os.path.exists(path_dicom):
+        raise FileNotFoundError("No dicom path found")
     if not os.path.exists(fname_config_dcm2bids):
         raise FileNotFoundError("No dcm2bids config file found")
     create_output_dir(path_nifti)

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -7,6 +7,10 @@ import os
 import tqdm
 import subprocess
 import logging
+from pathlib import Path
+
+HOME_DIR = str(Path.home())
+PATH_ST_VENV = f"{HOME_DIR}/shimming-toolbox/python/envs/st_venv/bin"
 
 
 def run_subprocess(cmd):
@@ -17,12 +21,16 @@ def run_subprocess(cmd):
     """
     logging.debug(f'{cmd}')
     try:
+        env = os.environ.copy()
+        # Add ST PATH before the rest of the path so that it takes precedence
+        env["PATH"] = PATH_ST_VENV + ":" + env["PATH"]
+
+        # print(env)
         subprocess.run(
             cmd.split(' '),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             text=True,
-            check=True
+            check=True,
+            env=env
         )
     except subprocess.CalledProcessError as err:
         msg = "Return code: ", err.returncode, "\nOutput: ", err.stderr

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -25,7 +25,6 @@ def run_subprocess(cmd):
         # Add ST PATH before the rest of the path so that it takes precedence
         env["PATH"] = PATH_ST_VENV + ":" + env["PATH"]
 
-        # print(env)
         subprocess.run(
             cmd.split(' '),
             text=True,


### PR DESCRIPTION
## Description
We simplified the install process of Shimming Toolbox and have included launchers so that they can be used outside of the shimming toolbox environment. Those launchers work correctly until they run a subprocess. The issue is described in #343 for dcm2bids. The problem seems to be similar to https://github.com/shimming-toolbox/fsleyes-plugin-shimming-toolbox/issues/21. The problem seems to be that the subprocess seems to have the PATH from when it was launched on the command line rather than being updated to the ST venv in the shebang. To fix this, the PATH is updated in Python and fed to the subprocess call.

## Linked issues
Fixed #343
