### PR TITLE
Add missing prelude test marker

### DIFF
--- a/test/test_example_scripts.py
+++ b/test/test_example_scripts.py
@@ -3,10 +3,12 @@
 from pathlib import Path
 import shutil
 import os
+import pytest
 
 from examples.general_demo import general_demo
 
 
+@pytest.mark.prelude
 class TestCore(object):
 
     def setup(self):


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

Per the documentation https://shimming-toolbox.org/en/latest/user_section/installation.html#testing-subsets-of-soft-dependencies, `pytest -m "not prelude"` should only execute the tests that don't depend on prelude. #332 raised that one such test still ran, so I added the prelude marker to it.

Screenshot:

<img width="1105" alt="Screen Shot 2022-07-11 at 3 37 54 PM" src="https://user-images.githubusercontent.com/1421029/178334741-4f7be209-3f1b-43d3-aed4-98fa4b0266c9.png">



## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolved #332 