### PR TITLE
Improve dcm2bids config file and fieldmap conversion

### DIFF
--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -299,6 +299,50 @@
             "criteria": {
                 "SequenceName": "*tfl2d1_16"
             }
+        },
+                {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude1",
+            "criteria": {
+                "SequenceName": "fm2d2",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "1"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude2",
+            "criteria": {
+                "SequenceName": "fm2d2",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "2"
+            }
+        },
+                {
+            "dataType": "fmap",
+            "modalityLabel": "phase1",
+            "criteria": {
+                "SequenceName": "fm2d2",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "1"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase2",
+            "criteria": {
+                "SequenceName": "fm2d2",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "2"
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "epi",
+            "criteria": {
+                "SequenceName": "*epfid2d*",
+                "ImageType": ["*", "*", "M", "*", "*"]
+            }
         }
     ]
 }

--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -32,197 +32,10 @@
             }
         },
         {
-            "dataType": "dwi",
-            "modalityLabel": "dwi",
-            "criteria": {
-                "SeriesDescription": "*DWI*"
-            }
-        },
-        {
             "dataType": "anat",
             "modalityLabel": "SWI",
             "criteria": {
                 "SeriesDescription": "*SWI*"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude1",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "1"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude2",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "2"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude3",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "3"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude4",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "4"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude5",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "5"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude6",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "6"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase1",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "1"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase2",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "2"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase3",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "3"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase4",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "4"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase5",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "5"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase6",
-            "criteria": {
-                "SeriesDescription": "a_gre_*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "6"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude1",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "1"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude2",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "2"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase1",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "1"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase2",
-            "criteria": {
-                "SeriesDescription": "*gre_field_map*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "2"
-            }
-        },
-                {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude1",
-            "criteria": {
-                "SeriesDescription": "*gre_fm*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "1"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude2",
-            "criteria": {
-                "SeriesDescription": "*gre_fm*",
-                "ImageType": ["*", "*", "M", "*"],
-                "EchoNumber": "2"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase1",
-            "criteria": {
-                "SeriesDescription": "*gre_fm*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "1"
-            }
-        },
-        {
-            "dataType": "fmap",
-            "modalityLabel": "phase2",
-            "criteria": {
-                "SeriesDescription": "*gre_fm*",
-                "ImageType": ["*", "*", "P", "*", "*"],
-                "EchoNumber": "2"
             }
         },
         {
@@ -280,27 +93,14 @@
             }
         },
         {
-            "dataType": "func",
-            "modalityLabel": "bold",
+            "dataType": "anat",
+            "modalityLabel": "epi",
             "criteria": {
-                "SeriesDescription": "*bold*"
+                "SequenceName": "*epfid2d*",
+                "ImageType": ["*", "*", "M", "*", "*"]
             }
         },
         {
-            "dataType": "func",
-            "modalityLabel": "task",
-            "criteria": {
-                "SeriesDescription": "*task-p2-s3*"
-            }
-        },
-        {
-            "dataType": "rfmap",
-            "modalityLabel": "TB1map",
-            "criteria": {
-                "SequenceName": "*tfl2d1_16"
-            }
-        },
-                {
             "dataType": "fmap",
             "modalityLabel": "magnitude1",
             "criteria": {
@@ -318,7 +118,7 @@
                 "EchoNumber": "2"
             }
         },
-                {
+        {
             "dataType": "fmap",
             "modalityLabel": "phase1",
             "criteria": {
@@ -337,11 +137,139 @@
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "epi",
+            "dataType": "fmap",
+            "modalityLabel": "magnitude1",
             "criteria": {
-                "SequenceName": "*epfid2d*",
-                "ImageType": ["*", "*", "M", "*", "*"]
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "1"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude2",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "2"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude3",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "3"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude4",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "4"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude5",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "5"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "magnitude6",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "M", "*"],
+                "EchoNumber": "6"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase1",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "1"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase2",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "2"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase3",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "3"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase4",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "4"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase5",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "5"
+            }
+        },
+        {
+            "dataType": "fmap",
+            "modalityLabel": "phase6",
+            "criteria": {
+                "SequenceName": "fl2d6",
+                "ImageType": ["*", "*", "P", "*", "*"],
+                "EchoNumber": "6"
+            }
+        },
+        {
+            "dataType": "func",
+            "modalityLabel": "bold",
+            "criteria": {
+                "SeriesDescription": "*bold*"
+            }
+        },
+        {
+            "dataType": "func",
+            "modalityLabel": "task",
+            "criteria": {
+                "SeriesDescription": "*task-p2-s3*"
+            }
+        },
+        {
+            "dataType": "dwi",
+            "modalityLabel": "dwi",
+            "criteria": {
+                "SeriesDescription": "*DWI*"
+            }
+        },
+        {
+            "dataType": "rfmap",
+            "modalityLabel": "TB1map",
+            "criteria": {
+                "SequenceName": "*tfl2d1_16"
             }
         }
     ]

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -67,7 +67,7 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
     # In the special case where a phasediff should be created but the filename is phase instead. Find the file and
     # rename it
     # Go in the fieldmap folder
-    path_fmap = os.path.join(path_nifti, subject_id, 'fmap')
+    path_fmap = os.path.join(path_nifti, f"sub-{subject_id}", 'fmap')
     if os.path.exists(path_fmap):
         # Make a list of the json files in fmap folder
         file_list = []
@@ -99,6 +99,7 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
             # Rename the json file an nifti file
             if is_renaming:
                 if os.path.exists(os.path.splitext(fname_json)[0] + '.nii.gz'):
+                    logger.debug("Renaming 'phase2' fieldmap to 'phasediff'")
                     fname_nifti_new = os.path.splitext(fname_new_json)[0] + '.nii.gz'
                     fname_nifti_old = os.path.splitext(fname_json)[0] + '.nii.gz'
                     os.rename(fname_nifti_old, fname_nifti_new)

--- a/test/test_dicom_to_nifti.py
+++ b/test/test_dicom_to_nifti.py
@@ -21,7 +21,7 @@ with open(fname_b1_json) as json_b1_file:
 def test_dicom_to_nifti():
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
-        subject_id = 'sub-test'
+        subject_id = 'test'
         dicom_to_nifti(
             path_dicom=path_dicom_unsorted,
             path_nifti=path_nifti,
@@ -32,8 +32,8 @@ def test_dicom_to_nifti():
         for i in range(1, 7):
             for modality in ['phase', 'magnitude']:
                 for ext in ['nii.gz', 'json']:
-                    assert os.path.exists(os.path.join(path_nifti, subject_id, 'fmap', subject_id + '_{}{}.{}'.format(
-                        modality, i, ext)))
+                    assert os.path.exists(os.path.join(path_nifti, f"sub-{subject_id}",
+                                                       'fmap', f"sub-{subject_id}_{modality}{i}.{ext}"))
 
 
 @pytest.mark.dcm2niix
@@ -41,7 +41,7 @@ def test_dicom_to_nifti_realtime_zshim(test_dcm2niix_installation):
     """Test dicom_to_nifti outputs the correct files for realtime_zshimming_data"""
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
-        subject_id = 'sub-test'
+        subject_id = 'test'
         dicom_to_nifti(
             path_dicom=os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'sourcedata'),
             path_nifti=path_nifti,
@@ -55,22 +55,23 @@ def test_dicom_to_nifti_realtime_zshim(test_dcm2niix_installation):
             for modality in ['phase', 'magnitude']:
                 for ext in ['nii.gz', 'json']:
                     if modality == 'phase':
-                        assert os.path.exists(os.path.join(path_nifti, subject_id, sequence_type,
-                                                           subject_id + f"_{'phasediff'}.{ext}"))
+                        assert os.path.exists(os.path.join(path_nifti, f"sub-{subject_id}", sequence_type,
+                                                           f"sub-{subject_id}_{'phasediff'}.{ext}"))
                     else:
-                        assert os.path.exists(os.path.join(path_nifti, subject_id, sequence_type,
-                                                           subject_id + f"_{modality}{i+1}.{ext}"))
+                        assert os.path.exists(os.path.join(path_nifti, f"sub-{subject_id}", sequence_type,
+                                                           f"sub-{subject_id}_{modality}{i+1}.{ext}"))
 
         sequence_type = 'anat'
         for i in range(3):
             for ext in ['nii.gz', 'json']:
                 assert os.path.exists(
-                    os.path.join(path_nifti, subject_id, sequence_type, subject_id + f"_unshimmed_e{i+1}.{ext}"))
+                    os.path.join(path_nifti, f"sub-{subject_id}", sequence_type,
+                                 f"sub-{subject_id}_unshimmed_e{i+1}.{ext}"))
 
         sequence_type = 'func'
         for ext in ['nii.gz', 'json']:
             assert os.path.exists(
-                os.path.join(path_nifti, subject_id, sequence_type, subject_id + f"_bold.{ext}"))
+                os.path.join(path_nifti, f"sub-{subject_id}", sequence_type, f"sub-{subject_id}_bold.{ext}"))
 
 
 @pytest.mark.dcm2niix
@@ -78,7 +79,7 @@ def test_dicom_to_nifti_remove_tmp(test_dcm2niix_installation):
     """Test the remove_tmp folder"""
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
-        subject_id = 'sub-test'
+        subject_id = 'test'
         dicom_to_nifti(
             path_dicom=path_dicom_unsorted,
             path_nifti=path_nifti,
@@ -97,7 +98,7 @@ def test_dicom_to_nifti_path_dicom_invalid(test_dcm2niix_installation):
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_dicom = 'dummy_path'
         path_nifti = os.path.join(tmp, 'nifti')
-        subject_id = 'sub-test'
+        subject_id = 'test'
         with pytest.raises(FileNotFoundError, match=r"No dicom path found"):
             dicom_to_nifti(
                 path_dicom=path_dicom,
@@ -111,7 +112,7 @@ def test_dicom_to_nifti_path_config_invalid(test_dcm2niix_installation):
     """Test the remove_tmp folder"""
     with tempfile.TemporaryDirectory(prefix='st_'+pathlib.Path(__file__).stem) as tmp:
         path_nifti = os.path.join(tmp, 'nifti')
-        subject_id = 'sub-test'
+        subject_id = 'test'
         with pytest.raises(FileNotFoundError, match=r"No dcm2bids config file found"):
             dicom_to_nifti(
                 path_dicom=path_dicom_unsorted,
@@ -159,5 +160,3 @@ def test_fix_tfl_b1_unknown_orientation():
     json_b1_unknown_orientation['ImageOrientationText'] = 'dummy_string'
     with pytest.raises(ValueError, match="Unknown slice orientation"):
         fix_tfl_b1(nii_b1, json_b1_unknown_orientation)
-
-


### PR DESCRIPTION
## Description
This changes the dcm2bids config file to use `SequenceName` instead of `SeriesDescription` to find the modality of the image. This allows to target more specifically while also being more useful to different groups that might not have the same 
`SeriesDescription` but would be using the same sequence.

This PR also addresses a bug where phase2.nii.gz images that were phasediff images would not get renamed correctly.
