### PR TITLE
Add fatsat option in dynamic and realtime dynamic b0shimming

### DIFF
--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -73,9 +73,9 @@ def b0shim_cli():
                    "slice cannot be estimated: there must be at least 2 (ideally 3) points to properly estimate the "
                    "linear term. When using 2nd order or more, more dilation is necessary.")
 @click.option('--fatsat', type=click.Choice(['auto', 'yes', 'no']), default='auto', show_default=True,
-              help="Describe what to do with a fat saturation pulse. 'auto': it will parse the NIfTI file "
+              help="Describe what to do with a fat saturation pulse. 'auto': It will parse the NIfTI file "
                    "for a fat-sat pulse and add shim coefficients of 0s before every shim group when using "
-                   "'chronological-*' output-file-format-coil. 'no': it will not add 0s. 'yes': it will add 0s.")
+                   "'chronological-...' output-file-format-coil. 'no': It will not add 0s. 'yes': It will add 0s.")
 @click.option('-o', '--output', 'path_output', type=click.Path(), default=os.path.abspath(os.curdir),
               show_default=True, help="Directory to output coil text file(s).")
 @click.option('--output-file-format-coil', 'o_format_coil',
@@ -469,9 +469,9 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, o
                    "slice cannot be estimated: there must be at least 2 (ideally 3) points to properly estimate the "
                    "linear term. When using 2nd order or more, more dilation is necessary.")
 @click.option('--fatsat', type=click.Choice(['auto', 'yes', 'no']), default='auto', show_default=True,
-              help="Describe what to do with a fat saturation pulse. 'auto': it will parse the NIfTI file "
+              help="Describe what to do with a fat saturation pulse. 'auto': It will parse the NIfTI file "
                    "for a fat-sat pulse and add shim coefficients of 0s before every shim group when using "
-                   "'chronological-*' output-file-format-coil. 'no': it will not add 0s. 'yes': it will add 0s.")
+                   "'chronological-...' output-file-format-coil. 'no': It will not add 0s. 'yes': It will add 0s.")
 @click.option('-o', '--output', 'path_output', type=click.Path(), default=os.path.abspath(os.curdir),
               show_default=True, help="Directory to output coil text file(s).")
 @click.option('--output-file-format-coil', 'o_format_coil',

--- a/test/cli/test_cli_b0shim.py
+++ b/test/cli/test_cli_b0shim.py
@@ -247,7 +247,45 @@ class TestCliDynamic(object):
 
             assert res.exit_code == 0
             assert os.path.isfile(os.path.join(tmp, "coefs_coil0_Prisma_fit_gradient_coil.txt"))
-            # There should be 10 x 4 values
+
+    def test_cli_dynamic_fatsat(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
+        """Test cli with input coil"""
+        with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+            # Save the inputs to the new directory
+            fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
+            fname_fm_json = os.path.join(tmp, 'fmap.json')
+            fname_mask = os.path.join(tmp, 'mask.nii.gz')
+            fname_anat = os.path.join(tmp, 'anat.nii.gz')
+            fname_anat_json = os.path.join(tmp, 'anat.json')
+            _save_inputs(nii_fmap=nii_fmap, fname_fmap=fname_fmap,
+                         nii_anat=nii_anat, fname_anat=fname_anat,
+                         nii_mask=nii_mask, fname_mask=fname_mask,
+                         fm_data=fm_data, fname_fm_json=fname_fm_json,
+                         anat_data=anat_data, fname_anat_json=fname_anat_json)
+
+            # Dummy coil
+            nii_dummy_coil, dummy_coil_constraints = _create_dummy_coil(nii_fmap)
+            fname_dummy_coil = os.path.join(tmp, 'dummy_coil.nii.gz')
+            nib.save(nii_dummy_coil, fname_dummy_coil)
+
+            # Save json
+            fname_constraints = os.path.join(tmp, 'dummy_coil.json')
+            with open(fname_constraints, 'w', encoding='utf-8') as f:
+                json.dump(dummy_coil_constraints, f, indent=4)
+
+            runner = CliRunner()
+            res = runner.invoke(b0shim_cli, ['dynamic',
+                                             '--coil', fname_dummy_coil, fname_constraints,
+                                             '--fmap', fname_fmap,
+                                             '--anat', fname_anat,
+                                             '--mask', fname_mask,
+                                             '--output-file-format-coil', 'chronological-coil',
+                                             '--fatsat', 'no',
+                                             '--output', tmp],
+                                catch_exceptions=False)
+
+            assert res.exit_code == 0
+            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_Dummy_coil.txt"))
 
     def test_cli_dynamic_format_chronological_ch(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
         """Test cli with scanner coil with chronological_ch o_format"""


### PR DESCRIPTION
## Description
#374 added the ability to parse the JSON sidecar for a fat saturation pulse. It automatically added 0s if it detected a fatsat pulse and if the `--output-file-format-coil` is 'chronological'. In practice, we sometimes want to turn off the feature. This PR adds a `--fatsat` option with the following input values:
- 'auto': Automatically detect a fatsat pulse and add the 0s
- 'yes' : Add a the 0s even if there is no fatsat pulse parsed
- 'no': Do not add 0s even if it does parse a fatsat pulse
