### PR TITLE
Reduce memory usage and speed things up when shimming

### DIFF
--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -9,7 +9,6 @@ the gradient method in a st_shim CLI with the argument being:
 import click
 import copy
 import json
-import math
 import nibabel as nib
 import numpy as np
 import logging
@@ -21,8 +20,8 @@ from shimmingtoolbox.cli.realtime_shim import realtime_shim_cli
 from shimmingtoolbox.coils.coil import Coil, ScannerCoil, convert_to_mp
 from shimmingtoolbox.pmu import PmuResp
 from shimmingtoolbox.shim.sequencer import shim_sequencer, shim_realtime_pmu_sequencer, new_bounds_from_currents
-from shimmingtoolbox.shim.sequencer import extend_slice, define_slices, extend_fmap_to_kernel_size, parse_slices
-from shimmingtoolbox.utils import create_output_dir, set_all_loggers
+from shimmingtoolbox.shim.sequencer import define_slices, extend_fmap_to_kernel_size, parse_slices
+from shimmingtoolbox.utils import create_output_dir, set_all_loggers, timeit
 from shimmingtoolbox.shim.shim_utils import phys_to_gradient_cs, phys_to_shim_cs, shim_to_phys_cs
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -115,6 +114,7 @@ def b0shim_cli():
                    "system unless the option --output-file-format is set to gradient. The delta value format should be "
                    "used in that case.")
 @click.option('-v', '--verbose', type=click.Choice(['info', 'debug']), default='info', help="Be more verbose")
+@timeit
 def dynamic_cli(fname_fmap, fname_anat, fname_mask_anat, method, slices, slice_factor, coils,
                 dilation_kernel_size, scanner_coil_order, fname_sph_constr, fatsat, path_output, o_format_coil,
                 o_format_sph, output_value_format, verbose):
@@ -510,6 +510,7 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, o
                    "system unless the option --output-file-format is set to gradient. The delta value format should be "
                    "used in that case.")
 @click.option('-v', '--verbose', type=click.Choice(['info', 'debug']), default='info', help="Be more verbose")
