### PR TITLE
Add option to save the calculated mask when using st_prepare_fieldmap

### DIFF
--- a/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -14,6 +14,7 @@ from shimmingtoolbox.utils import create_fname_from_path, set_all_loggers, creat
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 FILE_OUTPUT_DEFAULT = 'fieldmap.nii.gz'
+MASK_OUTPUT_DEFAULT = 'mask.nii.gz'
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -57,8 +58,7 @@ def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, f
 
     # Make sure output filename is valid
     fname_output_v2 = create_fname_from_path(fname_output, FILE_OUTPUT_DEFAULT)
-    if (fname_output_v2[-4:] != '.nii' and fname_output_v2[-7:] != '.nii.gz') or \
-            (fname_save_mask[-4:] != '.nii' and fname_save_mask[-7:] != '.nii.gz'):
+    if fname_output_v2[-4:] != '.nii' and fname_output_v2[-7:] != '.nii.gz':
         raise ValueError("Output filename must have one of the following extensions: '.nii', '.nii.gz'")
 
     # Prepare the output
@@ -113,7 +113,14 @@ def prepare_fieldmap_cli(phase, fname_mag, unwrapper, fname_output, autoscale, f
         json.dump(json_fieldmap, outfile, indent=2)
 
     # Save mask
-    if fname_save_mask:
+    if fname_save_mask is not None:
+        # If it is a path, add the default filename and create output directory
+        fname_save_mask = create_fname_from_path(fname_save_mask, MASK_OUTPUT_DEFAULT)
+        create_output_dir(fname_save_mask, is_file=True)
+
+        if fname_save_mask[-4:] != '.nii' and fname_save_mask[-7:] != '.nii.gz':
+            raise ValueError("Output filename must have one of the following extensions: '.nii', '.nii.gz'")
+
         nii_fieldmap = nib.Nifti1Image(save_mask, affine, header=nii_phase.header)
         nib.save(nii_fieldmap, fname_save_mask)
         logger.info(f"Filename of the output mask is: {fname_save_mask}")

--- a/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -14,7 +14,7 @@ from shimmingtoolbox.utils import create_fname_from_path, set_all_loggers, creat
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 FILE_OUTPUT_DEFAULT = 'fieldmap.nii.gz'
-MASK_OUTPUT_DEFAULT = 'mask.nii.gz'
+MASK_OUTPUT_DEFAULT = 'mask_fieldmap.nii.gz'
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 

--- a/shimmingtoolbox/prepare_fieldmap.py
+++ b/shimmingtoolbox/prepare_fieldmap.py
@@ -16,7 +16,7 @@ VALIDITY_THRESHOLD = 0.2
 
 
 def prepare_fieldmap(list_nii_phase, echo_times, mag, unwrapper='prelude', mask=None, threshold=0.05,
-                     gaussian_filter=False, sigma=1, save_mask=False):
+                     gaussian_filter=False, sigma=1):
     """ Creates fieldmap (in Hz) from phase images. This function accommodates multiple echoes (2 or more) and phase
     difference. This function also accommodates 4D phase inputs, where the 4th dimension represents the time, in case
     multiple field maps are acquired across time for the purpose of real-time shimming experiments.

--- a/shimmingtoolbox/prepare_fieldmap.py
+++ b/shimmingtoolbox/prepare_fieldmap.py
@@ -16,7 +16,7 @@ VALIDITY_THRESHOLD = 0.2
 
 
 def prepare_fieldmap(list_nii_phase, echo_times, mag, unwrapper='prelude', mask=None, threshold=0.05,
-                     gaussian_filter=False, sigma=1):
+                     gaussian_filter=False, sigma=1, save_mask=False):
     """ Creates fieldmap (in Hz) from phase images. This function accommodates multiple echoes (2 or more) and phase
     difference. This function also accommodates 4D phase inputs, where the 4th dimension represents the time, in case
     multiple field maps are acquired across time for the purpose of real-time shimming experiments.
