### PR TITLE
Faster B0 shimming by changing some mathematical expressions

### DIFF
--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -118,7 +118,7 @@ class LsqOptimizer(Optimizer):
         # Finally np.abs(coef).dot(self.reg_vector) is equivalent and faster to self.reg_factor*np.mean(np.abs(coef) / self.reg_factor_channel)
         # For the mathematical demonstration see : https://github.com/shimming-toolbox/shimming-toolbox/pull/432 
         # MSE regularized to minimize currents
-        shimmed_vec = unshimmed_vec + coil_mat@coef
+        shimmed_vec = unshimmed_vec + coil_mat @ coef
         return (shimmed_vec).dot(shimmed_vec) / len(unshimmed_vec) / factor + np.abs(coef).dot(self.reg_vector)
 
     def _residuals_std(self, coef, unshimmed_vec, coil_mat, factor):

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -90,7 +90,7 @@ class LsqOptimizer(Optimizer):
                             avoid positive directional linesearch
 
         Returns:
-            float: Residuals for least squares optimization -- equivalent to flattened shimmed vector
+            float: Residuals for least squares optimization 
         """
 
         # MAE regularized to minimize currents
@@ -109,7 +109,7 @@ class LsqOptimizer(Optimizer):
                             avoid positive directional linesearch
 
         Returns:
-            float: Residuals for least squares optimization -- equivalent to flattened shimmed vector
+            float: Residuals for least squares optimization 
         """
         # Old one was : np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False))**2) / factor + \
         #                (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
@@ -132,7 +132,7 @@ class LsqOptimizer(Optimizer):
                             avoid positive directional linesearch
 
         Returns:
-            float: Residuals for least squares optimization -- equivalent to flattened shimmed vector
+            float: Residuals for least squares optimization 
         """
 
         # STD regularized to minimize currents

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -94,7 +94,7 @@ class LsqOptimizer(Optimizer):
         """
 
         # MAE regularized to minimize currents
