### PR TITLE
Resample in logical-and if the volumes are not the same orientation

### DIFF
--- a/shimmingtoolbox/cli/image.py
+++ b/shimmingtoolbox/cli/image.py
@@ -74,7 +74,7 @@ def logical_and(inputs, fname_output):
     affine = nii_output.affine
     for fname_file in inputs:
         nii_input = nib.load(fname_file)
-        # Make sure dimensions and affines are the same
+        # Make sure to resample if dimensions and affines are not the same
         if not np.all(nii_input.shape == dimensions) or not np.all(nii_input.affine == affine):
             nii_input = resample_from_to(nii_input, nii_output, order=0, mode='grid-constant')
 


### PR DESCRIPTION
## Description
The logical-and CLI currently only accept volumes with the same affine and dimensions. When masks are computed from different sequences or volumes, they usually don't have the same orientations. This PR adds resampling of the inputs on the last input volume so that logical-and can work with different volume orientations.