@@ -117,7 +117,7 @@ def prepare_fieldmap(list_nii_phase, echo_times, mag, unwrapper='prelude', mask=
         fieldmap_hz = gaussian(fieldmap_hz, sigma, mode='nearest')
 
     # return fieldmap_hz_gaussian
-    return fieldmap_hz
+    return fieldmap_hz, mask
 
 
 def correct_2pi_offset(unwrapped, mag, mask, validity_threshold):

--- a/shimmingtoolbox/unwrap/prelude.py
+++ b/shimmingtoolbox/unwrap/prelude.py
@@ -45,56 +45,55 @@ def prelude(nii_wrapped_phase, mag=None, mask=None, threshold=None, is_unwrappin
     else:
         mag = np.zeros_like(wrapped_phase)
 
-    tmp = tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem)
-    path_tmp = tmp.name
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
 
-    # Save phase and mag images
-    nib.save(nii_wrapped_phase, os.path.join(path_tmp, 'rawPhase.nii'))
-    header = nii_wrapped_phase.header
-    header['descrip'] = "mag"
-    nii_mag = nib.Nifti1Image(mag, nii_wrapped_phase.affine, header=header)
-    nib.save(nii_mag, os.path.join(path_tmp, 'mag.nii'))
+        # Save phase and mag images
+        nib.save(nii_wrapped_phase, os.path.join(tmp, 'rawPhase.nii'))
+        header = nii_wrapped_phase.header
+        header['descrip'] = "mag"
+        nii_mag = nib.Nifti1Image(mag, nii_wrapped_phase.affine, header=header)
+        nib.save(nii_mag, os.path.join(tmp, 'mag.nii'))
 
-    # Fill options
-    if is_unwrapping_in_2d:
-        options = ['-s']
-    else:
-        options = []
+        # Fill options
+        if is_unwrapping_in_2d:
+            options = ['-s']
+        else:
+            options = []
 
-    # Add mask data and options if there is a mask provided
-    if mask is not None:
-        if mask.shape != wrapped_phase.shape:
-            raise ValueError("Mask must be the same shape as wrapped_phase")
-        nii_mask = nib.Nifti1Image(mask, nii_wrapped_phase.affine, header=nii_wrapped_phase.header)
-
-        fname_mask = os.path.join(path_tmp, 'mask.nii')
-        options += ['-m', fname_mask]
-
-        nib.save(nii_mask, fname_mask)
-
-    if threshold is not None:
-        options += ['-t', str(threshold)]
+        # Add mask data and options if there is a mask provided
         if mask is not None:
-            logger.warning("Specifying both a mask and a threshold is not recommended, results might not be what is "
-                           "expected")
+            if mask.shape != wrapped_phase.shape:
+                raise ValueError("Mask must be the same shape as wrapped_phase")
+            nii_mask = nib.Nifti1Image(mask, nii_wrapped_phase.affine, header=nii_wrapped_phase.header)
 
-    # Unwrap
-    fname_raw_phase = os.path.join(path_tmp, 'rawPhase')
-    fname_mag = os.path.join(path_tmp, 'mag')
-    fname_out = os.path.join(path_tmp, 'rawPhase_unwrapped')
+            fname_mask = os.path.join(tmp, 'mask.nii')
+            options += ['-m', fname_mask]
 
-    unwrap_command = ['prelude', '-p', fname_raw_phase, '-a', fname_mag, '-o', fname_out] + options
+            nib.save(nii_mask, fname_mask)
 
-    logger.debug("Unwrap with prelude")
-    run_subprocess(unwrap_command)
+        if threshold is not None:
+            options += ['-t', str(threshold)]
+            if mask is not None:
+                logger.warning("Specifying both a mask and a threshold is not recommended, results might not be what "
+                               "is expected")
 
-    fname_phase_unwrapped = glob.glob(os.path.join(path_tmp, 'rawPhase_unwrapped*'))[0]
+        # Unwrap
+        fname_raw_phase = os.path.join(tmp, 'rawPhase')
+        fname_mag = os.path.join(tmp, 'mag')
+        fname_out = os.path.join(tmp, 'rawPhase_unwrapped')
 
-    # When loading fname_phase_unwrapped, if a singleton is on the last dimension in wrapped_phase, it will not appear
-    # in the last dimension in phase_unwrapped. To be consistent with the size of the input, the singletons are added
-    # back.
-    phase_unwrapped = nib.load(fname_phase_unwrapped).get_fdata()
-    for _ in range(wrapped_phase.ndim - phase_unwrapped.ndim):
-        phase_unwrapped = np.expand_dims(phase_unwrapped, -1)
+        unwrap_command = ['prelude', '-p', fname_raw_phase, '-a', fname_mag, '-o', fname_out] + options
+
+        logger.debug("Unwrap with prelude")
+        run_subprocess(unwrap_command)
+
+        fname_phase_unwrapped = glob.glob(os.path.join(tmp, 'rawPhase_unwrapped*'))[0]
+
+        # When loading fname_phase_unwrapped, if a singleton is on the last dimension in wrapped_phase, it will not
+        # appear in the last dimension in phase_unwrapped. To be consistent with the size of the input, the singletons
+        # are added back.
+        phase_unwrapped = nib.load(fname_phase_unwrapped).get_fdata()
+        for _ in range(wrapped_phase.ndim - phase_unwrapped.ndim):
+            phase_unwrapped = np.expand_dims(phase_unwrapped, -1)
 
     return phase_unwrapped

--- a/test/cli/test_cli_prepare_fieldmap.py
+++ b/test/cli/test_cli_prepare_fieldmap.py
@@ -134,3 +134,20 @@ def test_cli_prepare_fieldmap_default_fname_output():
         assert result.exit_code == 0
         assert os.path.isfile(os.path.join(tmp, 'fieldmap.nii.gz'))
         assert os.path.isfile(os.path.join(tmp, 'fieldmap.json'))
+
+
+@pytest.mark.prelude
+def test_cli_prepare_fieldmap_savemask():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        fname_output = os.path.join(tmp, 'fieldmap.nii.gz')
+        fname_output_mask = os.path.join(tmp, 'output_mask.nii.gz')
+
+        result = runner.invoke(prepare_fieldmap_cli, [fname_phasediff,
+                                                      '--mag', fname_mag_realtime,
+                                                      '--savemask', fname_output_mask,
+                                                      '--output', fname_output], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output_mask)

--- a/test/test_prepare_fieldmap.py
+++ b/test/test_prepare_fieldmap.py
@@ -27,7 +27,7 @@ class TestPrepareFieldmap(object):
 
     def test_prepare_fieldmap_1_echo(self):
         """Test default works."""
-        fieldmap = prepare_fieldmap([self.nii_phase], self.echo_times, self.mag)
+        fieldmap, _ = prepare_fieldmap([self.nii_phase], self.echo_times, self.mag)
 
         assert fieldmap.shape == self.nii_phase.shape
         # If the behaviour of the called function is modified, this assertion below should capture it:
@@ -53,7 +53,7 @@ class TestPrepareFieldmap(object):
 
         echo_times = [0.0025, 0.0055]
 
-        fieldmap = prepare_fieldmap([nii_phase1_re, nii_phase2_re], echo_times, mag=mag)
+        fieldmap, _ = prepare_fieldmap([nii_phase1_re, nii_phase2_re], echo_times, mag=mag)
 
         assert fieldmap.shape == phase1.shape
 
@@ -108,7 +108,7 @@ class TestPrepareFieldmap(object):
     def test_prepare_fieldmap_gaussian_filter(self):
         """Test output of gaussian filter optional argument"""
 
-        fieldmap = prepare_fieldmap([self.nii_phase], self.echo_times, self.mag, gaussian_filter=True, sigma=1)
+        fieldmap, _ = prepare_fieldmap([self.nii_phase], self.echo_times, self.mag, gaussian_filter=True, sigma=1)
 
         assert fieldmap.shape == self.nii_phase.shape
         # If the behaviour of the called function is modified, this assertion below should capture it:


### PR DESCRIPTION
## Description
This PR adds an option in `st_prepare_fieldmap` to output the calculated mask. This is useful to calculate masks that take the fieldmap's validity region into consideration.

In more detail, this PR adds:
- `--savemask` option in `st_prepare_fieldmap`
