### PR TITLE
Faster B0 shimming 

### DIFF
--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -983,6 +983,7 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
     shimmed_slice = []
     n_shims = len(slices)
     list_slice_wo_shimmed = ""
+    unused_slice = False
     for i_shim in range(n_shims):
         if np.any(static_coefs[i_shim]):
             shimmed_slice.append(i_shim)
@@ -992,6 +993,7 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
             # Get the last index where the shimmed correction is null, this will allow to plot the last one as an example
             # for all the other ones
             last_i = i_shim
+            unused_slice = True
     number_slices_shimmed = len(shimmed_slice)
     fig = Figure(figsize=(8, 4 * number_slices_shimmed), tight_layout=True)
 
@@ -1037,8 +1039,10 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
                         pres_probe_max, bounds, min_y, max_y,
                         units, static_coefs, i_slice)
     # Print a subplot for all the non shimmed slices
-    nb_slices = nb_slices + 1
-    _add_sub_figure(last_i, fig, number_slices_shimmed, nb_slices+1, rt_coefs, pres_probe_min,
+
+    if unused_slice:
+        nb_slices = nb_slices + 1
+        _add_sub_figure(last_i, fig, number_slices_shimmed, nb_slices+1, rt_coefs, pres_probe_min,
                     pres_probe_max, bounds, min_y, max_y,
                     units, static_coefs, list_slice_wo_shimmed)
     # Save the figure

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -1078,8 +1078,7 @@ def _add_sub_figure(i_shim, fig, n_shims, axis, rt_coefs, pres_probe_min, pres_p
         len_hline_bounds = 0.4
         if np.all(bounds[:, 0] == bounds[0, 0]) and np.all(bounds[:, 1] == bounds[0, 1]):
             ax.hlines(bounds[0, 0], 0 - len_hline_bounds, n_channels + len_hline_bounds, colors='r',
-                      label='bounds',
-                      capstyle='projecting')
+                      label='bounds', capstyle='projecting')
             ax.hlines(bounds[0, 1], 0 - len_hline_bounds, n_channels + len_hline_bounds, colors='r',
                       capstyle='projecting')
         else:

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -335,7 +335,7 @@ def dynamic(fname_fmap, fname_anat, fname_mask_anat, method, opt_criteria, slice
                                                            options, coil_number=i_coil)
 
     logger.info(f"Coil txt file(s) are here:\n{os.linesep.join(list_fname_output)}")
-    logger.info(f"\nPlotting figure(s)")
+    logger.info(f"Plotting figure(s)")
 
     # Plot the coefs after outputting the currents to the text file
     end_channel = 0
@@ -765,7 +765,7 @@ def realtime_dynamic(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_
                                                        path_output, o_format_coil, options, i_coil)
 
     logger.info(f"Coil txt file(s) are here:\n{os.linesep.join(list_fname_output)}")
-    logger.info(f"\nPlotting figure(s)")
+    logger.info(f"Plotting figure(s)")
 
     # Plot the coefs after outputting the currents to the text file
     end_channel = 0

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -1032,8 +1032,7 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
         if max_y is None or max_y < temp_max:
             max_y = np.array(static_coefs).max()
     nb_slices = 0
-    for i_shim in shimmed_slice:
-        nb_slices = nb_slices + 1
+    for nb_slices, i_shim in enumerate(shimmed_slice):
         i_slice = slices[i_shim]
         _add_sub_figure(i_shim, fig, number_slices_shimmed, nb_slices, rt_coefs, pres_probe_min,
                         pres_probe_max, bounds, min_y, max_y,

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -1038,7 +1038,7 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
         _add_sub_figure(i_shim, fig, number_slices_shimmed, nb_slices, rt_coefs, pres_probe_min,
                         pres_probe_max, bounds, min_y, max_y,
                         units, static_coefs, i_slice)
-    # Print a sublplot for all the non shimmed slices
+    # Print a subplot for all the non shimmed slices
     nb_slices = nb_slices + 1
     _add_sub_figure(last_i, fig, number_slices_shimmed, nb_slices, rt_coefs, pres_probe_min,
                     pres_probe_max, bounds, min_y, max_y,

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -989,8 +989,8 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
         else:
             # Get a string with the number of all the unshimmed slices
             list_slice_wo_shimmed = list_slice_wo_shimmed + str(slices[i_shim]) + ","
-            # Get the last index where the shimmed correction is null will permit to plot the last one as an example
-            # for all the other one
+            # Get the last index where the shimmed correction is null, this will allow to plot the last one as an example
+            # for all the other ones
             last_i = i_shim
     number_slices_shimmed = len(shimmed_slice)
     fig = Figure(figsize=(8, 4 * number_slices_shimmed), tight_layout=True)

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -1031,15 +1031,14 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
         temp_max = np.array(static_coefs).max()
         if max_y is None or max_y < temp_max:
             max_y = np.array(static_coefs).max()
-    nb_slices = 0
     for nb_slices, i_shim in enumerate(shimmed_slice):
         i_slice = slices[i_shim]
-        _add_sub_figure(i_shim, fig, number_slices_shimmed, nb_slices, rt_coefs, pres_probe_min,
+        _add_sub_figure(i_shim, fig, number_slices_shimmed, nb_slices+1, rt_coefs, pres_probe_min,
                         pres_probe_max, bounds, min_y, max_y,
                         units, static_coefs, i_slice)
     # Print a subplot for all the non shimmed slices
     nb_slices = nb_slices + 1
-    _add_sub_figure(last_i, fig, number_slices_shimmed, nb_slices, rt_coefs, pres_probe_min,
+    _add_sub_figure(last_i, fig, number_slices_shimmed, nb_slices+1, rt_coefs, pres_probe_min,
                     pres_probe_max, bounds, min_y, max_y,
                     units, static_coefs, list_slice_wo_shimmed)
     # Save the figure

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -333,10 +333,25 @@ def dynamic(fname_fmap, fname_anat, fname_mask_anat, method, opt_criteria, slice
         else:
             list_fname_output += _save_to_text_file_static(coil, coefs_coil, list_slices, path_output, o_format_coil,
                                                            options, coil_number=i_coil)
+
+    logger.info(f"Coil txt file(s) are here:\n{os.linesep.join(list_fname_output)}")
+    logger.info(f"\nPlotting figure(s)")
+
+    # Plot the coefs after outputting the currents to the text file
+    end_channel = 0
+    for i_coil, coil in enumerate(list_coils):
+        # Figure out the start and end channels for a coil to be able to select it from the coefs
+        n_channels = coil.dim[3]
+        start_channel = end_channel
+        end_channel = start_channel + n_channels
+
+        if type(coil) != ScannerCoil:
+            # Select the coefficients for a coil
+            coefs_coil = copy.deepcopy(coefs[:, start_channel:end_channel])
             # Plot a figure of the coefficients
             _plot_coefs(coil, list_slices, coefs_coil, path_output, i_coil, bounds=coil.coef_channel_minmax)
 
-    logger.info(f"Coil txt file(s) are here:\n{os.linesep.join(list_fname_output)}")
+    logger.info(f"Finished plotting figure(s)")
 
 
 def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, options, coil_number,
@@ -746,15 +761,30 @@ def realtime_dynamic(fname_fmap, fname_anat, fname_mask_anat_static, fname_mask_
                                                        path_output, o_format_sph, options, i_coil)
 
         else:  # Custom coil
+            list_fname_output += _save_to_text_file_rt(coil, coefs_coil_static, coefs_coil_riro, mean_p, list_slices,
+                                                       path_output, o_format_coil, options, i_coil)
+
+    logger.info(f"Coil txt file(s) are here:\n{os.linesep.join(list_fname_output)}")
+    logger.info(f"\nPlotting figure(s)")
+
+    # Plot the coefs after outputting the currents to the text file
+    end_channel = 0
+    for i_coil, coil in enumerate(list_coils):
+        # Figure out the start and end channels for a coil to be able to select it from the coefs
+        n_channels = coil.dim[3]
+        start_channel = end_channel
+        end_channel = start_channel + n_channels
+
+        if type(coil) != ScannerCoil:
+            # Select the coefficients for a coil
+            coefs_coil_static = copy.deepcopy(coefs_static[:, start_channel:end_channel])
+            coefs_coil_riro = copy.deepcopy(coefs_riro[:, start_channel:end_channel])
             # Plot a figure of the coefficients
             _plot_coefs(coil, list_slices, coefs_coil_static, path_output, i_coil, coefs_coil_riro,
                         pres_probe_max=pmu.max - mean_p, pres_probe_min=pmu.min - mean_p,
                         bounds=coil.coef_channel_minmax)
 
-            list_fname_output += _save_to_text_file_rt(coil, coefs_coil_static, coefs_coil_riro, mean_p, list_slices,
-                                                       path_output, o_format_coil, options, i_coil)
-
-    logger.info(f"Coil txt file(s) are here:\n{os.linesep.join(list_fname_output)}")
+    logger.info(f"Finished plotting figure(s)")
 
 
 def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_slices, path_output, o_format,

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -979,7 +979,7 @@ def _get_current_shim_settings(json_data):
 @timeit
 def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=None, pres_probe_min=None,
                 pres_probe_max=None, units='', bounds=None):
-    # We want to find how much slices are not shimmed to have a smaller file and reduced the plotting and saving time
+    # We want to find which slices are not shimmed to have a smaller file size and reduce the plot saving time
     shimmed_slice = []
     n_shims = len(slices)
     list_slice_wo_shimmed = ""

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -68,7 +68,7 @@ def b0shim_cli():
                    "independently on the following groups: {0,1,2}, {3,4,5}, etc. With the mode 'interleaved', "
                    "it will be: {0,2,4}, {1,3,5}, etc.")
 @click.option('--optimizer-method', 'method', type=click.Choice(['least_squares', 'pseudo_inverse',
-                                                                 'least_squares_faster']), required=False,
+                                                                 ]), required=False,
               default='least_squares', show_default=True,
               help="Method used by the optimizer. LS will respect the constraints, PS will not respect the constraints")
 @click.option('--regularization-factor', 'reg_factor', type=click.FLOAT, required=False, default=0.0, show_default=True,
@@ -1037,12 +1037,12 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
         i_slice = slices[i_shim]
         _add_sub_figure(i_shim, fig, number_slices_shimmed, nb_slices, rt_coefs, pres_probe_min,
                         pres_probe_max, bounds, min_y, max_y,
-                        units, static_coefs, i_slice, lastindex=False)
+                        units, static_coefs, i_slice)
     # Print a sublplot for all the non shimmed slices
     nb_slices = nb_slices + 1
     _add_sub_figure(last_i, fig, number_slices_shimmed, nb_slices, rt_coefs, pres_probe_min,
                     pres_probe_max, bounds, min_y, max_y,
-                    units, static_coefs, list_slice_wo_shimmed, lastindex=True)
+                    units, static_coefs, list_slice_wo_shimmed)
     # Save the figure
     fname_figure = os.path.join(path_output, f"fig_currents_per_slice_group_coil{coil_number}_{coil.name}.png")
     fig.savefig(fname_figure, bbox_inches='tight')
@@ -1050,7 +1050,7 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
 
 
 def _add_sub_figure(i_shim, fig, n_shims, axis, rt_coefs, pres_probe_min, pres_probe_max, bounds, min_y, max_y,
-                    units, static_coefs, i_slice, lastindex):
+                    units, static_coefs, i_slice):
     # Make a subplot for slices
     # If it's the recap subplot for all the slices where the correction is null then we need to take an index further to
     # not have visual problem