-        return np.mean(np.abs(unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False))) / factor + \
+        return np.mean(np.abs(unshimmed_vec + coil_mat @ coef)) / factor + \
                (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
 
     def _residuals_mse(self, coef, unshimmed_vec, coil_mat, factor):
@@ -114,7 +114,7 @@ class LsqOptimizer(Optimizer):
         # Old one was : np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False))**2) / factor + \
         #                (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
         # MSE regularized to minimize currents
-        return np.mean((unshimmed_vec + coil_mat@coef) ** 2) / factor + \
+        return np.mean((unshimmed_vec + coil_mat @ coef) ** 2) / factor + \
                (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
 
     def _residuals_std(self, coef, unshimmed_vec, coil_mat, factor):
@@ -133,7 +133,7 @@ class LsqOptimizer(Optimizer):
         """
 
         # STD regularized to minimize currents
-        return np.std(unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False)) / factor + \
+        return np.std(unshimmed_vec + coil_mat @ coef) / factor + \
                (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
 
     def _define_scipy_constraints(self):

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -113,12 +113,13 @@ class LsqOptimizer(Optimizer):
         """
         # Old one was : np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False))**2) / factor + \
         #                (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
-        # First it's faster to switch np.sum(coil_mat*coef,axis=1,keepdims=False) by coil_mat@coef which is way faster
-        #Then for a vector , mean(x**2) is equivalent to x.dot(x)/n It's faster to do this operation instead of a np.mean
-        #Finally np.abs(coef).dot(self.reg_vector) is equivalent and faster to self.reg_factor*np.mean(np.abs(coef) / self.reg_factor_channel)
-        #For the mathematical demonstration see : https://github.com/shimming-toolbox/shimming-toolbox/pull/432 
+        # switch np.sum(coil_mat*coef,axis=1,keepdims=False) by coil_mat@coef which is way faster
+        # Then for a vector , mean(x**2) is equivalent to x.dot(x)/n , it's faster to do this operation instead of a np.mean
+        # Finally np.abs(coef).dot(self.reg_vector) is equivalent and faster to self.reg_factor*np.mean(np.abs(coef) / self.reg_factor_channel)
+        # For the mathematical demonstration see : https://github.com/shimming-toolbox/shimming-toolbox/pull/432 
         # MSE regularized to minimize currents
-        return (unshimmed_vec + coil_mat@coef).dot(unshimmed_vec + coil_mat @ coef) / len(unshimmed_vec) / factor + np.abs(coef).dot(self.reg_vector)
+        shimmed_vec = unshimmed_vec + coil_mat@coef
+        return (shimmed_vec).dot(shimmed_vec) / len(unshimmed_vec) / factor + np.abs(coef).dot(self.reg_vector)
 
     def _residuals_std(self, coef, unshimmed_vec, coil_mat, factor):
         """ Objective function to minimize the standard deviation (STD)

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -236,11 +236,6 @@ class LsqOptimizer(Optimizer):
         Returns:
             jacobian (numpy.ndarray) : 1D array of the gradient of the mse function to minimize
         """
-        #jacobian = np.array([
-            #self.b * np.sum((unshimmed_vec + coil_mat @ coef) * coil_mat[:, j]) + \
-            #np.sign(coef[j]) * (self.reg_factor / (len(coef) * self.reg_factor_channel[j]))
-            #for j in range(coef.size)
-        #])
         return self.b * (unshimmed_vec + np.matmul(coil_mat, coef)) @ coil_mat + np.sign(coef) * self.reg_vector
 
     def optimize(self, mask):

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -90,7 +90,7 @@ class LsqOptimizer(Optimizer):
                             avoid positive directional linesearch
 
         Returns:
-            float: Residuals for least squares optimization -- equivalent to flattened shimmed vector
+            float: Residuals for least squares optimization
         """
 
         # MAE regularized to minimize currents
@@ -109,7 +109,7 @@ class LsqOptimizer(Optimizer):
                             avoid positive directional linesearch
 
         Returns:
-            float: Residuals for least squares optimization -- equivalent to flattened shimmed vector
+            float: Residuals for least squares optimization
         """
         # Old one was : np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False))**2) / factor + \
         #                (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
@@ -129,7 +129,7 @@ class LsqOptimizer(Optimizer):
                             avoid positive directional linesearch
 
         Returns:
-            float: Residuals for least squares optimization -- equivalent to flattened shimmed vector
+            float: Residuals for least squares optimization
         """
 
         # STD regularized to minimize currents

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -39,7 +39,7 @@ class LsqOptimizer(Optimizer):
         self.initial_coefs = None
         self.reg_factor = reg_factor
         self.reg_factor_channel = np.array([max(np.abs(bound)) for bound in self.merged_bounds])
-
+        self.reg_vector = self.reg_factor / len(self.reg_factor_channel) / self.reg_factor_channel
         lsq_residual_dict = {
             allowed_opt_criteria[0]: self._residuals_mse,
             allowed_opt_criteria[1]: self._residuals_mae,
@@ -269,7 +269,6 @@ class LsqOptimizer(Optimizer):
         coil_mat = np.reshape(np.transpose(self.merged_coils, axes=(3, 0, 1, 2)),
                               (n_channels, -1)).T[mask_vec != 0, :]  # masked points x N
         unshimmed_vec = np.reshape(self.unshimmed, (-1,))[mask_vec != 0]  # mV'
-        self.reg_vector = self.reg_factor / len(self.reg_factor_channel) / self.reg_factor_channel
         scipy_constraints = self._define_scipy_constraints()
 
         # Set up output currents

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -195,10 +195,13 @@ def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices,
             shimmed[..., i_shim] = unshimmed
             continue
         list_shim_slice.append(i_shim)
-        correction_per_channel = coef[i_shim] * merged_coils
-        corrections[..., i_shim] = np.sum(correction_per_channel, axis=3, keepdims=False)
-        shimmed[..., i_shim] = unshimmed + corrections[..., i_shim]
-
+        #Old version of the code
+        #correction_per_channel = coef[i_shim] * merged_coils
+        #corrections[..., i_shim] = np.sum(correction_per_channel, axis=3, keepdims=False)
+        #shimmed[..., i_shim] = unshimmed + corrections[..., i_shim]
+        #New version of the code
+        corrections[...,i_shim] = merged_coils @ coef[i_shim]
+        shimmed[..., i_shim] = unshimmed + corrections[...,i_shim]
         ma_shimmed = np.ma.array(shimmed[..., i_shim], mask=masks_fmap[..., i_shim] == False)
         ma_unshimmed = np.ma.array(unshimmed, mask=masks_fmap[..., i_shim] == False)
         std_shimmed = np.ma.std(ma_shimmed)
@@ -289,7 +292,8 @@ def _cal_shimmed_anat_orient(coefs, coils, nii_mask_anat, nii_fieldmap, slices, 
 
     for i_shim in list_shim_slice:
         # We want to do the np.sum with a 3D matrix if possible
-        corr = np.sum(coefs[i_shim] * coils_anat[:, :, slices[i_shim], :], axis=3, keepdims=False)
+        corr = np.sum(coefs[i_shim] * coils_anat[:,:, slices[i_shim], :], axis=3, keepdims=False)
+        #Equivalent to this line :  corr = coils_anat[:, :, slices[i_shim], :] @ coefs[i_shim]
         shimmed_anat_orient[..., slices[i_shim]] += corr
     fname_shimmed_anat_orient = os.path.join(path_output, 'fig_shimmed_anat_orient.nii.gz')
     nii_shimmed_anat_orient = nib.Nifti1Image(shimmed_anat_orient * nii_mask_anat.get_fdata(), nii_mask_anat.affine,
@@ -939,27 +943,24 @@ def select_optimizer(method, unshimmed, affine, coils: ListCoil, opt_criteria, p
 
     return optimizer
 
-
 @timeit
 def _optimize(optimizer: Optimizer, nii_mask_anat, slices_anat, opt_criteria, shimwise_bounds=None,
               dilation_kernel='sphere', dilation_size=3, path_output=None):
-    # Number of optimizations to perform
+    # Count shims to perform
     n_shims = len(slices_anat)
-
-    # If the opt_criteria is mse with jacobian, it's faster to not use multiprocessing on mac for smaller
-    # datasets. For now, we use mp for every dataset.
-    # if opt_criteria == 'mse' and sys.platform != 'linux':
-    #     _worker_init(optimizer, nii_mask_anat, slices_anat, dilation_kernel, dilation_size, path_output,
-    #                  shimwise_bounds)
-    #     results = []
-    #     for i in range(n_shims):
-    #         result = _opt(i)
-    #         results.append(result)
-    # else:
-
-    # Multiprocessing optimization
-    _optimize_scope = (
-        optimizer, nii_mask_anat, slices_anat, dilation_kernel, dilation_size, path_output, shimwise_bounds)
+    # If the method is the mse with jacobian, it's faster to not do the multiprocessing on mac computer so far.
+    # However, if there is a way to make multiprocessing faster, we should do it.
+    if opt_criteria == 'mse' and sys.platform != 'linux':
+        _worker_init(optimizer, nii_mask_anat, slices_anat, dilation_kernel, dilation_size, path_output,
+                     shimwise_bounds)
+        results = []
+        for i in range(n_shims):
+            result = _opt(i)
+            results.append(result)
+    else:
+    # multiprocessing optimization
+        _optimize_scope = (
+            optimizer, nii_mask_anat, slices_anat, dilation_kernel, dilation_size, path_output, shimwise_bounds)
 
     # Default number of workers is set to mp.cpu_count()
     # _worker_init gets called by each worker with _optimize_scope as arguments
@@ -974,20 +975,20 @@ def _optimize(optimizer: Optimizer, nii_mask_anat, slices_anat, opt_criteria, sh
     # whole call needs to be finished to access the results (results.get()). A whole discussion
     # thread is available here: https://stackoverflow.com/questions/26520781/multiprocessing-pool-whats-the
     # -difference-between-map-async-and-imap
-    pool = mp.Pool(initializer=_worker_init, initargs=_optimize_scope)
-    try:
+        pool = mp.Pool(initializer=_worker_init, initargs=_optimize_scope)
+        try:
 
-        results = []
-        print(f"\rProgress 0.0%")
-        for i, result in enumerate(pool.imap_unordered(_opt, range(n_shims))):
-            print(f"\rProgress {np.round((i + 1) / n_shims * 100)}%")
-            results.append(result)
+            results = []
+            print(f"\rProgress 0.0%")
+            for i, result in enumerate(pool.imap_unordered(_opt, range(n_shims))):
+                print(f"\rProgress {np.round((i + 1) / n_shims * 100)}%")
+                results.append(result)
 
-    except mp.context.TimeoutError:
-        logger.info("Multiprocessing might have hung, retry the same command")
-    finally:
-        pool.close()
-        pool.join()
+        except mp.context.TimeoutError:
+            logger.info("Multiprocessing might have hung, retry the same command")
+        finally:
+            pool.close()
+            pool.join()
 
     results.sort(key=lambda x: x[0])
     results_final = [r for i, r in results]

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -90,6 +90,7 @@ def shim_sequencer(nii_fieldmap, nii_anat, nii_mask_anat, slices, coils: ListCoi
             nii_fmap_orig = nib.Nifti1Image(nii_fmap_orig.get_fdata()[..., np.newaxis], nii_fmap_orig.affine,
                                             header=nii_fmap_orig.header)
             nii_fieldmap = extend_fmap_to_kernel_size(nii_fmap_orig, mask_dilation_kernel_size, path_output)
+            extending = True 
         else:
             raise ValueError("Fieldmap must be 2d or 3d")
     else:

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -195,11 +195,6 @@ def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices,
             shimmed[..., i_shim] = unshimmed
             continue
         list_shim_slice.append(i_shim)
-        #Old version of the code
-        #correction_per_channel = coef[i_shim] * merged_coils
-        #corrections[..., i_shim] = np.sum(correction_per_channel, axis=3, keepdims=False)
-        #shimmed[..., i_shim] = unshimmed + corrections[..., i_shim]
-        #New version of the code
         corrections[...,i_shim] = merged_coils @ coef[i_shim]
         shimmed[..., i_shim] = unshimmed + corrections[...,i_shim]
         ma_shimmed = np.ma.array(shimmed[..., i_shim], mask=masks_fmap[..., i_shim] == False)
@@ -291,9 +286,7 @@ def _cal_shimmed_anat_orient(coefs, coils, nii_mask_anat, nii_fieldmap, slices, 
     shimmed_anat_orient = fieldmap_anat
 
     for i_shim in list_shim_slice:
-        # We want to do the np.sum with a 3D matrix if possible
         corr = np.sum(coefs[i_shim] * coils_anat[:,:, slices[i_shim], :], axis=3, keepdims=False)
-        #Equivalent to this line :  corr = coils_anat[:, :, slices[i_shim], :] @ coefs[i_shim]
         shimmed_anat_orient[..., slices[i_shim]] += corr
     fname_shimmed_anat_orient = os.path.join(path_output, 'fig_shimmed_anat_orient.nii.gz')
     nii_shimmed_anat_orient = nib.Nifti1Image(shimmed_anat_orient * nii_mask_anat.get_fdata(), nii_mask_anat.affine,

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -286,7 +286,7 @@ def _cal_shimmed_anat_orient(coefs, coils, nii_mask_anat, nii_fieldmap, slices, 
     shimmed_anat_orient = fieldmap_anat
 
     for i_shim in list_shim_slice:
-        corr = np.sum(coefs[i_shim] * coils_anat[:,:, slices[i_shim], :], axis=3, keepdims=False)
+        corr = np.sum(coefs[i_shim] * coils_anat[:, :, slices[i_shim], :], axis=3, keepdims=False)
         shimmed_anat_orient[..., slices[i_shim]] += corr
     fname_shimmed_anat_orient = os.path.join(path_output, 'fig_shimmed_anat_orient.nii.gz')
     nii_shimmed_anat_orient = nib.Nifti1Image(shimmed_anat_orient * nii_mask_anat.get_fdata(), nii_mask_anat.affine,

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -184,7 +184,7 @@ def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices,
     unshimmed = nii_fieldmap_orig.get_fdata()
     # If the fieldmap was changed (i.e. only 1 slice) we want to evaluate the output on the original fieldmap
     if equal_fieldmap:
-        # We extend the dimensions to have the same one as unshimmed
+        # We extend to make sure that merged_coils @ coef[i_shim] has the same dimensions of corrections[...,i_shim]
         merged_coils = np.expand_dims(opt.merged_coils[:, :, 1, :], 2)
 
     else:

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -165,13 +165,15 @@ def shim_sequencer(nii_fieldmap, nii_anat, nii_mask_anat, slices, coils: ListCoi
 
     # Evaluate theoretical shim
     logger.info("Calculating output files and preparing figures")
-    _eval_static_shim(optimizer, nii_fmap_orig, nii_mask_anat, coefs, slices, path_output, opt_criteria)
+    # We want to check the affine and data of both fieldmap to eventually save time in eval_static_shim
+    equal_fieldmap = np.all(nii_fmap_orig.affine == affine_fieldmap ) and np.all(nii_fmap_orig.get_fdata() == fieldmap)
+    _eval_static_shim(optimizer, nii_fmap_orig, nii_mask_anat, coefs, slices, path_output, equal_fieldmap, opt_criteria)
 
     return coefs
 
 
 @timeit
-def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices, path_output, opt_criteria=None):
+def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices, path_output, equal_fieldmap, opt_criteria=None):
     """Calculate theoretical shimmed map and output figures"""
 
     # Save the merged coil profiles if in debug
@@ -181,7 +183,12 @@ def _eval_static_shim(opt: Optimizer, nii_fieldmap_orig, nii_mask, coef, slices,
         nib.save(nii_merged_coils, os.path.join(path_output, "merged_coils.nii.gz"))
     unshimmed = nii_fieldmap_orig.get_fdata()
     # If the fieldmap was changed (i.e. only 1 slice) we want to evaluate the output on the original fieldmap
-    merged_coils, _ = opt.merge_coils(unshimmed, nii_fieldmap_orig.affine)
+    if equal_fieldmap:
+        # We extend the dimensions to have the same one as unshimmed
+        merged_coils = np.expand_dims(opt.merged_coils[:, :, 1, :], 2)
+
+    else:
+        merged_coils, _ = opt.merge_coils(unshimmed, nii_fieldmap_orig.affine)
     # Initialize
     shimmed = np.zeros(unshimmed.shape + (len(slices),))
     corrections = np.zeros(unshimmed.shape + (len(slices),))

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -939,7 +939,7 @@ def select_optimizer(method, unshimmed, affine, coils: ListCoil, opt_criteria, p
 @timeit
 def _optimize(optimizer: Optimizer, nii_mask_anat, slices_anat, opt_criteria, shimwise_bounds=None,
               dilation_kernel='sphere', dilation_size=3, path_output=None):
-    # Count shims to perform
+    # Number of optimizations to perform
     n_shims = len(slices_anat)
     # If the method is the mse with jacobian, it's faster to not do the multiprocessing on mac computer so far.
     # However, if there is a way to make multiprocessing faster, we should do it.

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -958,7 +958,7 @@ def _optimize(optimizer: Optimizer, nii_mask_anat, slices_anat, opt_criteria, sh
             result = _opt(i)
             results.append(result)
     else:
-    # multiprocessing optimization
+        # multiprocessing optimization
         _optimize_scope = (
             optimizer, nii_mask_anat, slices_anat, dilation_kernel, dilation_size, path_output, shimwise_bounds)
 


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer


## Description
This PR is make to be able to achieve faster B0 shimming, indeed, B0 shimming, is an important process in MRI, and need to be fast. However, before this PR, for a dataset like this : 
- coil ( 32 channels) ;
- anatomic image ([174,174,50] );
-  fieldmap([112,112,70]);
-  mask ([112,112,70]). 
The B0 shimming process took around **130 seconds on the Django Computer**, and with multiprocessing. We found that a big part of this time was caused by the optimizations of the different currents which are calculated in the lsq_optimizer class. After some research I found out that a simple modification can speed up a lot the optimization. 
For this, we just have to change some functions with a switch from np.sum(A*B,...), to A@B (or B@A), indeed in python, it's much more faster to do matrix multiplications than np.sum (And it gave exactly the same result ).
Here is the proof : Let's do this line of code : np.sum(coil_mat * coef, axis = 1 ) (This is used in the residuals_mse function)
with dim(coilmat)=(n,m) and dim(coef)=(m)(Here let's call coil_mat A, and coef B)
Also, it's important to note that in python the multiplication of two matrices is different that the mathematical multiplication of matrices.
Here A multiply by B is equal : 
```math
C= \begin{bmatrix}
 A_{1,1}*B_1,  A_{1,2}*B_2,..., A_{1,m}*B_m \\
...,...,...\\
A_{n,1}*B_1, A_{n,2}*B_2,...,A_{n,m}*B_m
\end{bmatrix}
```
And the np.sum(C, axis = 1 ), will do this :
```math
\begin{bmatrix}
 \\
\sum_{i=1}^{m} A_{1,i}*B_i \\
...\\
\sum_{i=1}^{m}A_{n,i}*B_i\\
\end{bmatrix} 
```
(I don't know why the term in the sum are going below, when I'm writing this on github...)
Which is also just the mathematical multiplication of two matrices !
So I've decided to change some parts of the code with that modification.( I didn't change all of the parts where we have np.sum, because it was already fast enough, and it's more readable for a user to keep np.sum(A*B))
This allows having much more faster optimization. Indeed, on Django mac computer, without multiprocessing it is now taking much less time. Indeed it went from **90 seconds to only 20 seconds** (With around 15 of them caused by resampling). So it does helps ! 
I also did a modification in the function eval_static_shim in the sequencer. to reduce the time by around 10 seconds (While keeping the same results). 

With all of these changes, **B0 shimming should now be faster (80 seconds VS 130)**.  Even with the problem of the high time processing of different resampling, and the fact that multiprocessing on mac computer is still really slow to start.(For this reason, I believe that with these change, it's for now better to not use multiprocessing on mac. However, if we succeed in doing faster multiprocessing, the optimization can be way faster !) 

## Linked issues
Adresses https://github.com/shimming-toolbox/shimming-toolbox/pull/423 , https://github.com/shimming-toolbox/shimming-toolbox/issues/412 
