### PR TITLE
Parse slice ordering from BIDS json sidecar

### DIFF
--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -62,9 +62,10 @@ def b0shim_cli():
               default='auto', show_default=True,
               help="Define the slice ordering. If set to 'auto', automatically parse the target image.")
 @click.option('--slice-factor', 'slice_factor', type=click.INT, required=False, default=1, show_default=True,
-              help="Number of slices per shimmed group. For example, if the value is '3', then with the 'sequential' "
-                   "mode, shimming will be performed independently on the following groups: {0,1,2}, {3,4,5}, etc. "
-                   "With the mode 'interleaved', it will be: {0,2,4}, {1,3,5}, etc.")
+              help="Number of slices per shimmed group. Used when '--slices' is not set to 'auto'. For example, if the "
+                   "'--slice-factor' value is '3', then with the 'sequential' mode, shimming will be performed "
+                   "independently on the following groups: {0,1,2}, {3,4,5}, etc. With the mode 'interleaved', "
+                   "it will be: {0,2,4}, {1,3,5}, etc.")
 @click.option('--optimizer-method', 'method', type=click.Choice(['least_squares', 'pseudo_inverse']), required=False,
               default='least_squares', show_default=True,
               help="Method used by the optimizer. LS will respect the constraints, PS will not respect the constraints")
@@ -432,9 +433,10 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, c
               default='auto', show_default=True,
               help="Define the slice ordering. If set to 'auto', automatically parse the target image.")
 @click.option('--slice-factor', 'slice_factor', type=click.INT, required=False, default=1, show_default=True,
-              help="Number of slices per shimmed group. For example, if the value is '3', then with the 'sequential' "
-                   "mode, shimming will be performed independently on the following groups: {0,1,2}, {3,4,5}, etc. "
-                   "With the mode 'interleaved', it will be: {0,2,4}, {1,3,5}, etc.")
+              help="Number of slices per shimmed group. Used when '--slices' is not set to 'auto'. For example, if the "
+                   "'--slice-factor' value is '3', then with the 'sequential' mode, shimming will be performed "
+                   "independently on the following groups: {0,1,2}, {3,4,5}, etc. With the mode 'interleaved', "
+                   "it will be: {0,2,4}, {1,3,5}, etc.")
 @click.option('--optimizer-method', 'method', type=click.Choice(['least_squares', 'pseudo_inverse']), required=False,
               default='least_squares', show_default=True,
               help="Method used by the optimizer. LS will respect the constraints, PS will not respect the constraints")

--- a/test/shim/test_sequencer.py
+++ b/test/shim/test_sequencer.py
@@ -770,3 +770,16 @@ class TestParseSlices(object):
 
         assert slices == [(1,), (3,), (5,), (7,), (9,), (11,), (13,), (15,), (17,), (19,),
                           (0,), (2,), (4,), (6,), (8,), (10,), (12,), (14,), (16,), (18,)]
+
+    def test_parse_slices_slice_encode(self):
+        with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+            fname_json = os.path.join(tmp, 'test.json')
+            fname_nifti = os.path.join(tmp, 'test.nii')
+
+            self.json_data['SliceEncodingDirection'] = 'k-'
+            with open(fname_json, 'w', encoding='utf-8') as f:
+                json.dump(self.json_data, f, indent=4)
+
+            slices = parse_slices(fname_nifti)
+
+            assert slices == [(2,), (3, 4), (0, 1)]


### PR DESCRIPTION
## Description
Allow to parse the slice information according to the BIDS json sidecar.

More precisely, this PR:
- Adds a `parse_slices()` function that returns the slices ordered according to when they were shimmed.
  - Looks at the `SliceTiming` tag to figure out this information
  - Include parsing of the `SliceEncodingDirection`
- Implement in the CLIs

Note: ACS lines are not written into the SliceTiming tag and are therefore not parsed.

## Linked issues
Fixes #377 
