### PR TITLE
Save figures faster thanks to open cv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "dataclasses",
         "raven",
         "joblib",
+        "opencv-python"
     ],
     extras_require={
         'docs': ["sphinx>=1.6", "sphinx_rtd_theme>=0.2.4", "sphinx-click"],

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -11,6 +11,7 @@ the gradient method in a st_shim CLI with the argument being:
 import click
 import copy
 import json
+import cv2 as cv
 import nibabel as nib
 import numpy as np
 import logging
@@ -1104,9 +1105,19 @@ def _plot_coefs(coil, slices, static_coefs, path_output, coil_number, rt_coefs=N
 
     # Save the figure
     fname_figure = os.path.join(path_output, f"fig_currents_per_slice_group_coil{coil_number}_{coil.name}.png")
-    fig.savefig(fname_figure, bbox_inches='tight')
+    save_figure_as_image(fig, fname_figure)
     logger.debug(f"Saved figure: {fname_figure}")
 
+
+def save_figure_as_image(figure, filename):
+    canvas = FigureCanvas(figure)
+    canvas.draw()
+    # convert canvas to image
+    graph_image = np.array(figure.canvas.get_renderer()._renderer)
+
+    # it still is rgb, convert to opencv's default bgr
+    graph_image = cv.cvtColor(graph_image, cv.COLOR_RGB2BGR)
+    cv.imwrite(filename, graph_image)
 
 def _add_sub_figure(fig, i_plot, n_plots, static_coefs, bounds, min_y, max_y, units, slice_number, rt_coefs=None,
                     pres_probe_min=None, pres_probe_max=None):

--- a/shimmingtoolbox/cli/b0shim.py
+++ b/shimmingtoolbox/cli/b0shim.py
@@ -17,6 +17,7 @@ import numpy as np
 import logging
 import os
 from matplotlib.figure import Figure
+from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 
 from shimmingtoolbox import __dir_config_scanner_constraints__
 from shimmingtoolbox.cli.realtime_shim import gradient_realtime


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer



## Description
This PR allows to save in a faster way figures for the B0 shimming, thanks to opencv library. For a 50 slices and 32 channel coils shimming, and a mac computer of 16 Go RAM,  the saving time went from 16 seconds to around 6. 


