### PR TITLE
Make Resampling faster by using multiprocessing with joblib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "pillow>=9.0.0",
         "dataclasses",
         "raven",
+        "joblib",
     ],
     extras_require={
         'docs': ["sphinx>=1.6", "sphinx_rtd_theme>=0.2.4", "sphinx-click"],

--- a/shimmingtoolbox/coils/coordinates.py
+++ b/shimmingtoolbox/coils/coordinates.py
@@ -7,6 +7,7 @@ from nibabel.affines import apply_affine
 import math
 import multiprocessing as mp
 import nibabel as nib
+from joblib import Parallel, delayed
 from nibabel.processing import resample_from_to as nib_resample_from_to
 
 

--- a/shimmingtoolbox/coils/coordinates.py
+++ b/shimmingtoolbox/coils/coordinates.py
@@ -8,6 +8,8 @@ import math
 import nibabel as nib
 from nibabel.processing import resample_from_to as nib_resample_from_to
 from joblib import Parallel, delayed
+
+
 def generate_meshgrid(dim, affine):
     """
     Generate meshgrid of size dim, with coordinate system defined by affine.
@@ -167,7 +169,6 @@ def resample_from_to(nii_from_img, nii_to_vox_map, order=2, mode='nearest', cval
         results = Parallel(-1, backend='loky')(
             delayed(_resample_4d)(it, nii_from_img, nii_to_vox_map, order, mode, cval, out_class)
             for it in range(nt))
-        # results.sort(key=lambda x: x[0])
         resampled_4d = np.array([results[it] for it in range(nt)]).transpose(1, 2, 3, 0)
         nii_resampled = nib.Nifti1Image(resampled_4d, nii_to_vox_map.affine, header=nii_to_vox_map.header)
 

--- a/shimmingtoolbox/coils/coordinates.py
+++ b/shimmingtoolbox/coils/coordinates.py
@@ -187,12 +187,6 @@ def _resample_4d(nii_from_img, nii_to_vox_map, i, order, mode, cval, out_class )
     return i, resampled_image
 
 
-# def _resample_3d(nii_3d, nii_to_vox_map, order, mode, cval, out_class):
-#
-#     nii_resampled_3d = nib_resample_from_to(nii_3d, nii_to_vox_map, order=order, mode=mode, cval=cval,
-#                                             out_class=out_class)
-#     return nii_resampled_3d.get_fdata()
-
 
 def get_main_orientation(cosines: list):
     """ Returns the orientation of the slice axis by looking at the ImageOrientationPatientDICOM JSON tag

--- a/shimmingtoolbox/coils/coordinates.py
+++ b/shimmingtoolbox/coils/coordinates.py
@@ -7,7 +7,7 @@ from nibabel.affines import apply_affine
 import math
 import nibabel as nib
 from nibabel.processing import resample_from_to as nib_resample_from_to
-from joblib import Parallel, delayed, effective_n_jobs
+from joblib import Parallel, delayed
 def generate_meshgrid(dim, affine):
     """
     Generate meshgrid of size dim, with coordinate system defined by affine.
@@ -164,8 +164,7 @@ def resample_from_to(nii_from_img, nii_to_vox_map, order=2, mode='nearest', cval
 
     elif from_img.ndim == 4:
         nt = from_img.shape[3]
-        nb_cpu_used = int(effective_n_jobs())
-        results = Parallel(n_jobs=nb_cpu_used, backend='loky')(
+        results = Parallel(-1, backend='loky')(
             delayed(_resample_4d)( nii_from_img, nii_to_vox_map, it, order, mode, cval, out_class)
             for it in range(nt))
         results.sort(key=lambda x: x[0])

--- a/shimmingtoolbox/coils/coordinates.py
+++ b/shimmingtoolbox/coils/coordinates.py
@@ -5,6 +5,7 @@
 import numpy as np
 from nibabel.affines import apply_affine
 import math
+import multiprocessing as mp
 import nibabel as nib
 from nibabel.processing import resample_from_to as nib_resample_from_to
 

--- a/shimmingtoolbox/coils/coordinates.py
+++ b/shimmingtoolbox/coils/coordinates.py
@@ -165,11 +165,10 @@ def resample_from_to(nii_from_img, nii_to_vox_map, order=2, mode='nearest', cval
     elif from_img.ndim == 4:
         nt = from_img.shape[3]
         results = Parallel(-1, backend='loky')(
-            delayed(_resample_4d)( nii_from_img, nii_to_vox_map, it, order, mode, cval, out_class)
+            delayed(_resample_4d)(it, nii_from_img, nii_to_vox_map, order, mode, cval, out_class)
             for it in range(nt))
-        results.sort(key=lambda x: x[0])
-        resampled_4d = np.array([results[i][1] for i in range(nt)]).transpose(1, 2, 3, 0)
-
+        # results.sort(key=lambda x: x[0])
+        resampled_4d = np.array([results[it] for it in range(nt)]).transpose(1, 2, 3, 0)
         nii_resampled = nib.Nifti1Image(resampled_4d, nii_to_vox_map.affine, header=nii_to_vox_map.header)
 
     else:
@@ -178,13 +177,11 @@ def resample_from_to(nii_from_img, nii_to_vox_map, order=2, mode='nearest', cval
     return nii_resampled
 
 
-def _resample_4d(nii_from_img, nii_to_vox_map, i, order, mode, cval, out_class ):
-
-    nii_from_img_3d = nib.Nifti1Image(nii_from_img.get_fdata()[...,i], nii_from_img.affine, header=nii_from_img.header)
+def _resample_4d(i, nii_from_img, nii_to_vox_map, order, mode, cval, out_class):
+    nii_from_img_3d = nib.Nifti1Image(nii_from_img.get_fdata()[..., i], nii_from_img.affine, header=nii_from_img.header)
     resampled_image = nib_resample_from_to(nii_from_img_3d, nii_to_vox_map, order=order, mode=mode,
-                                            cval=cval, out_class=out_class).get_fdata()
-    return i, resampled_image
-
+                                           cval=cval, out_class=out_class).get_fdata()
+    return resampled_image
 
 
 def get_main_orientation(cosines: list):


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer


## Description
This PR will fix the issue of slow resampling for huge datasets. Indeed,  doing all of the resamplings for big dataset can take up to one minute. This can be solved in the case of 4D images by multiprocessing.  Because in this case, without multiprocessing, we would make the resampling for each 3D array corresponding to the fourth dimension index. So with a multiprocessing loop on the fourth dimension , we can, in theory, divide the time for the resampling divide by the number of cores in the computer. 
However, this is still not perfect because joblib takes some time to start, but it can reduce the time of 4D resampling by a lot of time. (In my case, with a quadcores , it goes from around 20 seconds to 8 seconds, which is a good start, but not the ideal 2.5 seconds).
If, in the future, someone finds a good way to make fast and safe multiprocessing, it could be a good idea to implement it in the resampling, to save more time 

## Linked issues
Addresses #434 