+@timeit
 def realtime_cli(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_anat_riro, fname_resp, method, slices,
                  slice_factor, coils, dilation_kernel_size, scanner_coil_order, fname_sph_constr, fatsat,
                  path_output, o_format_coil, o_format_sph, output_value_format, verbose):

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -117,7 +117,7 @@ def dynamic_cli(fname_fmap, fname_anat, fname_mask_anat, method, slices, slice_f
     """ Static shim by fitting a fieldmap. Use the option --optimizer-method to change the shimming algorithm used to
     optimize. Use the options --slices and --slice-factor to change the shimming order/size of the slices.
 
-    Example of use: st_b0shim static --coil coil1.nii coil1_config.json --coil coil2.nii coil2_config.json
+    Example of use: st_b0shim dynamic --coil coil1.nii coil1_config.json --coil coil2.nii coil2_config.json
     --fmap fmap.nii --anat anat.nii --mask mask.nii --optimizer-method least_squares
     """
     # Set logger level
@@ -506,7 +506,7 @@ def realtime_cli(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_anat
     the shimming algorithm used to optimize. Use the options --slices and --slice-factor to change the shimming
     order/size of the slices.
 
-    Example of use: st_b0shim realtime --coil coil1.nii coil1_config.json --coil coil2.nii coil2_config.json
+    Example of use: st_b0shim realtime-dynamic --coil coil1.nii coil1_config.json --coil coil2.nii coil2_config.json
     --fmap fmap.nii --anat anat.nii --mask-static mask.nii --resp trace.resp --optimizer-method least_squares
     """
 

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -947,6 +947,7 @@ def _get_current_shim_settings(json_data):
     return current_coefs
 
 
+@timeit
 def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=None, pres_probe_min=None,
                 pres_probe_max=None, units='', bounds=None):
     n_shims = static_coefs.shape[0]

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -138,14 +138,13 @@ def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices,
     merged_coils, _ = opt.merge_coils(unshimmed, nii_fieldmap_orig.affine)
 
     # Initialize
-    correction_per_channel = np.zeros(merged_coils.shape + (len(slices),))
     shimmed = np.zeros(unshimmed.shape + (len(slices),))
     corrections = np.zeros(unshimmed.shape + (len(slices),))
     masks_fmap = np.zeros(unshimmed.shape + (len(slices),))
     for i_shim in range(len(slices)):
         # Calculate shimmed values
-        correction_per_channel[..., i_shim] = coef[i_shim] * merged_coils
-        corrections[..., i_shim] = np.sum(correction_per_channel[..., i_shim], axis=3, keepdims=False)
+        correction_per_channel = coef[i_shim] * merged_coils
+        corrections[..., i_shim] = np.sum(correction_per_channel, axis=3, keepdims=False)
         shimmed[..., i_shim] = unshimmed + corrections[..., i_shim]
 
         masks_fmap[..., i_shim] = resample_mask(nii_mask, nii_fieldmap_orig, slices[i_shim]).get_fdata()

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -21,7 +21,7 @@ from shimmingtoolbox.pmu import PmuResp
 from shimmingtoolbox.masking.mask_utils import resample_mask
 from shimmingtoolbox.masking.threshold import threshold
 from shimmingtoolbox.coils.coordinates import resample_from_to
-from shimmingtoolbox.utils import montage
+from shimmingtoolbox.utils import montage, timeit
 from shimmingtoolbox.shim.shim_utils import calculate_metric_within_mask
 
 ListCoil = List[Coil]
@@ -35,6 +35,7 @@ supported_optimizers = {
 }
 
 
+@timeit
 def shim_sequencer(nii_fieldmap, nii_anat, nii_mask_anat, slices, coils: ListCoil, method='least_squares',
                    mask_dilation_kernel='sphere', mask_dilation_kernel_size=3, path_output=None):
     """
@@ -124,6 +125,7 @@ def shim_sequencer(nii_fieldmap, nii_anat, nii_mask_anat, slices, coils: ListCoi
     return coefs
 
 
+@timeit
 def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices, path_output):
     """Calculate theoretical shimmed map and output figures"""
 
@@ -322,6 +324,7 @@ def _plot_static_full_mask(unshimmed, shimmed_masked, mask, path_output):
     fig.savefig(fname_figure, bbox_inches='tight')
 
 
+@timeit
 def shim_realtime_pmu_sequencer(nii_fieldmap, json_fmap, nii_anat, nii_static_mask, nii_riro_mask, slices,
                                 pmu: PmuResp, coils: ListCoil, opt_method='least_squares',
                                 mask_dilation_kernel='sphere', mask_dilation_kernel_size=3, path_output=None):
@@ -513,6 +516,7 @@ def shim_realtime_pmu_sequencer(nii_fieldmap, json_fmap, nii_anat, nii_static_ma
     return coef_static, coef_riro, mean_p, pressure_rms
 
 
+@timeit
 def _eval_rt_shim(opt: Optimizer, nii_fieldmap, nii_mask_static, coef_static, coef_riro, mean_p,
                   acq_pressures, slices, pressure_rms, pmu: PmuResp, path_output):
     logger.debug("Calculating the sum of the shimmed vs unshimmed in the static ROI.")

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -8,6 +8,10 @@ import tqdm
 import subprocess
 import logging
 from pathlib import Path
+import time
+import functools
+
+logger = logging.getLogger(__name__)
 
 HOME_DIR = str(Path.home())
 PATH_ST_VENV = f"{HOME_DIR}/shimming-toolbox/python/envs/st_venv/bin"
@@ -202,3 +206,24 @@ def montage(X):
             result[slice_m:slice_m + x, slice_n:slice_n + y] = X[:, :, image_id]
             image_id += 1
     return result
+
+
+def timeit(func):
+    """ Decorator to time a function. Decorate a function: @timeit on top of the function definition. The elapsed time
+    will output in debug mode
+    """
+
+    @functools.wraps(func)
+    def timed(*args, **kw):
+
+        ts = time.time()
+        # Call the original function
+        result = func(*args, **kw)
+        te = time.time()
+
+        # Log the output
+        logger.debug(f"Function: {func.__name__} took {te - ts:.4}s to run")
+
+        return result
+
+    return timed


### PR DESCRIPTION
## Description
When shimming with large coil profiles and/or many target slices, we can end up using a large amount of memory (>10Gb). I have isolated the problem to be when we calculate the shimmed profiles. This causes Shimming toolbox to be really slow since it saturates the RAM.

This PR:
- Removes variables that consumed lots of memory but were not used afterwards.
- Adds a decorator to time a function and output it in debug logger mode
- Improves the stability of the optimizer by scaling the output of the `_residual` function
