### PR TITLE
Share a single conda environment.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,10 +98,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          source $HOME/shimming-toolbox/python/etc/profile.d/conda.sh  # to be able to call conda
-          set +u
-          conda activate st_venv
-          set -u
+          source ~/shimming-toolbox/python/bin/activate  # to be able to call conda
           py.test . -v --cov shimmingtoolbox/ --cov-report term-missing
 
       - name: macOS Shellcheck

--- a/installer/create_venv.sh
+++ b/installer/create_venv.sh
@@ -48,4 +48,4 @@ sed_i 's/^ENABLE_USER_SITE.*$/ENABLE_USER_SITE = False/' "$ST_DIR/$PYTHON_DIR/li
 
 # activate miniconda
 # shellcheck disable=SC1091
-source python/etc/profile.d/conda.sh
+source python/etc/profile.d/conda.sh # useless?

--- a/installer/create_venv.sh
+++ b/installer/create_venv.sh
@@ -3,17 +3,11 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/utils.sh
 
-VENV=st_venv
 ST_DIR="$HOME/shimming-toolbox"
 PYTHON_DIR=python
 cd "$ST_DIR"
 
-print info "Creating new virtual environment in $ST_DIR/$PYTHON_DIR/envs/$VENV"
-
-rm -rf "$ST_DIR/$PYTHON_DIR/envs/$VENV"
-
-# create Python 3.7 venv (for Keras/TF compatibility with Centos7, see issue #2270)
-python/bin/conda create -y -p "$ST_DIR/$PYTHON_DIR/envs/$VENV" python=3.7
+print info "Creating new virtual environment in $ST_DIR/$PYTHON_DIR"
 
 if [ "$(uname)" = "Darwin" ]; then
   # macOS polyfills
@@ -50,12 +44,8 @@ fi
 # * https://github.com/neuropoly/spinalcordtoolbox/issues/3200
 # this needs to be added very early in python's boot process
 # so using sitecustomize.py or even just appending to the file are impossible.
-sed_i 's/^ENABLE_USER_SITE.*$/ENABLE_USER_SITE = False/' "$ST_DIR/$PYTHON_DIR/envs/$VENV/lib/python"*"/site.py"
+sed_i 's/^ENABLE_USER_SITE.*$/ENABLE_USER_SITE = False/' "$ST_DIR/$PYTHON_DIR/lib/python"*"/site.py"
 
 # activate miniconda
 # shellcheck disable=SC1091
 source python/etc/profile.d/conda.sh
-
-# set +u #disable safeties, for conda is not written to their standard.
-conda activate $VENV
-# set -u # reactivate safeties

--- a/installer/create_venv.sh
+++ b/installer/create_venv.sh
@@ -45,7 +45,3 @@ fi
 # this needs to be added very early in python's boot process
 # so using sitecustomize.py or even just appending to the file are impossible.
 sed_i 's/^ENABLE_USER_SITE.*$/ENABLE_USER_SITE = False/' "$ST_DIR/$PYTHON_DIR/lib/python"*"/site.py"
-
-# activate miniconda
-# shellcheck disable=SC1091
-source python/etc/profile.d/conda.sh # useless?

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -17,9 +17,9 @@ cd "$ST_DIR"
 set -e
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    CONDA_INSTALLER=Miniconda3-latest-Linux-x86_64.sh
+    CONDA_INSTALLER=Miniconda3-py37_4.11.0-Linux-x86_64.sh
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    CONDA_INSTALLER=Miniconda3-latest-MacOSX-x86_64.sh
+    CONDA_INSTALLER=Miniconda3-py37_4.11.0-MacOSX-x86_64.sh
 elif [[ "$OSTYPE" == "cygwin" ]]; then
     # POSIX compatibility layer and Linux environment emulation for Windows
     echo "Invalid operating system"

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -6,12 +6,11 @@ source "$SCRIPT_DIR/utils.sh"
 
 set -e
 
-VENV=st_venv
 ST_DIR=$HOME/shimming-toolbox
 PYTHON_DIR=python
 BIN_DIR=bin
 
-print info "Beginning shimming-toolbox install in $ST_DIR/$PYTHON_DIR/envs/$VENV"
+print info "Beginning shimming-toolbox install in $ST_DIR/$PYTHON_DIR"
 
 
 # Define sh files
@@ -38,12 +37,9 @@ function edit_shellrc() {
 }
 
 source "$ST_DIR/$PYTHON_DIR/etc/profile.d/conda.sh"
-# set +u
-conda activate $VENV
-# set -u
 
 print info "Installing dcm2niix"
-yes | conda install -c conda-forge dcm2niix
+conda install -y -c conda-forge dcm2niix
 
 print info "Installing shimming-toolbox"
 cd "$ST_PACKAGE_DIR"
@@ -54,7 +50,7 @@ python -m pip install -e ".[docs,dev]"
 print info "Creating launchers for Python scripts. List of functions available:"
 mkdir -p "$ST_DIR/$BIN_DIR"
 
-for file in "$ST_DIR"/"$PYTHON_DIR"/envs/"$VENV"/bin/*st_*; do
+for file in "$ST_DIR"/"$PYTHON_DIR"/bin/*st_*; do
   cp "$file" "$ST_DIR/$BIN_DIR/" # || die "Problem creating launchers!"
   print list "$file"
 done

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -36,15 +36,15 @@ function edit_shellrc() {
   fi
 }
 
-source "$ST_DIR/$PYTHON_DIR/etc/profile.d/conda.sh"
+#source "$ST_DIR/$PYTHON_DIR/etc/profile.d/conda.sh" # TODO: is this needed?
 
 print info "Installing dcm2niix"
-conda install -y -c conda-forge dcm2niix
+"$ST_DIR"/"$PYTHON_DIR"/bin/conda install -y -c conda-forge dcm2niix
 
 print info "Installing shimming-toolbox"
 cd "$ST_PACKAGE_DIR"
 cp "config/dcm2bids.json" "$ST_DIR/dcm2bids.json"
-python -m pip install -e ".[docs,dev]"
+"$ST_DIR"/"$PYTHON_DIR"/bin/python -m pip install -e ".[docs,dev]"
 
 # Create launchers for Python scripts
 print info "Creating launchers for Python scripts. List of functions available:"

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -36,7 +36,7 @@ function edit_shellrc() {
   fi
 }
 
-#source "$ST_DIR/$PYTHON_DIR/etc/profile.d/conda.sh" # TODO: is this needed?
+source "$ST_DIR/$PYTHON_DIR/bin/activate"
 
 print info "Installing dcm2niix"
 "$ST_DIR"/"$PYTHON_DIR"/bin/conda install -y -c conda-forge dcm2niix


### PR DESCRIPTION
pst_venv and st_venv were separated due to version conflicts -- we believe
over wxPython. We have lost the git log explaining exactly what they were.

They seem to be compatible now, especially after https://github.com/shimming-toolbox/fsleyes-plugin-shimming-toolbox/pull/35
so we can recombine everything into a single env.

Notice that this switches from using Miniconda-latest to Miniconda-py3.7, so that the base environment has
the version of python we expect. This is safe because this conda install is *just* for shimming-toolbox.

Corresponds to https://github.com/shimming-toolbox/fsleyes-plugin-shimming-toolbox/pull/37/

## Checklist

- [ ] I've given this PR a concise, self-descriptive, and meaningful title
- [ ] I've linked relevant issues in the PR body
- [ ] I've applied the relevant labels to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [ ] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
