### PR TITLE
Add regularization term to CV reduction

### DIFF
--- a/shimmingtoolbox/shim/b1shim.py
+++ b/shimmingtoolbox/shim/b1shim.py
@@ -82,9 +82,9 @@ def b1shim(b1, mask=None, algorithm=1, target=None, q_matrix=None, sar_factor=1.
         # CV minimization
         def cost(weights):
             b1_abs = combine_maps(b1_roi, vector_to_complex(weights))
-            # Regularize with mean B1+ efficiency/1000 to favor high efficiency solutions. Avoid convergence towards 0
-            # 1000 was determined empirically. It did not affect the obtained CV for any testing data
-            return variation(b1_abs) - b1_abs.mean()/1000
+            # Regularize with mean B1+ efficiency/2000 to favor high efficiency solutions. Avoid convergence towards 0
+            # 2000 was determined empirically. It did not affect the obtained CV for any testing data
+            return variation(b1_abs) - b1_abs.mean()/2000
 
     elif algorithm == 2:
         # MLS targeting value

--- a/shimmingtoolbox/shim/b1shim.py
+++ b/shimmingtoolbox/shim/b1shim.py
@@ -81,10 +81,10 @@ def b1shim(b1, mask=None, algorithm=1, target=None, q_matrix=None, sar_factor=1.
     if algorithm == 1:
         # CV minimization
         def cost(weights):
-            return variation(combine_maps(b1_roi, vector_to_complex(weights)))
-
-        # Add a constraint that keeps the norm of the shim weights above 0.8 to avoid convergence towards 0
-        constraint.append({'type': 'ineq', 'fun': lambda w: np.linalg.norm(vector_to_complex(w)) - 0.8})
+            b1_abs = combine_maps(b1_roi, vector_to_complex(weights))
+            # Regularize with mean B1+ efficiency/1000 to favor high efficiency solutions. Avoid convergence towards 0
+            # 1000 was determined empirically. It did not affect the obtained CV for any testing data
+            return variation(b1_abs) - b1_abs.mean()/1000
 
     elif algorithm == 2:
         # MLS targeting value


### PR DESCRIPTION
## Description
It's a feature I've been willing to add for a long time but I wanted to test it on different types of data to make sure it would be robust. 

The idea is to add a regularization term to the cost function of the CV reduction algorithm to favour the solutions that yield a higher B1+ efficiency.

By testing it over segmented spine and brain data, I found that using mean(B1+)/2000 as a regularization term works really well as illustrated on the image below that shows how CV values are not modified over 10 iterations while the B1+ efficiency greatly increases.

Note that the new implementation is likely to approach the SAR limit constraining the optimization as high efficiency generally necessitate higher SAR.
 
![image](https://user-images.githubusercontent.com/54723104/157346340-4ac96814-692d-480c-831d-b5bff9c11c60.png)