### PR TITLE
Deal with saturation pulse when B0 shimming

### DIFF
--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -476,8 +476,10 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, o
                    "Use 'slicewise' to output in row 1, 2, 3, etc. the shim coefficients for slice "
                    "1, 2, 3, etc. Use 'chronological' to output in row 1, 2, 3, etc. the shim value "
                    "for trigger 1, 2, 3, etc. The trigger is an event sent by the scanner and "
-                   "captured by the controller of the shim amplifier. In both cases, there will be one output "
-                   "file per coil channel (coil1_ch1.txt, coil1_ch2.txt, etc.). The static, "
+                   "captured by the controller of the shim amplifier. If there is a fat saturation "
+                   "pulse in the anat sequence, shim weights of 0s are included in the output "
+                   "text file before each slice coefficients. For both 'slicewice' and 'chronological', there will be "
+                   "one output file per coil channel (coil1_ch1.txt, coil1_ch2.txt, etc.). The static, "
                    "time-varying and mean pressure are encoded in the columns of each file.")
 @click.option('--output-file-format-scanner', 'o_format_sph',
               type=click.Choice(['slicewise-ch', 'chronological-ch', 'gradient']), default='slicewise-ch',

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -302,10 +302,10 @@ def dynamic_cli(fname_fmap, fname_anat, fname_mask_anat, method, slices, slice_f
                     list_fname_output += _save_to_text_file_static(coil, coefs_coil, list_slices, path_output,
                                                                    o_format_sph, options, coil_number=i_coil,
                                                                    default_coefs=initial_coefs)
-                # If it's delta
-                else:
-                    list_fname_output += _save_to_text_file_static(coil, coefs_coil, list_slices, path_output,
-                                                                   o_format_sph, options, coil_number=i_coil)
+                    continue
+
+            list_fname_output += _save_to_text_file_static(coil, coefs_coil, list_slices, path_output, o_format_sph,
+                                                           options, coil_number=i_coil)
 
         else:
             list_fname_output += _save_to_text_file_static(coil, coefs_coil, list_slices, path_output, o_format_coil,
@@ -697,10 +697,10 @@ def realtime_cli(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_anat
                     list_fname_output += _save_to_text_file_rt(coil, coefs_coil_static, coefs_coil_riro, mean_p,
                                                                list_slices, path_output, o_format_sph, options, i_coil,
                                                                default_st_coefs=initial_coefs)
-                # If it's delta,
-                else:
-                    list_fname_output += _save_to_text_file_rt(coil, coefs_coil_static, coefs_coil_riro, mean_p,
-                                                               list_slices, path_output, o_format_sph, options, i_coil)
+                    continue
+
+            list_fname_output += _save_to_text_file_rt(coil, coefs_coil_static, coefs_coil_riro, mean_p, list_slices,
+                                                       path_output, o_format_sph, options, i_coil)
 
         else:  # Custom coil
             # Plot a figure of the coefficients

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -321,16 +321,13 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, o
             if o_format == 'chronological-coil':
                 # Output per shim (chronological), output all channels for a particular shim, then repeat
                 for i_shim in range(len(list_slices)):
+                    # If fatsat pulse, set shim coefs to 0
                     if options['fatsat']:
                         for i_channel in range(n_channels):
-                            f.write(f"{0:.1f}")
-                            if i_channel != n_channels:
-                                f.write(", ")
+                            f.write(f"{0:.1f}, ")
                         f.write(f"\n")
                     for i_channel in range(n_channels):
-                        f.write(f"{coefs[i_shim, i_channel]:.6f}")
-                        if i_channel != n_channels:
-                            f.write(", ")
+                        f.write(f"{coefs[i_shim, i_channel]:.6f}, ")
                     f.write("\n")
 
             elif o_format == 'slicewise-coil':
@@ -341,9 +338,7 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, o
                 for i_slice in range(n_slices):
                     i_shim = [list_slices.index(a_shim) for a_shim in list_slices if i_slice in a_shim][0]
                     for i_channel in range(n_channels):
-                        f.write(f"{coefs[i_shim, i_channel]:.6f}")
-                        if i_channel != n_channels:
-                            f.write(", ")
+                        f.write(f"{coefs[i_shim, i_channel]:.6f}, ")
                     f.write("\n")
 
         list_fname_output.append(os.path.abspath(fname_output))
@@ -359,9 +354,10 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, o
                 with open(fname_output, 'w', encoding='utf-8') as f:
                     # Each row will have one coef representing the shim in chronological order
                     for i_shim in range(len(list_slices)):
+                        # If fatsat pulse, set shim coefs to 0
                         if options['fatsat']:
-                            f.write(f"{0:.1f}\n")
-                        f.write(f"{coefs[i_shim, i_channel]:.6f}\n")
+                            f.write(f"{0:.1f},\n")
+                        f.write(f"{coefs[i_shim, i_channel]:.6f},\n")
 
             if o_format == 'slicewise-ch':
                 with open(fname_output, 'w', encoding='utf-8') as f:
@@ -708,11 +704,12 @@ def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_sli
             with open(fname_output, 'w', encoding='utf-8') as f:
                 # Each row will have 3 coef representing the static, riro and mean_p in chronological order
                 for i_shim in range(len(list_slices)):
+                    # If fatsat pulse, set shim coefs to 0 and output mean pressure
                     if options['fatsat']:
-                        f.write(f"{0:.1f}, {0:.1f}, {0:.1f}\n")
+                        f.write(f"{0:.1f}, {0:.1f}, {mean_p:.4f},\n")
                     f.write(f"{currents_static[i_shim, i_channel]:.6f}, ")
                     f.write(f"{currents_riro[i_shim, i_channel]:.12f}, ")
-                    f.write(f"{mean_p:.4f}\n")
+                    f.write(f"{mean_p:.4f},\n")
 
         elif o_format == 'slicewise-ch':
             fname_output = os.path.join(path_output, f"coefs_coil{coil_number}_ch{i_channel}_{coil.name}.txt")
@@ -723,7 +720,7 @@ def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_sli
                     i_shim = [list_slices.index(i) for i in list_slices if i_slice in i][0]
                     f.write(f"{currents_static[i_shim, i_channel]:.6f}, ")
                     f.write(f"{currents_riro[i_shim, i_channel]:.12f}, ")
-                    f.write(f"{mean_p:.4f}\n")
+                    f.write(f"{mean_p:.4f},\n")
 
         else:  # o_format == 'gradient':
 

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -101,7 +101,7 @@ def shim_sequencer(nii_fieldmap, nii_anat, nii_mask_anat, slices, coils: ListCoi
     # Make sure shape and affine of mask are the same as the anat
     if not np.all(mask.shape == anat.shape):
         raise ValueError(f"Shape of mask:\n {mask.shape} must be the same as the shape of anat:\n{anat.shape}")
-    if not np.all(nii_mask_anat.affine == nii_anat.affine):
+    if not np.all(np.isclose(nii_mask_anat.affine, nii_anat.affine)):
         raise ValueError(f"Affine of mask:\n{nii_mask_anat.affine}\nmust be the same as the affine of anat:\n"
                          f"{nii_anat.affine}")
 

--- a/test/cli/test_cli_b0shim.py
+++ b/test/cli/test_cli_b0shim.py
@@ -15,7 +15,6 @@ from shimmingtoolbox.cli.b0shim import define_slices_cli
 from shimmingtoolbox.cli.b0shim import b0shim_cli
 from shimmingtoolbox.masking.shapes import shapes
 from shimmingtoolbox import __dir_testing__
-from shimmingtoolbox import __dir_config_scanner_constraints__
 from shimmingtoolbox.coils.siemens_basis import siemens_basis
 from shimmingtoolbox.coils.coordinates import generate_meshgrid
 
@@ -43,6 +42,7 @@ def _define_inputs(fmap_dim):
 
     fname_anat_json = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.json')
     anat_data = json.load(open(fname_anat_json))
+    anat_data['ScanOptions'] = ['FS']
 
     anat = nii_anat.get_fdata()
 


### PR DESCRIPTION
## Description
This PR adresses the fat saturation pulse issues that can arise when shim coils are active during a fat sat.

This PR specifically:
- Parses the BIDS json sidecar to know if there were fat saturation pulses
- Outputs shim coefficients of 0s before each slice when using `chronological` (triggers) outputs if fat sat is used
- Adds commas after every shim coefficients for easy transfer to other files
- When using `absolute` for `--output-value-format` option, output the initial coefficients instead of 0s

Note:
- This requires a trigger before every fat sat pulse and every slice and assumes fat sat pulses are before every slice

## Linked issues
Fixes #373 