### PR TITLE
Update names of subcommand in the documentation

### DIFF
--- a/docs/source/cli_reference/cli.rst
+++ b/docs/source/cli_reference/cli.rst
@@ -18,7 +18,6 @@ Fieldmapping
 Shimming
 --------
 
-
 .. click:: shimmingtoolbox.cli.b0shim:b0shim_cli
    :prog: st_b0shim
    :nested: full

--- a/examples/demo_realtime_shimming.sh
+++ b/examples/demo_realtime_shimming.sh
@@ -27,7 +27,7 @@ mkdir "../../derivatives/sub-gradient_realtime"
 st_mask box --input "../anat/sub-gradient_realtime_unshimmed_e1.nii.gz" --size 15 15 20 --output "../../derivatives/sub-gradient_realtime/sub-gradient_realtime_anat_mask.nii.gz" || exit
 
 # Shim
-st_b0shim gradient_realtime --fmap "sub-gradient_realtime_fieldmap.nii.gz" --anat "../anat/sub-gradient_realtime_unshimmed_e1.nii.gz" --resp "../../derivatives/sub-realtime/sub-realtime_PMUresp_signal.resp" --mask-static "../../derivatives/sub-gradient_realtime/sub-gradient_realtime_anat_mask.nii.gz" --mask-riro "../../derivatives/sub-gradient_realtime/sub-gradient_realtime_anat_mask.nii.gz" --output "../../derivatives/sub-gradient_realtime/gradient_realtime" || exit
+st_b0shim gradient-realtime --fmap "sub-gradient_realtime_fieldmap.nii.gz" --anat "../anat/sub-gradient_realtime_unshimmed_e1.nii.gz" --resp "../../derivatives/sub-realtime/sub-realtime_PMUresp_signal.resp" --mask-static "../../derivatives/sub-gradient_realtime/sub-gradient_realtime_anat_mask.nii.gz" --mask-riro "../../derivatives/sub-gradient_realtime/sub-gradient_realtime_anat_mask.nii.gz" --output "../../derivatives/sub-gradient_realtime/gradient_realtime" || exit
 
 echo -e "\n\033[0;32mOutput is located here: ${TESTING_DATA_PATH}/ds_b0/derivatives/sub-gradient_realtime/gradient_realtime"
 

--- a/examples/realtime_shimming.sh
+++ b/examples/realtime_shimming.sh
@@ -24,7 +24,7 @@ mkdir "../../derivatives/sub-example"
 st_mask box --input "../anat/sub-example_unshimmed_e1.nii.gz" --size 40 40 14 --output "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" || exit
 
 # Shim
-st_b0shim gradient_realtime --fmap "sub-example_fieldmap.nii.gz" --anat "../anat/sub-example_unshimmed_e1.nii.gz" --resp "${INPUT_PATH}/PMUresp_signal.resp" --mask-static "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --mask-riro "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --output "../../derivatives/sub-example/gradient_realtime" || exit
+st_b0shim gradient-realtime --fmap "sub-example_fieldmap.nii.gz" --anat "../anat/sub-example_unshimmed_e1.nii.gz" --resp "${INPUT_PATH}/PMUresp_signal.resp" --mask-static "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --mask-riro "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --output "../../derivatives/sub-example/gradient_realtime" || exit
 st_b0shim realtime-dynamic --fmap "sub-example_fieldmap.nii.gz" --anat "../anat/sub-example_unshimmed_e1.nii.gz" --mask-static "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --mask-riro "../../derivatives/sub-example/sub-example_anat_mask.nii.gz" --resp "${INPUT_PATH}/PMUresp_signal.resp" --scanner-coil-order '1' --output-file-format-scanner "gradient" --output "../../derivatives/sub-example/realtime" || exit
 OUTPUT_PATH="$(dirname "${INPUT_PATH}")/rt_shim_nifti/derivatives/sub-example"
 echo -e "\n\033[0;32mOutput is located here: ${OUTPUT_PATH}"

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -18,7 +18,7 @@ import os
 from matplotlib.figure import Figure
 
 from shimmingtoolbox import __dir_config_scanner_constraints__
