### PR TITLE
Real/imaginary B1+ shim weights splitting instead of magnitude/phase

### DIFF
--- a/shimmingtoolbox/shim/b1shim.py
+++ b/shimmingtoolbox/shim/b1shim.py
@@ -123,10 +123,9 @@ def b1shim(b1, mask=None, algorithm=1, target=None, q_matrix=None, sar_factor=1.
         logger.info(f"No Q matrix provided, performing SAR unconstrained optimization while keeping the RF shim-weighs "
                     f"normalized.")
     # Optimize the complex shim weights
-    shim_weights = scipy.optimize.minimize(cost, weights_init, constraints=constraint).x
-    # Set the phase of the first element to 0
-    shim_weights[n_channels:] -= shim_weights[n_channels]
-    shim_weights = vector_to_complex(shim_weights)
+    shim_weights = vector_to_complex(scipy.optimize.minimize(cost, weights_init, constraints=constraint).x)
+    # Apply phase shift to set the phase of the first channel to 0
+    shim_weights = np.abs(shim_weights) * np.exp(1j * (np.angle(shim_weights) - np.angle(shim_weights[0])))
     return shim_weights
 
 
@@ -153,10 +152,10 @@ def combine_maps(b1_maps, weights):
 
 def vector_to_complex(weights):
     """
-    Combines magnitude and phase values contained in a vector into a half long complex vector.
+    Combines real and imaginary values contained in a vector into a half long complex vector.
 
     Args:
-        weights (numpy.ndarray): 1D array of shim weights (length 2*n_channels). First/second half: magnitude/phase.
+        weights (numpy.ndarray): 1D array of length 2*n_channels. First/second half: real/imaginary.
 
     Returns:
         numpy.ndarray: 1D complex array of length n_channels.
@@ -166,21 +165,21 @@ def vector_to_complex(weights):
         pass
     else:
         raise ValueError("The vector must have an even number of elements.")
-    return weights[:len(weights) // 2] * np.exp(1j * weights[len(weights) // 2:])
+    return weights[:len(weights) // 2] + 1j * weights[len(weights) // 2:]
 
 
 def complex_to_vector(weights):
     """
-    Combines separates magnitude and phase values contained in a complex vector into a twice as long vector.
+    Separates the real and imaginary components of a complex vector into a twice as long vector.
 
     Args:
         weights (numpy.ndarray): 1D complex array of length n_channels.
 
     Returns:
-        numpy.ndarray: 1D array of shim weights (length 2*n_channels). First/second half: magnitude/phase.
+        numpy.ndarray: 1D array of length 2*n_channels. First/second half: real/imaginary.
 
     """
-    return np.concatenate((np.abs(weights), np.angle(weights)))
+    return np.concatenate((np.real(weights), np.imag(weights)))
 
 
 def max_sar(weights, q_matrix):

--- a/test/shim/test_b1shim.py
+++ b/test/shim/test_b1shim.py
@@ -100,17 +100,17 @@ def test_b1shim_no_b1_in_mask():
 
 
 def test_vector_to_complex():
-    assert np.isclose(vector_to_complex(np.asarray([1, 1, 1, 0, np.pi/2, np.pi])), np.asarray([1,  1j, -1])).all(),\
+    assert np.isclose(vector_to_complex(np.asarray([1, 4, -1, 2, -1, 6])), np.asarray([1+2j,  4-1j, -1+6j])).all(),\
         "The function vector_to_complex returns unexpected results"
 
 
 def test_vector_to_complex_wrong_length():
     with pytest.raises(ValueError, match=r"The vector must have an even number of elements."):
-        vector_to_complex(np.asarray([1, 1, 1, 0, np.pi/2])), np.asarray([1,  1j, -1])
+        vector_to_complex(np.asarray([1, 4, -1, 2, -1]))
 
 
 def test_complex_to_vector():
-    assert np.isclose(complex_to_vector(np.asarray([1,  1j, -1])), np.asarray([1, 1, 1, 0, np.pi/2, np.pi])).all(),\
+    assert np.isclose(complex_to_vector(np.asarray([1+2j,  4-1j, -1+6j])), np.asarray([1, 4, -1, 2, -1, 6])).all(),\
         "The function complex_to_vector returns unexpected results"
 
 


### PR DESCRIPTION
## Description
At the beginning of the B1+ shimming experimentation, I compare the shimming results obtained when splitting the B1+ shim weights by phase/magnitude or by real/imaginary component before running the non-convex optimization routine via `scipy.optimize.minimize()`. At the time, I did not observe much difference (they converged towards the same shimming solutions and the optimization time were very close) so I decided to go with magnitude/phase splitting because I was more comfortable with it. 

Now that I have access to individual B1+ maps of a full brain volume, I decided to run this comparison again. The results are show on the figure below with the target algorithm.

While both solutions indeed converge toward the same optimized shim weights, real/imaginary splitting is faster over a large number of voxels. 

This PR therefore simply switches from Magnitude/Phase to Real/Imaginary splitting to increase the shimming speed.

![image](https://user-images.githubusercontent.com/54723104/157696196-a9f7cc9b-81a6-4aab-88e1-66428021eea0.png)
 

