### PR TITLE
Use multiprocessing's fork method to speed up optimizing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "scipy~=1.6.0",
         "tqdm",
         "matplotlib~=3.1.2",
-        "multiprocessing-logging~=0.3.3",
         "psutil~=5.7.3",
         "pytest~=4.6.3",
         "pytest-cov~=2.5.1",

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -13,6 +13,7 @@ from matplotlib.figure import Figure
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import json
 import multiprocessing as mp
+import sys
 
 from shimmingtoolbox.optimizer.lsq_optimizer import LsqOptimizer, PmuLsqOptimizer
 from shimmingtoolbox.optimizer.basic_optimizer import Optimizer
@@ -28,7 +29,11 @@ from shimmingtoolbox.shim.shim_utils import calculate_metric_within_mask
 ListCoil = List[Coil]
 
 logger = logging.getLogger(__name__)
-mp.set_start_method('fork', force=True)
+
+if sys.platform == 'linux':
+    mp.set_start_method('fork', force=True)
+else:
+    mp.set_start_method('spawn', force=True)
 
 supported_optimizers = {
     'least_squares_rt': PmuLsqOptimizer,

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -14,7 +14,6 @@ from matplotlib.figure import Figure
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import json
 import multiprocessing as mp
-import multiprocessing_logging
 
 from shimmingtoolbox.optimizer.lsq_optimizer import LsqOptimizer, PmuLsqOptimizer
 from shimmingtoolbox.optimizer.basic_optimizer import Optimizer
@@ -30,7 +29,6 @@ from shimmingtoolbox.shim.shim_utils import calculate_metric_within_mask
 ListCoil = List[Coil]
 
 logger = logging.getLogger(__name__)
-multiprocessing_logging.install_mp_handler(logger)
 
 supported_optimizers = {
     'least_squares_rt': PmuLsqOptimizer,


### PR DESCRIPTION
- avoid python interpreter's startup time
- avoid passing large data via pickle by instead using a global that can be inherited by the subprocesses

Basically this is apply [the advice](https://docs.python.org/3/library/multiprocessing.html#programming-guidelines)

> Better to inherit than pickle/unpickle
>
>    When using the spawn or forkserver start methods many types from multiprocessing need to be picklable so that child processes can use them. However, one should generally avoid sending shared objects to other processes using pipes or queues. Instead you should arrange the program so that a process which needs access to a shared resource created elsewhere can inherit it from an ancestor process.