@@ -1117,10 +1117,8 @@ def _add_sub_figure(i_shim, fig, n_shims, axis, rt_coefs, pres_probe_min, pres_p
     ax.set(ylim=(min_y - (0.05 * delta_y), max_y + (0.05 * delta_y)), xlim=(-0.75, n_channels - 0.25),
            xticks=range(n_channels))
     ax.legend()
-    if lastindex:
-        ax.set_title(f"Slices: {i_slice}, Total static current: {0}")
-    else:
-        ax.set_title(f"Slices: {i_slice}, Total static current: {np.abs(static_coefs[i_shim]).sum()}")
+
+    ax.set_title(f"Slices: {i_slice}, Total static current: {np.abs(static_coefs[i_shim]).sum()}")
     ax.set_xlabel('Channels')
     ax.set_ylabel(f"Coefficients {units}")
 

--- a/shimmingtoolbox/masking/mask_utils.py
+++ b/shimmingtoolbox/masking/mask_utils.py
@@ -59,10 +59,10 @@ def resample_mask(nii_mask_from, nii_target, from_slices=None, dilation_kernel='
     mask_dilated_in_roi = np.logical_and(mask_dilated, nii_full_mask_target.get_fdata())
     nii_mask_dilated = nib.Nifti1Image(mask_dilated_in_roi, nii_mask_target.affine, header=nii_mask_target.header)
 
-    if logger.level <= getattr(logging, 'DEBUG') and path_output is not None:
-        nib.save(nii_mask, os.path.join(path_output, f"fig_mask_{from_slices[0]}.nii.gz"))
-        nib.save(nii_mask_target, os.path.join(path_output, f"fig_mask_res{from_slices[0]}.nii.gz"))
-        nib.save(nii_mask_dilated, os.path.join(path_output, f"fig_mask_dilated{from_slices[0]}.nii.gz"))
+    # if logger.level <= getattr(logging, 'DEBUG') and path_output is not None:
+    #     nib.save(nii_mask, os.path.join(path_output, f"fig_mask_{from_slices[0]}.nii.gz"))
+    #     nib.save(nii_mask_target, os.path.join(path_output, f"fig_mask_res{from_slices[0]}.nii.gz"))
+    #     nib.save(nii_mask_dilated, os.path.join(path_output, f"fig_mask_dilated{from_slices[0]}.nii.gz"))
 
     return nii_mask_dilated
 

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -417,15 +417,8 @@ class PmuLsqOptimizer(LsqOptimizer):
 
     def _scipy_minimize(self, currents_0, unshimmed_vec, coil_mat, scipy_constraints, factor):
         """Redefined from super() since normal bounds are now constraints"""
-        if self.method_to_minimize == 'mse':
-            currents_sp = opt.minimize(self._criteria_func, currents_0,
-                                       args=(unshimmed_vec, coil_mat, factor),
-                                       method='SLSQP',
-                                       constraints=tuple(scipy_constraints),
-                                       jac = self._residuals_mse_jacobian(),
-                                       options={'maxiter': 500})
-        else:
-            currents_sp = opt.minimize(self._criteria_func, currents_0,
+
+        currents_sp = opt.minimize(self._criteria_func, currents_0,
                                    args=(unshimmed_vec, coil_mat, factor),
                                    method='SLSQP',
                                    constraints=tuple(scipy_constraints),

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -286,7 +286,7 @@ class LsqOptimizer(Optimizer):
             # regularization on the currents has no affect on the output stability factor.
             stability_factor = self._criteria_func(self._initial_guess_zeros(), unshimmed_vec, np.zeros_like(coil_mat),
                                                    factor=1)
-            if self.method_to_minimize == 'mse':
+            if self.opt_criteria == 'mse':
                 # This factor is used to calculate the Jacobian of the mse function
                 self.b = (2 / (unshimmed_vec.size * stability_factor))
             currents_sp = self._scipy_minimize(currents_0, unshimmed_vec, coil_mat, scipy_constraints,

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
+from timeit import timeit
 
 import numpy as np
 import scipy.optimize as opt
 from typing import List
 import warnings
-
 from shimmingtoolbox.optimizer.basic_optimizer import Optimizer
 from shimmingtoolbox.pmu import PmuResp
 from shimmingtoolbox.coils.coil import Coil
@@ -72,7 +72,7 @@ class LsqOptimizer(Optimizer):
 
         # MAE regularized to minimize currents
         return np.mean(np.abs(unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False))) / factor + \
-            (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
+               (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
 
     def _residuals_mse(self, coef, unshimmed_vec, coil_mat, factor):
         """ Objective function to minimize
@@ -91,7 +91,7 @@ class LsqOptimizer(Optimizer):
 
         # MSE regularized to minimize currents
         return np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False)) ** 2) / factor + \
-            (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
+               (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
 
     def _define_scipy_constraints(self):
         return self._define_scipy_coef_sum_max_constraint()
@@ -353,3 +353,144 @@ class PmuLsqOptimizer(LsqOptimizer):
                                    constraints=tuple(scipy_constraints),
                                    options={'maxiter': 500})
         return currents_sp
+
+
+class LsqOptimizer_faster(LsqOptimizer):
+    """ Optimizer object that stores coil profiles and optimizes an unshimmed volume given a mask.
+        Use optimize(args) to optimize a given mask. The algorithm uses a least squares solver to find the best shim.
+        It supports bounds for each channel as well as a bound for the absolute sum of the channels.
+    """
+
+    def _residuals_mae_jacobian(self, coef, unshimmed_vec, coil_mat, factor):
+        """ Jacobian of the mae function to minimize.
+            Obsolete, you shouldn't use it, it's slower ( I keep it, in case someone find a way to faster the time to
+            calculate the sign matrix )
+
+        Args:
+            coef (numpy.ndarray): 1D array of channel coefficients
+            unshimmed_vec (numpy.ndarray): 1D flattened array (point) of the masked unshimmed map
+            coil_mat (numpy.ndarray): 2D flattened array (point, channel) of masked coils
+                                      (axis 0 must align with unshimmed_vec)
+            factor (float): Devise the result by 'factor'. This allows to scale the output for the minimize function to
+                            avoid positive directional linesearch
+
+        Returns:
+            jacobian (numpy.ndarray) : 1D array of the gradient of the mae function to minimize
+        """
+        sign_matrix = np.array([
+            np.sign(unshimmed_vec[i] + np.sum(coil_mat[i, :] * coef))
+            for i in range(unshimmed_vec.size)
+        ])
+        jacobian = np.array([
+            np.sum(sign_matrix * coil_mat[:, j]) / (unshimmed_vec.size * factor) + \
+            np.sign(coef[j]) * (self.reg_factor / (9 * self.reg_factor_channel[j]))
+            for j in range(coef.size)
+        ])
+
+        return jacobian
+
+    def _scipy_minimize_with_jacobian_mae(self, currents_0, unshimmed_vec, coil_mat, scipy_constraints, factor):
+        """ Minimizing the Mae function with the help of a jacobian function to make it faster
+            Attention : This function is actually slower than the one without jacobian,
+             so it's better to use the one for the mse function """
+
+        currents_sp = opt.minimize(self._residuals_mae, currents_0,
+                                   args=(unshimmed_vec, coil_mat, factor),
+                                   method='SLSQP',
+                                   # jac=self._residuals_mae_jacobian,
+                                   constraints=tuple(scipy_constraints),
+                                   options={'maxiter': 1000})
+        return currents_sp
+
+    def _scipy_minimize_with_jacobian_mse(self, currents_0, unshimmed_vec, coil_mat, scipy_constraints, factor):
+        """ Minimizing the Mae function with the help of a jacobian function to make it faster
+        This function is 10 times faster than the solver for the mae function"""
+        currents_sp = opt.minimize(self._residuals_mse, currents_0,
+                                   args=(unshimmed_vec, coil_mat, factor),
+                                   method='SLSQP',
+                                   jac=self._residuals_mse_jacobian,
+                                   constraints=tuple(scipy_constraints),
+                                   options={'maxiter': 1000})
+        return currents_sp
+
+    def _residuals_mse_jacobian(self, coef, unshimmed_vec, coil_mat, factor):
+        """ Jacobian of the function that we want to minimize
+        The function to minimize is :
+        np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False)) ** 2) / factor+\
+           (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
+        If you want to see the mathematical expression for the jacobian, of this function or for the mae one,
+         please contact : aurelienpujolmpro@gmail.com
+
+        Args:
+            coef (numpy.ndarray): 1D array of channel coefficients
+            unshimmed_vec (numpy.ndarray): 1D flattened array (point) of the masked unshimmed map
+            coil_mat (numpy.ndarray): 2D flattened array (point, channel) of masked coils
+                                      (axis 0 must align with unshimmed_vec)
+            factor (float): unused but necessary to call the function in scipy.optimize.minimize
+
+        Returns:
+            jacobian (numpy.ndarray) : 1D array of the gradient of the mse function to minimize
+        """
+        jacobian = np.array([
+            self.b * np.sum((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False)) * coil_mat[:, j]) + \
+            np.sign(coef[j]) * (self.reg_factor / (9 * self.reg_factor_channel[j]))
+            for j in range(coef.size)
+        ])
+
+        return jacobian
+
+    def optimize(self, mask):
+        """
+    Optimize unshimmed volume by varying current to each channel; this function will use the mse function and jacobian
+
+    Args:
+        mask (numpy.ndarray): 3D integer mask used for the optimizer (only consider voxels with non-zero values).
+
+    Returns:
+        numpy.ndarray: Coefficients corresponding to the coil profiles that minimize the objective function.
+                       The shape of the array returned has shape corresponding to the total number of channels
+    """
+        # Check for sizing errors
+        self._check_sizing(mask)
+
+        # Define coil profiles
+        n_channels = self.merged_coils.shape[3]
+
+        mask_vec = mask.reshape((-1,))
+
+        # Reshape coil profile: X, Y, Z, N --> [mask.shape], N
+        #   --> N, [mask.shape] --> N, mask.size --> mask.size, N --> masked points, N
+        coil_mat = np.reshape(np.transpose(self.merged_coils, axes=(3, 0, 1, 2)),
+                              (n_channels, -1)).T[mask_vec != 0, :]  # masked points x N
+        unshimmed_vec = np.reshape(self.unshimmed, (-1,))[mask_vec != 0]  # mV'
+
+        scipy_constraints = self._define_scipy_constraints()
+
+        # Set up output currents
+        currents_0 = self.get_initial_guess()
+
+        # Optimize
+        # When clipping to bounds, scipy raises a warning. Since this can be frequent for our purposes, we ignore that
+        # warning
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', message="Values in x were outside bounds during a "
+                                                      "minimize step, clipping to bounds",
+                                    category=RuntimeWarning,
+                                    module='scipy')
+        # scipy minimize expects the return value of the residual function to be ~10^0 to 10^1
+        # --> aiming for 1 then optimizing will lower that. We are using an initial guess of 0s so that the
+        # regularization on the currents has no effect on the output stability factor.
+
+        stability_factor = self._residuals_mse(self._initial_guess_zeros(), unshimmed_vec, np.zeros_like(coil_mat),
+                                               factor=1)
+        # This parameter will be use; to calculate the jacobian mse, so it's better to calculate it now, to do it
+        #  only once per slice
+        self.b = (2 / (unshimmed_vec.size * stability_factor))
+        currents_sp = self._scipy_minimize_with_jacobian_mse(currents_0, unshimmed_vec, coil_mat, scipy_constraints,
+                                                             factor=stability_factor)
+
+        if not currents_sp.success:
+            raise RuntimeError(f"Optimization failed due to: {currents_sp.message}")
+
+        currents = currents_sp.x
+        return currents

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-from timeit import timeit
 
 import numpy as np
 import scipy.optimize as opt
@@ -223,7 +222,7 @@ class LsqOptimizer(Optimizer):
         np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False)) ** 2) / factor+\
            (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
         If you want to see the mathematical expression for the jacobian, of this function or for the mae one,
-         please contact : aurelienpujolmpro@gmail.com
+        please contact : aurelienpujolmpro@gmail.com
 
         Args:
             coef (numpy.ndarray): 1D array of channel coefficients

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -46,7 +46,7 @@ class LsqOptimizer(Optimizer):
         }
         if opt_criteria in lsq_residual_dict:
             self._criteria_func = lsq_residual_dict[opt_criteria]
-            self.method_to_minimize = opt_criteria
+            self.opt_criteria = opt_criteria
         else:
             raise ValueError("Optimization criteria not supported")
 
@@ -148,7 +148,7 @@ class LsqOptimizer(Optimizer):
         return constraints
 
     def _scipy_minimize(self, currents_0, unshimmed_vec, coil_mat, scipy_constraints, factor):
-        if self.method_to_minimize == 'mse':
+        if self.opt_criteria == 'mse':
             currents_sp = opt.minimize(self._criteria_func, currents_0,
                                        args=(unshimmed_vec, coil_mat, factor),
                                        method='SLSQP',

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -281,14 +281,11 @@ def _cal_shimmed_anat_orient(coefs, coils, nii_mask_anat, nii_fieldmap, slices, 
                                      mode='grid-constant',
                                      cval=0).get_fdata()
     shimmed_anat_orient = fieldmap_anat
-    nb_channel = np.shape(coefs)[1]
-    dimx = np.shape(coils_anat)[0]
-    dimy = np.shape(coils_anat)[1]
+
     for i_shim in list_shim_slice:
-        # We want to do the np.sum with a 2D matrix so that it is faster
-        coils_anat_reduced = np.reshape(coils_anat[:, :, slices[i_shim], :], (-1, nb_channel))
-        corr = np.sum(coefs[i_shim] * coils_anat_reduced, axis=1, keepdims=False)
-        shimmed_anat_orient[..., slices[i_shim]] += np.reshape(corr, (dimx, dimy, 1))
+        # We want to do the np.sum with a 3D matrix if possible
+        corr = np.sum(coefs[i_shim] * coils_anat[:,:, slices[i_shim], :], axis=3, keepdims=False)
+        shimmed_anat_orient[..., slices[i_shim]] += corr
     fname_shimmed_anat_orient = os.path.join(path_output, 'fig_shimmed_anat_orient.nii.gz')
     nii_shimmed_anat_orient = nib.Nifti1Image(shimmed_anat_orient * nii_mask_anat.get_fdata(), nii_mask_anat.affine,
                                               header=nii_mask_anat.header)

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -171,12 +171,9 @@ def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices,
         # Save coils
         nii_merged_coils = nib.Nifti1Image(opt.merged_coils, nii_fieldmap_orig.affine, header=nii_fieldmap_orig.header)
         nib.save(nii_merged_coils, os.path.join(path_output, "merged_coils.nii.gz"))
-
     unshimmed = nii_fieldmap_orig.get_fdata()
-
     # If the fieldmap was changed (i.e. only 1 slice) we want to evaluate the output on the original fieldmap
     merged_coils, _ = opt.merge_coils(unshimmed, nii_fieldmap_orig.affine)
-
     # Initialize
     shimmed = np.zeros(unshimmed.shape + (len(slices),))
     corrections = np.zeros(unshimmed.shape + (len(slices),))
@@ -249,7 +246,6 @@ def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices,
             nii_correction = nib.Nifti1Image(masks_fmap * shimmed, opt.unshimmed_affine)
             nib.save(nii_correction, fname_correction)
 
-
 @timeit
 def _cal_shimmed_anat_orient(coefs, coils, nii_mask_anat, nii_fieldmap, slices, path_output, list_shim_slice):
     nii_coils = nib.Nifti1Image(coils, nii_fieldmap.affine, header=nii_fieldmap.header)
@@ -272,7 +268,7 @@ def _cal_shimmed_anat_orient(coefs, coils, nii_mask_anat, nii_fieldmap, slices, 
         # We want to do the np.sum with a 2D matrix to get it aster
         coils_anat_reduced = np.reshape(coils_anat[:, :, slices[i_shim], :], (-1, nb_channel))
         corr = np.sum(coefs[i_shim] * coils_anat_reduced, axis=1, keepdims=False)
-        shimmed_anat_orient[..., slices[i_shim]] += np.shape(corr, (dimx, dimy, 1))
+        shimmed_anat_orient[..., slices[i_shim]] += np.reshape(corr, (dimx, dimy, 1))
     logger.debug(f"Creating shimmed anat took {time.time() - time_start:.4}s to run ")
     fname_shimmed_anat_orient = os.path.join(path_output, 'fig_shimmed_anat_orient.nii.gz')
     nii_shimmed_anat_orient = nib.Nifti1Image(shimmed_anat_orient * nii_mask_anat.get_fdata(), nii_mask_anat.affine,

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -62,7 +62,7 @@ def shim_sequencer(nii_fieldmap, nii_anat, nii_mask_anat, slices, coils: ListCoi
                           are larger than the extent of the fieldmap. This is especially true for dimensions with only
                           1 voxel(e.g. (50x50x1). Refer to :func:`shimmingtoolbox.shim.sequencer.extend_slice`/
                           :func:`shimmingtoolbox.shim.sequencer.update_affine_for_ap_slices`
-        method (str): Supported optimizer: 'least_squares', 'pseudo_inverse', 'least_squares_faster. Note: refer to their specific
+        method (str): Supported optimizer: 'least_squares', 'pseudo_inverse', Note: refer to their specific
                       implementation to know limits of the methods in: :mod:`shimmingtoolbox.optimizer`
         opt_criteria (str): Criteria for the optimizer 'least_squares'. Supported: 'mse': mean squared error,
                             'mae': mean absolute error, 'std': standard deviation.
@@ -181,16 +181,13 @@ def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices,
     shimmed = np.zeros(unshimmed.shape + (len(slices),))
     corrections = np.zeros(unshimmed.shape + (len(slices),))
     masks_fmap = np.zeros(unshimmed.shape + (len(slices),))
-    chaine = ""
     list_shim_slice = []
     for i_shim in range(len(slices)):
         # Create non binary mask
         masks_fmap[..., i_shim] = resample_mask(nii_mask, nii_fieldmap_orig, slices[i_shim]).get_fdata()
         # Calculate shimmed values
         if not np.any(coef[i_shim]):
-            chaine = chaine + str(slices[i_shim]) + ","
             shimmed[..., i_shim] = unshimmed
-            masks_fmap[..., i_shim] = resample_mask(nii_mask, nii_fieldmap_orig, slices[i_shim]).get_fdata()
         else:
             list_shim_slice.append(i_shim)
             correction_per_channel = coef[i_shim] * merged_coils
@@ -588,7 +585,7 @@ def shim_realtime_pmu_sequencer(nii_fieldmap, json_fmap, nii_anat, nii_static_ma
     # Static shim
     optimizer = select_optimizer(opt_method, static, affine_fieldmap, coils, opt_criteria, reg_factor=reg_factor)
     logger.info("Static optimization")
-    coef_static = _optimize(optimizer, nii_static_mask, slices,
+    coef_static = _optimize(optimizer, nii_static_mask, slices, opt_criteria,
                             dilation_kernel=mask_dilation_kernel,
                             dilation_size=mask_dilation_kernel_size,
                             path_output=path_output)
@@ -602,7 +599,7 @@ def shim_realtime_pmu_sequencer(nii_fieldmap, json_fmap, nii_anat, nii_static_ma
 
     optimizer = select_optimizer(opt_method, riro, affine_fieldmap, coils, opt_criteria, pmu, reg_factor=reg_factor)
     logger.info("Realtime optimization")
-    coef_riro = _optimize(optimizer, nii_riro_mask, slices,
+    coef_riro = _optimize(optimizer, nii_riro_mask, slices, opt_criteria,
                           shimwise_bounds=bounds,
                           dilation_kernel=mask_dilation_kernel,
                           dilation_size=mask_dilation_kernel_size,

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -285,7 +285,7 @@ def _cal_shimmed_anat_orient(coefs, coils, nii_mask_anat, nii_fieldmap, slices, 
     dimx = np.shape(coils_anat)[0]
     dimy = np.shape(coils_anat)[1]
     for i_shim in list_shim_slice:
-        # We want to do the np.sum with a 2D matrix to get it aster
+        # We want to do the np.sum with a 2D matrix so that it is faster
         coils_anat_reduced = np.reshape(coils_anat[:, :, slices[i_shim], :], (-1, nb_channel))
         corr = np.sum(coefs[i_shim] * coils_anat_reduced, axis=1, keepdims=False)
         shimmed_anat_orient[..., slices[i_shim]] += np.reshape(corr, (dimx, dimy, 1))

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -188,6 +188,7 @@ def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices,
         # Calculate shimmed values
         if not np.any(coef[i_shim]):
             shimmed[..., i_shim] = unshimmed
+            continue
         else:
             list_shim_slice.append(i_shim)
             correction_per_channel = coef[i_shim] * merged_coils

--- a/test/cli/test_cli_b0shim.py
+++ b/test/cli/test_cli_b0shim.py
@@ -90,14 +90,12 @@ class TestCliDynamic(object):
                                              '--mask', fname_mask,
                                              '--scanner-coil-order', '2',
                                              '--regularization-factor', '0.1',
-                                             # '-v', 'debug',
                                              '--output', tmp],
                                 catch_exceptions=False)
 
             assert res.exit_code == 0
             assert os.path.isfile(os.path.join(tmp, "coefs_coil0_Prisma_fit_gradient_coil.txt"))
 
-   
     def test_cli_dynamic_no_mask(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
         """Test cli with scanner coil profiles of order 1 with default constraints"""
         with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:

--- a/test/cli/test_cli_b0shim.py
+++ b/test/cli/test_cli_b0shim.py
@@ -97,45 +97,7 @@ class TestCliDynamic(object):
             assert res.exit_code == 0
             assert os.path.isfile(os.path.join(tmp, "coefs_coil0_Prisma_fit_gradient_coil.txt"))
 
-    def test_cli_dynamic_sph_faster(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
-        """Test cli with scanner coil profiles of order 1 with default constraints and least squares faster solver"""
-        with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
-            # Save the inputs to the new directory
-            fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
-            fname_fm_json = os.path.join(tmp, 'fmap.json')
-            fname_mask = os.path.join(tmp, 'mask.nii.gz')
-            fname_anat = os.path.join(tmp, 'anat.nii.gz')
-            fname_anat_json = os.path.join(tmp, 'anat.json')
-            _save_inputs(nii_fmap=nii_fmap, fname_fmap=fname_fmap,
-                         nii_anat=nii_anat, fname_anat=fname_anat,
-                         nii_mask=nii_mask, fname_mask=fname_mask,
-                         fm_data=fm_data, fname_fm_json=fname_fm_json,
-                         anat_data=anat_data, fname_anat_json=fname_anat_json)
-            runner = CliRunner()
-            # If you want to try the test with the bigger dataset, please send a mail to aurelienpujolm@outlook.fr,
-            # Then uncomment the following lines, and the line 125. And Comment the line 129
-
-            # fname_fmap = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'fmap', 'fieldmap.nii.gz')
-            # fname_mask = os.path.join(__dir_testing__, 'eroded-mask.nii.gz')
-            # fname_anat = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-st-shim_epi.nii.gz')
-            # fname_coil = os.path.join(__dir_testing__, 'profiles_7T_V2.nii.gz')
-            # fname_coil_constraints = os.path.join(__dir_testing__, 'jason_coil_config_15e_20a.json')
-
-            res = runner.invoke(b0shim_cli, ['dynamic',
-                                             # '--coil', fname_coil, fname_coil_constraints,
-                                             '--fmap', fname_fmap,
-                                             '--anat', fname_anat,
-                                             '--mask', fname_mask,
-                                             '--scanner-coil-order', '2',
-                                             '--regularization-factor', '0.1',
-                                             '--output', tmp,
-                                             # '-v', 'debug',
-                                             '--optimizer-method', 'least_squares_faster'],
-                                catch_exceptions=False)
-
-            assert res.exit_code == 0
-            # assert os.path.isfile(os.path.join(tmp, "coefs_coil0_Prisma_fit_gradient_coil.txt"))
-
+   
     def test_cli_dynamic_no_mask(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
         """Test cli with scanner coil profiles of order 1 with default constraints"""
         with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
This PR will be trying to make the B0 shimming as fast as possible 
Specially, this PR will 

- Change the function to minimize to a newest one which is faster to minimize (residuals mse)
- Find a way to plot the newest currents coefficients as fast as possible 
- Reduced the processing time of the sequencer 

## Linked issues
This pull request fixes #412 about the time of the B0 shimming 