### PR TITLE
Allow spaces in the CLIs

### DIFF
--- a/examples/general_demo.py
+++ b/examples/general_demo.py
@@ -46,7 +46,7 @@ def general_demo(path_output=os.path.join(os.path.curdir, 'output_dir')):
 
     # Download example data
     path_testing_data = os.path.join(path_output, 'testing_data')
-    run_subprocess(f'st_download_data testing_data --output {path_testing_data}')
+    run_subprocess(f"st_download_data testing_data --output '{path_testing_data}'")
 
     # Transfer from dicom to nifti
     path_dicom_unsorted = os.path.join(path_testing_data, 'dicom_unsorted')

--- a/examples/general_demo.py
+++ b/examples/general_demo.py
@@ -46,7 +46,7 @@ def general_demo(path_output=os.path.join(os.path.curdir, 'output_dir')):
 
     # Download example data
     path_testing_data = os.path.join(path_output, 'testing_data')
-    run_subprocess(f"st_download_data testing_data --output '{path_testing_data}'")
+    run_subprocess(['st_download_data', 'testing_data', '--output', path_testing_data])
 
     # Transfer from dicom to nifti
     path_dicom_unsorted = os.path.join(path_testing_data, 'dicom_unsorted')

--- a/shimmingtoolbox/cli/mask.py
+++ b/shimmingtoolbox/cli/mask.py
@@ -230,8 +230,8 @@ def sct(fname_input, fname_output, contrast, centerline, file_centerline, brain,
     else:
         remove = 0
 
-    cmd = f"sct_deepseg_sc -i {fname_process} -o {fname_seg} -c {contrast} -centerline {centerline} -kernel {kernel} " \
-          f"-r {str(remove)} -v {str(verbose)}"
+    cmd = f"sct_deepseg_sc -i '{fname_process}' -o '{fname_seg}' -c {contrast} -centerline {centerline} " \
+          f"-kernel {kernel} -r {str(remove)} -v {str(verbose)}"
     if centerline == 'file':
         cmd += f" -file_centerline {file_centerline}"
     if brain is not None and centerline == 'cnn':
@@ -240,8 +240,8 @@ def sct(fname_input, fname_output, contrast, centerline, file_centerline, brain,
     run_subprocess(cmd)
 
     # Create the mask
-    run_subprocess(f"sct_create_mask -i {fname_process} -p centerline,{fname_seg} -size {size} -f {shape} "
-                   f"-o {fname_output} -r {str(remove)} -v {str(verbose)}")
+    run_subprocess(f"sct_create_mask -i '{fname_process}' -p 'centerline,{fname_seg}' -size {size} -f {shape} "
+                   f"-o '{fname_output}' -r {str(remove)} -v {str(verbose)}")
 
     if remove:
         os.remove(fname_seg)

--- a/shimmingtoolbox/cli/mask.py
+++ b/shimmingtoolbox/cli/mask.py
@@ -230,18 +230,19 @@ def sct(fname_input, fname_output, contrast, centerline, file_centerline, brain,
     else:
         remove = 0
 
-    cmd = f"sct_deepseg_sc -i '{fname_process}' -o '{fname_seg}' -c {contrast} -centerline {centerline} " \
-          f"-kernel {kernel} -r {str(remove)} -v {str(verbose)}"
+    cmd = ['sct_deepseg_sc', '-i', fname_process, '-o', fname_seg, '-c', contrast, '-centerline', centerline,
+           '-kernel', kernel, '-r', str(remove), '-v', str(verbose)]
+
     if centerline == 'file':
-        cmd += f" -file_centerline {file_centerline}"
+        cmd += ['-file_centerline', file_centerline]
     if brain is not None and centerline == 'cnn':
-        cmd += f" -brain {brain}"
+        cmd += ['-brain', str(brain)]
 
     run_subprocess(cmd)
 
     # Create the mask
-    run_subprocess(f"sct_create_mask -i '{fname_process}' -p 'centerline,{fname_seg}' -size {size} -f {shape} "
-                   f"-o '{fname_output}' -r {str(remove)} -v {str(verbose)}")
+    run_subprocess(['sct_create_mask', '-i', fname_process, '-p', f"centerline,{fname_seg}", '-size', str(size),
+                    '-f', shape, '-o', fname_output, '-r', str(remove), '-v', str(verbose)])
 
     if remove:
         os.remove(fname_seg)

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -44,13 +44,13 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
 
     # dcm2bids is broken for windows as a python package so using CLI
     # Create bids structure for data
-    run_subprocess(f"dcm2bids_scaffold -o '{path_nifti}'")
+    run_subprocess(['dcm2bids_scaffold', '-o', path_nifti])
 
     # # Copy original dicom files into nifti_path/sourcedata
     copy_tree(path_dicom, os.path.join(path_nifti, 'sourcedata'))
     #
     # # Call the dcm2bids_helper
-    run_subprocess(f"dcm2bids_helper -d '{path_dicom}' -o '{path_nifti}'")
+    run_subprocess(['dcm2bids_helper', '-d', path_dicom, '-o', path_nifti])
     #
     # Check if the helper folder has been created
     path_helper = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
@@ -62,7 +62,7 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
     if not helper_file_list:
         raise ValueError('No data to process')
 
-    run_subprocess(f"dcm2bids -d '{path_dicom}' -o '{path_nifti}' -p '{subject_id}' -c '{fname_config_dcm2bids}'")
+    run_subprocess(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', fname_config_dcm2bids])
 
     # In the special case where a phasediff should be created but the filename is phase instead. Find the file and
     # rename it

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -44,13 +44,13 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
 
     # dcm2bids is broken for windows as a python package so using CLI
     # Create bids structure for data
-    run_subprocess(f"dcm2bids_scaffold -o {path_nifti}")
+    run_subprocess(f"dcm2bids_scaffold -o '{path_nifti}'")
 
     # # Copy original dicom files into nifti_path/sourcedata
     copy_tree(path_dicom, os.path.join(path_nifti, 'sourcedata'))
     #
     # # Call the dcm2bids_helper
-    run_subprocess(f"dcm2bids_helper -d {path_dicom} -o {path_nifti}")
+    run_subprocess(f"dcm2bids_helper -d '{path_dicom}' -o '{path_nifti}'")
     #
     # Check if the helper folder has been created
     path_helper = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
@@ -62,7 +62,7 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
     if not helper_file_list:
         raise ValueError('No data to process')
 
-    run_subprocess(f"dcm2bids -d {path_dicom} -o {path_nifti} -p {subject_id} -c {fname_config_dcm2bids}")
+    run_subprocess(f"dcm2bids -d '{path_dicom}' -o '{path_nifti}' -p '{subject_id}' -c '{fname_config_dcm2bids}'")
 
     # In the special case where a phasediff should be created but the filename is phase instead. Find the file and
     # rename it

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -66,8 +66,7 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
             raise ValueError("Mask must be the same shape as wrapped_phase")
         nii_mask = nib.Nifti1Image(mask, nii_wrapped_phase.affine, header=nii_wrapped_phase.header)
 
-        options += " -m "
-        options += os.path.join(path_tmp, 'mask.nii')
+        options += f" -m '{os.path.join(path_tmp, 'mask.nii')}'"
         nib.save(nii_mask, os.path.join(path_tmp, 'mask.nii'))
 
     if threshold is not None:
@@ -80,7 +79,7 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
     fname_raw_phase = os.path.join(path_tmp, 'rawPhase')
     fname_mag = os.path.join(path_tmp, 'mag')
     fname_out = os.path.join(path_tmp, 'rawPhase_unwrapped')
-    unwrap_command = f"prelude -p {fname_raw_phase} -a {fname_mag} -o {fname_out}{options}"
+    unwrap_command = f"prelude -p '{fname_raw_phase}' -a '{fname_mag}' -o '{fname_out}'{options}"
 
     logger.debug("Unwrap with prelude")
     run_subprocess(unwrap_command)

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -56,9 +56,10 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
     nib.save(nii_mag, os.path.join(path_tmp, 'mag.nii'))
 
     # Fill options
-    options = ""
     if is_unwrapping_in_2d:
-        options = " -s"
+        options = ['-s']
+    else:
+        options = []
 
     # Add mask data and options if there is a mask provided
     if mask is not None:
@@ -66,11 +67,13 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
             raise ValueError("Mask must be the same shape as wrapped_phase")
         nii_mask = nib.Nifti1Image(mask, nii_wrapped_phase.affine, header=nii_wrapped_phase.header)
 
-        options += f" -m '{os.path.join(path_tmp, 'mask.nii')}'"
-        nib.save(nii_mask, os.path.join(path_tmp, 'mask.nii'))
+        fname_mask = os.path.join(path_tmp, 'mask.nii')
+        options += ['-m', fname_mask]
+
+        nib.save(nii_mask, fname_mask)
 
     if threshold is not None:
-        options += f" -t {threshold}"
+        options += ['-t', str(threshold)]
         if mask is not None:
             logger.warning("Specifying both a mask and a threshold is not recommended, results might not be what is "
                            "expected")
@@ -79,7 +82,8 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
     fname_raw_phase = os.path.join(path_tmp, 'rawPhase')
     fname_mag = os.path.join(path_tmp, 'mag')
     fname_out = os.path.join(path_tmp, 'rawPhase_unwrapped')
-    unwrap_command = f"prelude -p '{fname_raw_phase}' -a '{fname_mag}' -o '{fname_out}'{options}"
+
+    unwrap_command = ['prelude', '-p', fname_raw_phase, '-a', fname_mag, '-o', fname_out] + options
 
     logger.debug("Unwrap with prelude")
     run_subprocess(unwrap_command)

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 import time
 import functools
+import shlex
 
 logger = logging.getLogger(__name__)
 
@@ -23,14 +24,15 @@ def run_subprocess(cmd):
     Args:
         cmd (string): full command to be run on the command line
     """
-    logging.debug(f'{cmd}')
+    logger.debug(f'{cmd}')
     try:
         env = os.environ.copy()
         # Add ST PATH before the rest of the path so that it takes precedence
         env["PATH"] = PATH_ST_VENV + ":" + env["PATH"]
 
+        command = shlex.split(cmd)
         subprocess.run(
-            cmd.split(' '),
+            command,
             text=True,
             check=True,
             env=env

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -10,7 +10,6 @@ import logging
 from pathlib import Path
 import time
 import functools
-import shlex
 
 logger = logging.getLogger(__name__)
 
@@ -19,27 +18,28 @@ PATH_ST_VENV = f"{HOME_DIR}/shimming-toolbox/python/envs/st_venv/bin"
 
 
 def run_subprocess(cmd):
-    """Wrapper for ``subprocess.run()`` that enables to input ``cmd`` as a full string (easier for debugging).
+    """Wrapper for ``subprocess.run()``.
 
     Args:
-        cmd (string): full command to be run on the command line
+        cmd (list): list of arguments to be passed to the command line
     """
-    logger.debug(f'{cmd}')
+    logger.debug(f"Command to run on the terminal: {cmd}")
     try:
         env = os.environ.copy()
         # Add ST PATH before the rest of the path so that it takes precedence
         env["PATH"] = PATH_ST_VENV + ":" + env["PATH"]
 
-        command = shlex.split(cmd)
         subprocess.run(
-            command,
+            cmd,
             text=True,
             check=True,
             env=env
         )
     except subprocess.CalledProcessError as err:
         msg = "Return code: ", err.returncode, "\nOutput: ", err.stderr
-        raise Exception(msg)
+        logger.debug(msg)
+        # Should we really reraise the exception?
+        raise err
 
 
 def add_suffix(fname, suffix):

--- a/shimmingtoolbox/utils.py
+++ b/shimmingtoolbox/utils.py
@@ -23,7 +23,7 @@ def run_subprocess(cmd):
     Args:
         cmd (list): list of arguments to be passed to the command line
     """
-    logger.debug(f"Command to run on the terminal: {cmd}")
+    logger.debug(f"Command to run on the terminal:\n{' '.join(cmd)}")
     try:
         env = os.environ.copy()
         # Add ST PATH before the rest of the path so that it takes precedence
@@ -37,8 +37,7 @@ def run_subprocess(cmd):
         )
     except subprocess.CalledProcessError as err:
         msg = "Return code: ", err.returncode, "\nOutput: ", err.stderr
-        logger.debug(msg)
-        # Should we really reraise the exception?
+        print(msg)
         raise err
 
 


### PR DESCRIPTION
## Description
This PR adds the ability to have spaces in the input paths of the CLIs. The limitation we previously had was when using any subprocess calls, the algorithm to split the call would split at every space therefore the command would not be correct (`cd a b` != `cd "a b"`). This is now fixed by using `shlex` and quotes around arguments/options that can have spaces.

### Note:
When validating the changes, I noticed that dcm2bids does not handle spaces in paths so `st_dicom_to_nifti` can't either. However, they do have a [PR](https://github.com/UNFmontreal/Dcm2Bids/pull/158) about this, so the changes should propagate soon.