-from shimmingtoolbox.cli.realtime_shim import realtime_shim_cli
+from shimmingtoolbox.cli.realtime_shim import gradient_realtime
 from shimmingtoolbox.coils.coil import Coil, ScannerCoil, convert_to_mp
 from shimmingtoolbox.pmu import PmuResp
 from shimmingtoolbox.shim.sequencer import shim_sequencer, shim_realtime_pmu_sequencer, new_bounds_from_currents
@@ -121,9 +121,9 @@ def b0shim_cli():
                    "used in that case.")
 @click.option('-v', '--verbose', type=click.Choice(['info', 'debug']), default='info', help="Be more verbose")
 @timeit
-def dynamic_cli(fname_fmap, fname_anat, fname_mask_anat, method, slices, slice_factor, coils,
-                dilation_kernel_size, scanner_coil_order, fname_sph_constr, fatsat, path_output, o_format_coil,
-                o_format_sph, output_value_format, reg_factor, verbose):
+def dynamic(fname_fmap, fname_anat, fname_mask_anat, method, slices, slice_factor, coils,
+            dilation_kernel_size, scanner_coil_order, fname_sph_constr, fatsat, path_output, o_format_coil,
+            o_format_sph, output_value_format, reg_factor, verbose):
     """ Static shim by fitting a fieldmap. Use the option --optimizer-method to change the shimming algorithm used to
     optimize. Use the options --slices and --slice-factor to change the shimming order/size of the slices.
 
@@ -526,9 +526,9 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, o
                    "used in that case.")
 @click.option('-v', '--verbose', type=click.Choice(['info', 'debug']), default='info', help="Be more verbose")
 @timeit
-def realtime_cli(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_anat_riro, fname_resp, method, slices,
-                 slice_factor, coils, dilation_kernel_size, scanner_coil_order, fname_sph_constr, fatsat,
-                 path_output, o_format_coil, o_format_sph, output_value_format, reg_factor, verbose):
+def realtime_dynamic(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_anat_riro, fname_resp, method, slices,
+                     slice_factor, coils, dilation_kernel_size, scanner_coil_order, fname_sph_constr, fatsat,
+                     path_output, o_format_coil, o_format_sph, output_value_format, reg_factor, verbose):
     """ Realtime shim by fitting a fieldmap to a pressure monitoring unit. Use the option --optimizer-method to change
     the shimming algorithm used to optimize. Use the options --slices and --slice-factor to change the shimming
     order/size of the slices.
@@ -1075,7 +1075,6 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
     logger.debug(f"Saved figure: {fname_figure}")
 
 
-b0shim_cli.add_command(realtime_shim_cli, 'gradient_realtime')
-b0shim_cli.add_command(dynamic_cli, 'dynamic')
-b0shim_cli.add_command(realtime_cli, 'realtime-dynamic')
-# shim_cli.add_command(define_slices_cli, 'define_slices')
+b0shim_cli.add_command(gradient_realtime)
+b0shim_cli.add_command(dynamic)
+b0shim_cli.add_command(realtime_dynamic)

--- a/shimmingtoolbox/cli/realtime_shim.py
+++ b/shimmingtoolbox/cli/realtime_shim.py
@@ -35,7 +35,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('-o', '--output', 'fname_output', type=click.Path(), default=os.path.abspath(os.curdir),
               show_default=True,
               help="Directory to output gradient text file and figures.")
-def realtime_shim_cli(fname_fmap, fname_mask_anat_static, fname_mask_anat_riro, fname_resp, fname_anat, fname_output):
+def gradient_realtime(fname_fmap, fname_mask_anat_static, fname_mask_anat_riro, fname_resp, fname_anat, fname_output):
     """ Perform gradient realtime xyz-shimming. This function will generate text files containing static and dynamic (due to
     respiration) Gx, Gy, Gz components based on a fieldmap time series and respiratory trace information obtained from
     Siemens bellows (PMUresp_signal.resp). An additional multi-gradient echo (MGRE) magnitude image is used to

--- a/test/cli/test_cli_check_env.py
+++ b/test/cli/test_cli_check_env.py
@@ -85,7 +85,7 @@ def test_get_sct_version(test_sct_installation):
     """
     sct_version_info = st_ce.get_sct_version()
     version_regex = r"git*"
-    assert re.search(version_regex, sct_version_info)
+    assert re.search(version_regex, sct_version_info) or re.search(r"\d\.\d", sct_version_info)
 
 
 def test_get_env_info():

