### PR TITLE
Allow 4d masks and target anatomical when using dynamic shimming

### DIFF
--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -96,7 +96,7 @@ def shim_sequencer(nii_fieldmap, nii_anat, nii_mask_anat, slices, coils: ListCoi
     if anat.ndim == 3:
         pass
     elif anat.ndim == 4:
-        logger.debug("Target anatomical is 4d, taking the average and converting to 3d")
+        logger.info("Target anatomical is 4d, taking the average and converting to 3d")
         anat = np.mean(anat, axis=3)
         nii_anat = nib.Nifti1Image(anat, nii_anat.affine, header=nii_anat.header)
     else:

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -93,12 +93,35 @@ def shim_sequencer(nii_fieldmap, nii_anat, nii_mask_anat, slices, coils: ListCoi
 
     # Make sure anat has the appropriate dimensions
     anat = nii_anat.get_fdata()
-    if anat.ndim != 3:
-        raise ValueError("Anatomical image must be in 3d")
+    if anat.ndim == 3:
+        pass
+    elif anat.ndim == 4:
+        logger.debug("Target anatomical is 4d, taking the average and converting to 3d")
+        anat = np.mean(anat, axis=3)
+        nii_anat = nib.Nifti1Image(anat, nii_anat.affine, header=nii_anat.header)
+    else:
+        raise ValueError("Target anatomical image must be in 3d or 4d")
 
     # Make sure the mask has the appropriate dimensions
-    if nii_mask_anat.get_fdata().ndim != 3:
-        raise ValueError("Mask image must be in 3d")
+    mask = nii_mask_anat.get_fdata()
+    if mask.ndim == 3:
+        pass
+    elif mask.ndim == 4:
+        logger.debug("Mask is 4d, converting to 3d")
+        tmp_3d = np.zeros(mask.shape[:3])
+        n_vol = mask.shape[-1]
+        # Summing over 4th dimension making sure that the max value is 1
+        for i_vol in range(mask.shape[-1]):
+            tmp_3d += (mask[..., i_vol] / mask[..., i_vol].max())
+
+        # 80% of the volumes must contain the desired pixel to be included, this avoids having dead voxels in the
+        # output mask
+        tmp_3d = threshold(tmp_3d, thr=int(n_vol * 0.8))
+        nii_mask_anat = nib.Nifti1Image(tmp_3d.astype(int), nii_mask_anat.affine, header=nii_mask_anat.header)
+        if logger.level <= getattr(logging, 'DEBUG') and path_output is not None:
+            nib.save(nii_mask_anat, os.path.join(path_output, "fig_3d_mask.nii.gz"))
+    else:
+        raise ValueError("Mask must be in 3d or 4d")
 
     # Resample the input mask on the target anatomical image if they are different
     if not np.all(nii_mask_anat.shape == anat.shape) or not np.all(nii_mask_anat.affine == nii_anat.affine):

--- a/test/shim/test_sequencer.py
+++ b/test/shim/test_sequencer.py
@@ -236,25 +236,15 @@ class TestSequencer(object):
         currents = shim_sequencer(nii_fieldmap, nii_anat, nii_diff_mask, slices, [sph_coil])
         assert_results(nii_fieldmap, nii_anat, nii_diff_mask, [sph_coil], currents, slices)
 
-    # def test_speed_huge_matrix(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
-    #     # Create 1 huge coil which essentially is siemens basis concatenated 4 times
-    #     coils = [sph_coil, sph_coil, sph_coil, sph_coil]
-    #
-    #     coil_profiles_list = []
-    #
-    #     for coil in coils:
-    #         # Concat coils and bounds
-    #         coil_profiles_list.append(coil.profile)
-    #
-    #     coil_profiles = np.concatenate(coil_profiles_list, axis=3)
-    #     constraints = create_constraints(1000, -1000, 5000, 32)
-    #
-    #     huge_coil = Coil(coil_profiles, sph_coil.affine, constraints)
-    #
-    #     slices = define_slices(nii_anat.shape[2], 1)
-    #     currents = shim_sequencer(nii_fieldmap, nii_anat, nii_mask, slices, [huge_coil], method='least_squares')
-    #
-    #     assert_results(nii_fieldmap, nii_anat, nii_mask, [huge_coil], currents, slices)
+    def test_shim_sequencer_4dmask_4d_anat(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
+        anat_4d = np.repeat(nii_anat.get_fdata()[..., np.newaxis], 3, -1)
+        mask_4d = np.repeat(nii_mask.get_fdata()[..., np.newaxis], 2, -1)
+        nii_4d_anat = nib.Nifti1Image(anat_4d, nii_anat.affine, header=nii_anat.header)
+        nii_4d_mask = nib.Nifti1Image(mask_4d, nii_mask.affine, header=nii_mask.header)
+
+        slices = [(0, 2), (1,)]
+        currents = shim_sequencer(nii_fieldmap, nii_4d_anat, nii_4d_mask, slices, [sph_coil])
+        assert_results(nii_fieldmap, nii_anat, nii_mask, [sph_coil], currents, slices)
 
 
 def assert_results(nii_fieldmap, nii_anat, nii_mask, coil, currents, slices):

--- a/test/shim/test_sequencer.py
+++ b/test/shim/test_sequencer.py
@@ -201,14 +201,14 @@ class TestSequencer(object):
         # Optimize
         slices = [(0, 2), (1,)]
         nii_wrong_anat = nib.Nifti1Image(nii_anat.get_fdata()[..., 0], nii_anat.affine, header=nii_anat.header)
-        with pytest.raises(ValueError, match="Anatomical image must be in 3d"):
+        with pytest.raises(ValueError, match="Target anatomical image must be in 3d or 4d"):
             shim_sequencer(nii_fieldmap, nii_wrong_anat, nii_mask, slices, [sph_coil])
 
     def test_shim_sequencer_wrong_mask_dim(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
         slices = [(0, 2), (1,)]
         nii_wrong_mask = nib.Nifti1Image(nii_mask.get_fdata()[..., 0], nii_mask.affine, header=nii_mask.header)
-        with pytest.raises(ValueError, match="Mask image must be in 3d"):
+        with pytest.raises(ValueError, match="Mask must be in 3d or 4d"):
             shim_sequencer(nii_fieldmap, nii_anat, nii_wrong_mask, slices, [sph_coil])
 
     # def test_shim_sequencer_wrong_units(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2, caplog):


### PR DESCRIPTION
## Description
When using dynamic shimming, we previously were shimming using 3d GREs. When shimming EPIs, the target anatomical is usually 4d. This was not supported since we expected 3d target anatomical images. This PR allows to accept 4d target images by averaging over the 4th dimension (note that we could simply used the 1st of the volumes since the target image is simply used to get the slice orientations, the voxel data is not used).

Similarly, the mask created from a 4d target anatomical can also be 4d (i.e. using threshold on an EPI, while not being recommended because of the distortions, is possible). This PR allows to accept 4d masks by computing an average over the 4th dimension of the mask and thresholding to remove noise voxels and create a 3d binary mask.

In summary, this PR 
- Allows to input 3d and 4d masks
- Allows to input 3d and 4d target anatomical images