### PR TITLE
Add a CLI to sort DICOMs in separate folders

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
             "st_dump_env_info=shimmingtoolbox.cli.check_env:dump_env_info",
             "st_image=shimmingtoolbox.cli.image:image_cli",
             "st_maths=shimmingtoolbox.cli.maths:maths_cli",
-            "st_b0shim=shimmingtoolbox.cli.b0shim:b0shim_cli"
+            "st_b0shim=shimmingtoolbox.cli.b0shim:b0shim_cli",
+            "st_sort_dicoms=shimmingtoolbox.cli.sort_dicoms:sort_dicoms"
         ]
     },
     packages=find_packages(exclude=["docs"]),
@@ -45,6 +46,7 @@ setup(
         "tqdm",
         "matplotlib~=3.3.4",
         "psutil~=5.7.3",
+        "pydicom",
         "pytest>=6.2.5",
         "pytest-cov~=2.5.1",
         "scikit-learn>=1.1.2",

--- a/shimmingtoolbox/cli/sort_dicoms.py
+++ b/shimmingtoolbox/cli/sort_dicoms.py
@@ -21,9 +21,6 @@ logger = logging.getLogger(__name__)
 def sort_dicoms(path_input, path_output, verbose):
     set_all_loggers(verbose)
 
-    # Create output directory
-    create_output_dir(path_output)
-
     # Create a list containing all the DICOMs in the input folder
     list_dicoms = []
     for name in os.listdir(path_input):
@@ -39,6 +36,9 @@ def sort_dicoms(path_input, path_output, verbose):
     # Make sure there is at least one DICOM
     if not list_dicoms:
         raise RuntimeError(f"{path_input} does not contain dicom files")
+
+    # Create output directory
+    create_output_dir(path_output)
 
     # For loop on all DICOMs in the directory
     for fname_dcm in sorted(list_dicoms):

--- a/shimmingtoolbox/cli/sort_dicoms.py
+++ b/shimmingtoolbox/cli/sort_dicoms.py
@@ -1,0 +1,60 @@
+#!usr/bin/env python3
+# coding: utf-8
+
+import click
+import logging
+import os
+from pydicom import dcmread
+import shutil
+
+from shimmingtoolbox.utils import set_all_loggers, create_output_dir
+
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option('-i', "--input", "path_input", help="Input folder.")
+@click.option('-o', "--output", "path_output", help="Output folder.")
+@click.option('-v', '--verbose', type=click.Choice(['info', 'debug']), default='info', help="Be more verbose")
+def sort_dicoms(path_input, path_output, verbose):
+    set_all_loggers(verbose)
+
+    # Create output directory
+    create_output_dir(path_output)
+
+    # Create a list containing all the DICOMs in the input folder
+    list_dicoms = []
+    for name in os.listdir(path_input):
+        fname_tmp = os.path.join(path_input, name)
+        # If it's not a file
+        if not os.path.isfile(fname_tmp):
+            continue
+        # If it's not a .dcm or .ima
+        if (fname_tmp[-4:] != '.ima') and (fname_tmp[-4:] != '.dcm'):
+            continue
+        list_dicoms.append(fname_tmp)
+
+    # Make sure there is at least one DICOM
+    if not list_dicoms:
+        raise RuntimeError(f"{path_input} does not contain dicom files")
+
+    # For loop on all DICOMs in the directory
+    for fname_dcm in sorted(list_dicoms):
+        # Create the file path
+        ds = dcmread(fname_dcm)
+        series_number = ds["SeriesNumber"].value
+        series_description = ds["SeriesDescription"].value
+        folder_name = f"{series_number:02d}-" + series_description
+        path_folder_output = os.path.join(path_output, folder_name)
+
+        # Create output directory with the new name if it does not exist
+        if not os.path.isdir(path_folder_output):
+            create_output_dir(path_folder_output)
+
+        fname_output = os.path.join(path_folder_output, os.path.basename(fname_dcm))
+        # Copy files to the new folder
+        shutil.copyfile(fname_dcm, fname_output)
+
+    logger.info("Successfully sorted the DICOMs")

--- a/test/cli/test_cli_sort_dicoms.py
+++ b/test/cli/test_cli_sort_dicoms.py
@@ -1,0 +1,31 @@
+#!usr/bin/env python3
+# coding: utf-8
+
+from click.testing import CliRunner
+import os
+import pathlib
+import pytest
+import tempfile
+
+from shimmingtoolbox.cli.sort_dicoms import sort_dicoms
+from shimmingtoolbox import __dir_testing__
+
+
+def test_sort_dicoms_cli():
+    path_unsorted = os.path.join(__dir_testing__, 'dicom_unsorted')
+
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        result = CliRunner().invoke(sort_dicoms,
+                                    ['-i', path_unsorted,
+                                     '-o', tmp], catch_exceptions=True)
+
+        assert result.exit_code == 0
+        outputs = os.listdir(tmp)
+        assert '06-a_gre_DYNshim' in outputs
+        assert '07-a_gre_DYNshim' in outputs
+
+
+def test_sort_dicoms_cli_no_dicom():
+    path = os.path.join(__dir_testing__)
+    with pytest.raises(RuntimeError, match=f"{path} does not contain dicom files"):
+        CliRunner().invoke(sort_dicoms, ['-i', path], catch_exceptions=False)


### PR DESCRIPTION
## Description
This PR adds a convenience CLI to sort a flat directory containing DICOMs into separate folders based on their acquisition name and acquisition number.

Usage:
- st_sort_dicoms -i "path_to_dicoms" -o "path_to_output"