--- a/test/cli/test_cli_realtime_shim.py
+++ b/test/cli/test_cli_realtime_shim.py
@@ -8,7 +8,7 @@ import pytest
 import json
 
 from click.testing import CliRunner
-from shimmingtoolbox.cli.realtime_shim import realtime_shim_cli
+from shimmingtoolbox.cli.realtime_shim import gradient_realtime
 from shimmingtoolbox.masking.shapes import shapes
 from shimmingtoolbox import __dir_testing__
 from shimmingtoolbox.cli.realtime_shim import get_phase_encode_direction_sign
@@ -58,7 +58,7 @@ def test_cli_realtime_shim():
         path_output = os.path.join(tmp, 'test_realtime_shim')
 
         # Run the CLI
-        result = runner.invoke(realtime_shim_cli, ['--fmap', fname_fieldmap,
+        result = runner.invoke(gradient_realtime, ['--fmap', fname_fieldmap,
                                                    '--mask-static', fname_mask_static,
                                                    '--mask-riro', fname_mask_riro,
                                                    '--output', path_output,
@@ -76,7 +76,7 @@ def test_cli_realtime_shim_no_mask():
         path_output = os.path.join(tmp, 'test_realtime_shim')
 
         # Run the CLI
-        result = runner.invoke(realtime_shim_cli, ['--fmap', fname_fieldmap,
+        result = runner.invoke(gradient_realtime, ['--fmap', fname_fieldmap,
                                                    '--output', path_output,
                                                    '--resp', fname_resp,
                                                    '--anat', fname_anat],
@@ -151,7 +151,7 @@ def test_cli_realtime_shim_sag_anat():
         nib.save(nii, fname_anat_sag)
 
         # Run the CLI
-        result = runner.invoke(realtime_shim_cli, ['--fmap', fname_fieldmap,
+        result = runner.invoke(gradient_realtime, ['--fmap', fname_fieldmap,
                                                    '--output', path_output,
                                                    '--resp', fname_resp,
                                                    '--anat', fname_anat_sag],
@@ -180,7 +180,7 @@ def test_cli_realtime_shim_cor_anat():
         nib.save(nii, fname_anat_cor)
 
         # Run the CLI
-        result = runner.invoke(realtime_shim_cli, ['--fmap', fname_fieldmap,
+        result = runner.invoke(gradient_realtime, ['--fmap', fname_fieldmap,
                                                    '--output', path_output,
                                                    '--resp', fname_resp,
                                                    '--anat', fname_anat_cor],
@@ -209,7 +209,7 @@ def test_cli_realtime_shim_tra_orient_text():
         nib.save(nii, fname_anat_text)
 
         # Run the CLI
-        result = runner.invoke(realtime_shim_cli, ['--fmap', fname_fieldmap,
+        result = runner.invoke(gradient_realtime, ['--fmap', fname_fieldmap,
                                                    '--output', path_output,
                                                    '--resp', fname_resp,
                                                    '--anat', fname_anat_text],
@@ -232,7 +232,7 @@ def test_realtime_shim_cli_dim_info():
 
         with pytest.raises(RuntimeError, match="Slice encode direction must be the 3rd dimension of the NIfTI file."):
             # Run the CLI
-            runner.invoke(realtime_shim_cli, ['--fmap', fname_fieldmap,
+            runner.invoke(gradient_realtime, ['--fmap', fname_fieldmap,
                                               '--output', path_output,
                                               '--resp', fname_resp,
                                               '--anat', fname_new_anat],


### PR DESCRIPTION
## Description
This PR addresses a problem where the names of the cli commands do not have the right name in the documentation. This is a known [issue](https://github.com/click-contrib/sphinx-click/issues/74) that has not been fixed in 2 years (It likely needs a major refactoring from the sphinx-click team). The problem is that sphinx-click does not evaluate the code and therefore does not "see" that we rename the functions.

<img width="148" alt="Screen Shot 2022-11-15 at 8 24 52 PM" src="https://user-images.githubusercontent.com/47249340/202060371-b3b60534-6c38-4102-84c1-6bd781dbb78c.png">

These should be: dynamic, gradient-realtime, realtime-dynamic.

To solve this, we can simply name the click functions to what we want to be displayed to both the documentation and the user without renaming them using the `click.add_command()` function.
