### PR TITLE
Change SCT CLI call to check version

### DIFF
--- a/shimmingtoolbox/cli/check_env.py
+++ b/shimmingtoolbox/cli/check_env.py
@@ -191,7 +191,7 @@ def get_sct_version() -> str:
     if sct_version.returncode != 0:
         raise subprocess.CalledProcessError("Error while getting SCT's version")
     version_output: str = sct_version.stdout.rstrip()
-    version_output = version_output.split("\n\n")[2].split("\n")[1]
+    version_output = version_output.split("\n\n")[2].split("\n")[-5]
 
     return version_output
 

--- a/shimmingtoolbox/cli/check_env.py
+++ b/shimmingtoolbox/cli/check_env.py
@@ -187,11 +187,10 @@ def get_sct_version() -> str:
         str: Version of the ``SCT`` installation.
     """
     # `sct_check_dependencies -short` returns
-    sct_version: str = subprocess.run(["sct_check_dependencies", "-short"], capture_output=True, encoding="utf-8")
+    sct_version: str = subprocess.run(["sct_version", "-short"], capture_output=True, encoding="utf-8")
     if sct_version.returncode != 0:
         raise subprocess.CalledProcessError("Error while getting SCT's version")
     version_output: str = sct_version.stdout.rstrip()
-    version_output = version_output.split("\n\n")[2].split("\n")[-5]
 
     return version_output
 

--- a/test/cli/test_cli_check_env.py
+++ b/test/cli/test_cli_check_env.py
@@ -84,7 +84,7 @@ def test_get_sct_version(test_sct_installation):
     """Checks sct version output for expected structure.
     """
     sct_version_info = st_ce.get_sct_version()
-    version_regex = r"- version *"
+    version_regex = r"git*"
     assert re.search(version_regex, sct_version_info)
 
 


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

SCT recently ([see here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blame/df74db89bcf64ed8cb3a8d0ae8a1f3ef24e8714f/spinalcordtoolbox/scripts/sct_check_dependencies.py#L201-L203), from this PR: https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3820) added a line in their `sct_depencency_check` output, resulting in `st_depencency_check` in outputting

```
Check if Spinal Cord Toolbox is installed...........[OK]
    SYSTEM INFORMATION
```

instead of

```
Check if Spinal Cord Toolbox is installed...........[OK]
    - version: git-mb/3810-mtsat-7d495ca33892ccb20148ec5e6f1b9650c1f3f2fe
```

The root cause on our end was that this line:

https://github.com/shimming-toolbox/shimming-toolbox/blob/4013cae6031e544e5a3ae77e2b623e17a14b90af/shimmingtoolbox/cli/check_env.py#L194

where `.split("\n")[1] ` was counting from the top line of the SCT output and trying to fetch `- version ...`, but instead was fetching the new line in their output. My proposed solution that will be retrocompatible (I tested it locally on the old vs new SCT versions) is to fetch the SCT `- version` line from counting from the bottom with `.split("\n")[-5] ` instead.

## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->

Resolves #401 
