### PR TITLE
Version/python version updates for pre-commit, sklearn and read the docs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: Cache pip dependencies
         id: cache-pip-dependencies
         uses: actions/cache@v2

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,9 @@
 version: 2
 
 build:
-    image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
 
 sphinx:
   configuration: docs/source/conf.py
@@ -9,7 +11,6 @@ sphinx:
   builder: html
 
 python:
-    version: 3.7
     install:
       - method: pip
         path: .

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "psutil~=5.7.3",
         "pytest>=6.2.5",
         "pytest-cov~=2.5.1",
-        "sklearn~=0.0",
+        "scikit-learn>=1.1.2",
         "pillow>=9.0.0",
         "dataclasses",
         "raven",


### PR DESCRIPTION
## Description
This PR resolves three problems with versions and python versions.

- pip install sklearn is now deprecated and we should use pip install scikit-learn
- We are still using python 3.7 for building the documentation leading to errors (3.7 --> 3.9)
- We are still using python 3.7 for the pre-commit check leading to errors (3.7 --> 3.9)
