### PR TITLE
Improve mask resampling

### DIFF
--- a/shimmingtoolbox/masking/mask_utils.py
+++ b/shimmingtoolbox/masking/mask_utils.py
@@ -47,10 +47,10 @@ def resample_mask(nii_mask_from, nii_target, from_slices, dilation_kernel='None'
     # Find highest value and stretch to 1
     # Look into dilation of soft mask
 
-    if dilation_kernel is not None:
-        # dilate the mask to add more pixels in particular directions
-        mask_dilated = dilate_binary_mask(nii_mask_target.get_fdata(), dilation_kernel, dilation_size)
-        nii_mask_dilated = nib.Nifti1Image(mask_dilated, nii_mask_target.affine, header=nii_mask_target.header)
+    # dilate the mask to add more pixels in particular directions
+    mask_dilated = dilate_binary_mask(nii_mask_target.get_fdata(), dilation_kernel, dilation_size)
+    mask_dilated_in_roi = np.logical_and(mask_dilated, nii_mask_target.get_fdata())
+    nii_mask_dilated = nib.Nifti1Image(mask_dilated_in_roi, nii_mask_target.affine, header=nii_mask_target.header)
 
     if logger.level <= getattr(logging, 'DEBUG') and path_output is not None:
         nib.save(nii_mask, os.path.join(path_output, f"fig_mask_{from_slices[0]}.nii.gz"))

--- a/test/masking/test_mask_utils.py
+++ b/test/masking/test_mask_utils.py
@@ -107,6 +107,6 @@ def test_resample_mask():
     nii_mask_res = resample_mask(nii_mask_static, nii_target, (0,), dilation_kernel='line')
 
     expected = np.full_like(nii_target.get_fdata(), fill_value=False)
-    expected[24:28, 26:29, 0] = 1
+    expected[24:28, 27:29, 0] = 1
 
     assert np.all(nii_mask_res.get_fdata() == expected)


### PR DESCRIPTION
## Description
When we use st_b0shim, there is a resampling of the sliced mask onto the target space. We also have the option to dilate that resampled sliced mask. When we dilate, it is possible to go outside the ROI, when this happens, we can get unexpected results if the fieldmap is undefined outside of that region. Therefore, when an output sliced mask is dilated, it should still be within the ROI of the full mask.

This PR reflects those changes.
