### PR TITLE
Update required importlib-metadata version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         "click",
         "dcm2bids==2.1.4",
-        'importlib-metadata ~= 1.0 ; python_version < "3.8"',
+        'importlib-metadata ~= 4.0 ; python_version < "3.8"',
         "numpy>=1.21",
         "phantominator~=0.6.4",
         "nibabel~=3.2.1",


### PR DESCRIPTION
## Description
Update the version of importlib-metadata required by shimming-toolbox to get rid of a conflict with FSLeyes.

## Linked issues
Closes #361 