### PR TITLE
Changed the optimization to get faster results

### DIFF
--- a/shimmingtoolbox/masking/mask_utils.py
+++ b/shimmingtoolbox/masking/mask_utils.py
@@ -4,16 +4,15 @@
 import logging
 import nibabel as nib
 import numpy as np
-import os
-from scipy.ndimage import binary_dilation, binary_opening, generate_binary_structure, iterate_structure
 
+from scipy.ndimage import binary_dilation, binary_opening, generate_binary_structure, iterate_structure
 from shimmingtoolbox.coils.coordinates import resample_from_to
 
 logger = logging.getLogger(__name__)
 
 
 def resample_mask(nii_mask_from, nii_target, from_slices=None, dilation_kernel='None', dilation_size=3,
-                  path_output=None):
+                  path_output=None, both_masks=False):
     """
     Select the appropriate slices from ``nii_mask_from`` using ``from_slices`` and resample onto ``nii_target``
 
@@ -26,11 +25,11 @@ def resample_mask(nii_mask_from, nii_target, from_slices=None, dilation_kernel='
         dilation_size (int): Length of a side of the 3d kernel to dilate the mask. Must be odd. For example,
                                          a kernel of size 3 will dilate the mask by 1 pixel.
         path_output (str): Path to output debug artefacts.
+        both_masks (bool): See if we want to return the dilated and non dilated resampled mask
 
     Returns:
         nib.Nifti1Image: Mask resampled with nii_target.shape and nii_target.affine.
     """
-
     mask_from = nii_mask_from.get_fdata()
 
     if from_slices is None:
@@ -42,13 +41,10 @@ def resample_mask(nii_mask_from, nii_target, from_slices=None, dilation_kernel='
 
     # Create nibabel object of sliced mask
     nii_mask = nib.Nifti1Image(sliced_mask.astype(float), nii_mask_from.affine, header=nii_mask_from.header)
-
     # Resample the sliced mask onto nii_target
     nii_mask_target = resample_from_to(nii_mask, nii_target, order=1, mode='grid-constant', cval=0)
-
     # Resample the full mask onto nii_target
     nii_full_mask_target = resample_from_to(nii_mask_from, nii_target, order=0, mode='grid-constant', cval=0)
-
     # TODO: Deal with soft mask
     # Find highest value and stretch to 1
     # Look into dilation of soft mask
@@ -64,7 +60,14 @@ def resample_mask(nii_mask_from, nii_target, from_slices=None, dilation_kernel='
     #     nib.save(nii_mask_target, os.path.join(path_output, f"fig_mask_res{from_slices[0]}.nii.gz"))
     #     nib.save(nii_mask_dilated, os.path.join(path_output, f"fig_mask_dilated{from_slices[0]}.nii.gz"))
 
-    return nii_mask_dilated
+    if both_masks:
+        mask_in_roi = np.logical_and(nii_mask_target.get_fdata(), nii_full_mask_target.get_fdata())
+        nii_mask = nib.Nifti1Image(mask_in_roi, nii_mask_target.affine, header=nii_mask_target.header)
+        return nii_mask, nii_mask_dilated
+
+    else:
+
+        return nii_mask_dilated
 
 
 def dilate_binary_mask(mask, shape='sphere', size=3):

--- a/shimmingtoolbox/masking/mask_utils.py
+++ b/shimmingtoolbox/masking/mask_utils.py
@@ -4,15 +4,15 @@
 import logging
 import nibabel as nib
 import numpy as np
-
 from scipy.ndimage import binary_dilation, binary_opening, generate_binary_structure, iterate_structure
+
 from shimmingtoolbox.coils.coordinates import resample_from_to
 
 logger = logging.getLogger(__name__)
 
 
 def resample_mask(nii_mask_from, nii_target, from_slices=None, dilation_kernel='None', dilation_size=3,
-                  path_output=None, both_masks=False):
+                  path_output=None, return_non_dil_mask=False):
     """
     Select the appropriate slices from ``nii_mask_from`` using ``from_slices`` and resample onto ``nii_target``
 
@@ -25,7 +25,7 @@ def resample_mask(nii_mask_from, nii_target, from_slices=None, dilation_kernel='
         dilation_size (int): Length of a side of the 3d kernel to dilate the mask. Must be odd. For example,
                                          a kernel of size 3 will dilate the mask by 1 pixel.
         path_output (str): Path to output debug artefacts.
-        both_masks (bool): See if we want to return the dilated and non dilated resampled mask
+        return_non_dil_mask (bool): See if we want to return the dilated and non dilated resampled mask
 
     Returns:
         nib.Nifti1Image: Mask resampled with nii_target.shape and nii_target.affine.
@@ -60,10 +60,11 @@ def resample_mask(nii_mask_from, nii_target, from_slices=None, dilation_kernel='
     #     nib.save(nii_mask_target, os.path.join(path_output, f"fig_mask_res{from_slices[0]}.nii.gz"))
     #     nib.save(nii_mask_dilated, os.path.join(path_output, f"fig_mask_dilated{from_slices[0]}.nii.gz"))
 
-    if both_masks:
+    if return_non_dil_mask:
         mask_in_roi = np.logical_and(nii_mask_target.get_fdata(), nii_full_mask_target.get_fdata())
-        nii_mask = nib.Nifti1Image(mask_in_roi, nii_mask_target.affine, header=nii_mask_target.header)
-        return nii_mask, nii_mask_dilated
+        nii_mask_resampled = nib.Nifti1Image(mask_in_roi, nii_mask_target.affine, header=nii_mask_target.header)
+
+        return nii_mask_resampled, nii_mask_dilated
 
     else:
 

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -13,11 +13,6 @@ from shimmingtoolbox.coils.coil import Coil
 ListCoil = List[Coil]
 allowed_opt_criteria = ['mse', 'mae', 'std']
 
-import logging
-
-logger = logging.getLogger(__name__)
-
-
 class LsqOptimizer(Optimizer):
     """ Optimizer object that stores coil profiles and optimizes an unshimmed volume given a mask.
         Use optimize(args) to optimize a given mask. The algorithm uses a least squares solver to find the best shim.

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -13,6 +13,7 @@ from shimmingtoolbox.coils.coil import Coil
 ListCoil = List[Coil]
 allowed_opt_criteria = ['mse', 'mae', 'std']
 
+
 class LsqOptimizer(Optimizer):
     """ Optimizer object that stores coil profiles and optimizes an unshimmed volume given a mask.
         Use optimize(args) to optimize a given mask. The algorithm uses a least squares solver to find the best shim.
@@ -326,10 +327,12 @@ class LsqOptimizer(Optimizer):
                                                        factor=1)
             currents_sp = self._scipy_minimize(currents_0, unshimmed_vec, coil_mat, scipy_constraints,
                                                factor=stability_factor)
+
         if not currents_sp.success:
             raise RuntimeError(f"Optimization failed due to: {currents_sp.message}")
 
         currents = currents_sp.x
+
         return currents
 
 

--- a/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -13,6 +13,10 @@ from shimmingtoolbox.coils.coil import Coil
 ListCoil = List[Coil]
 allowed_opt_criteria = ['mse', 'mae', 'std']
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class LsqOptimizer(Optimizer):
     """ Optimizer object that stores coil profiles and optimizes an unshimmed volume given a mask.
@@ -58,8 +62,6 @@ class LsqOptimizer(Optimizer):
         else:
             raise ValueError("Optimization criteria not supported")
 
-        self.b = None
-
     @property
     def initial_guess_method(self):
         return self._initial_guess_method
@@ -90,15 +92,42 @@ class LsqOptimizer(Optimizer):
                             avoid positive directional linesearch
 
         Returns:
-            float: Residuals for least squares optimization 
+            float: Residuals for least squares optimization
         """
 
         # MAE regularized to minimize currents
-        return np.mean(np.abs(unshimmed_vec + coil_mat @ coef)) / factor + \
-               (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
+        return np.mean(np.abs(unshimmed_vec + coil_mat @ coef)) / factor + np.abs(coef).dot(self.reg_vector)
 
-    def _residuals_mse(self, coef, unshimmed_vec, coil_mat, factor):
+    def _residuals_mse(self, coef, a, b, c):
         """ Objective function to minimize the mean squared error (MSE)
+
+        Args:
+            coef (numpy.ndarray): 1D array of channel coefficients
+            a (numpy.ndarray): 2D array used for the optimization
+            b (numpy.ndarray): 1D flattened array used for the optimization
+            c (float) : Float used for the optimization
+
+        Returns:
+            float: Residuals for least squares optimization
+        """
+        # The first version was :
+        # np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False))**2) / factor + \ (
+        # self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
+        # For the second version we switched np.sum(coil_mat*coef,axis=1,keepdims=False) by coil_mat@coef
+        # which is way faster Then for a vector, mean(x**2) is equivalent to x.dot( x)/n
+        # it's faster to do this operation instead of a np.mean Finally np.abs(coef).dot(self.reg_vector) is
+        # equivalent and faster to self.reg_factor*np.mean(np.abs(coef) / self.reg_factor_channel) For the
+        # mathematical demonstration see : https://github.com/shimming-toolbox/shimming-toolbox/pull/432
+        # This gave us the following expression for the residuals mse :
+        # shimmed_vec = unshimmed_vec + coil_mat @ coef
+        # mse = (shimmed_vec).dot(shimmed_vec) / len(unshimmed_vec) / factor + np.abs(coef).dot(self.reg_vector)
+        # The new expression of residuals mse, is the fastest way to the optimization because it allows us to not
+        # calculate everytime some long processing operation, the term of a, b and c were calculated in scipy_minimize
+
+        return a @ coef @ coef + b @ coef + c
+
+    def _initial_guess_mse(self, coef, unshimmed_vec, coil_mat, factor):
+        """ Objective function to find the initial guess for the mean squared error (MSE) optimization
 
         Args:
             coef (numpy.ndarray): 1D array of channel coefficients
@@ -109,17 +138,8 @@ class LsqOptimizer(Optimizer):
                             avoid positive directional linesearch
 
         Returns:
-            float: Residuals for least squares optimization 
+            float: Residuals for least squares optimization
         """
-        # Old one was :
-        # np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False))**2) / factor + \ (
-        # self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
-        # And switch np.sum(coil_mat*coef,axis=1,keepdims=False) by coil_mat@coef which is way faster
-        # Then for a vector , mean(x**2) is equivalent to x.dot( x)/n
-        # it's faster to do this operation instead of a np.mean Finally np.abs(coef).dot(self.reg_vector) is
-        # equivalent and faster to self.reg_factor*np.mean(np.abs(coef) / self.reg_factor_channel) For the
-        # mathematical demonstration see : https://github.com/shimming-toolbox/shimming-toolbox/pull/432 
-        # MSE regularized to minimize currents
         shimmed_vec = unshimmed_vec + coil_mat @ coef
         return (shimmed_vec).dot(shimmed_vec) / len(unshimmed_vec) / factor + np.abs(coef).dot(self.reg_vector)
 
@@ -135,12 +155,32 @@ class LsqOptimizer(Optimizer):
                             avoid positive directional linesearch
 
         Returns:
-            float: Residuals for least squares optimization 
+            float: Residuals for least squares optimization
         """
 
         # STD regularized to minimize currents
-        return np.std(unshimmed_vec + coil_mat @ coef) / factor + \
-               (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
+        return np.std(unshimmed_vec + coil_mat @ coef) / factor + np.abs(coef).dot(self.reg_vector)
+
+    def _residuals_mse_jacobian(self, coef, a, b, c):
+        """ Jacobian of the function that we want to minimize
+        The function to minimize is :
+        np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False)) ** 2) / factor+\
+           (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
+        The first Version of the jacobian was :
+        self.b * (unshimmed_vec + coil_mat @ coef) @ coil_mat + np.sign(coef) * self.reg_vector where self.b was equal
+        to 2/(len(unshimmed_vec * factor)
+        This jacobian come from the new version of the residuals mse that was implemented with the PR#451
+
+        Args:
+            coef (numpy.ndarray): 1D array of channel coefficients
+            a (numpy.ndarray): 2D array using for the optimization
+            b (numpy.ndarray): 1D flattened array used for the optimization
+            c (float) : Float used for the optimization but not used here
+
+        Returns:
+            jacobian (numpy.ndarray) : 1D array of the gradient of the mse function to minimize
+        """
+        return 2 * a @ coef + b
 
     def _define_scipy_constraints(self):
         return self._define_scipy_coef_sum_max_constraint()
@@ -165,13 +205,26 @@ class LsqOptimizer(Optimizer):
         return constraints
 
     def _scipy_minimize(self, currents_0, unshimmed_vec, coil_mat, scipy_constraints, factor):
-        currents_sp = opt.minimize(self._criteria_func, currents_0,
-                                   args=(unshimmed_vec, coil_mat, factor),
-                                   method='SLSQP',
-                                   bounds=self.merged_bounds,
-                                   constraints=tuple(scipy_constraints),
-                                   jac=self._jacobian_func,
-                                   options={'maxiter': 1000})
+        if self.opt_criteria == 'mse':
+            inv_factor = 1 / (len(unshimmed_vec) * factor)
+            a = (coil_mat.T @ coil_mat) * inv_factor + np.diag(self.reg_vector)
+            b = 2 * inv_factor * (unshimmed_vec @ coil_mat)
+            c = inv_factor * (unshimmed_vec @ unshimmed_vec)
+            currents_sp = opt.minimize(self._criteria_func, currents_0,
+                                       args=(a, b, c),
+                                       method='SLSQP',
+                                       bounds=self.merged_bounds,
+                                       constraints=tuple(scipy_constraints),
+                                       jac=self._jacobian_func,
+                                       options={'maxiter': 1000})
+        else:
+            currents_sp = opt.minimize(self._criteria_func, currents_0,
+                                       args=(unshimmed_vec, coil_mat, factor),
+                                       method='SLSQP',
+                                       bounds=self.merged_bounds,
+                                       constraints=tuple(scipy_constraints),
+                                       jac=self._jacobian_func,
+                                       options={'maxiter': 1000})
 
         return currents_sp
 
@@ -226,24 +279,6 @@ class LsqOptimizer(Optimizer):
 
         return current_0
 
-    def _residuals_mse_jacobian(self, coef, unshimmed_vec, coil_mat, factor):
-        """ Jacobian of the function that we want to minimize
-        The function to minimize is :
-        np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False)) ** 2) / factor+\
-           (self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
-
-        Args:
-            coef (numpy.ndarray): 1D array of channel coefficients
-            unshimmed_vec (numpy.ndarray): 1D flattened array (point) of the masked unshimmed map
-            coil_mat (numpy.ndarray): 2D flattened array (point, channel) of masked coils
-                                      (axis 0 must align with unshimmed_vec)
-            factor (float): unused but necessary to call the function in scipy.optimize.minimize
-
-        Returns:
-            jacobian (numpy.ndarray) : 1D array of the gradient of the mse function to minimize
-        """
-        return self.b * (unshimmed_vec + coil_mat @ coef) @ coil_mat + np.sign(coef) * self.reg_vector
-
     def optimize(self, mask):
         """
         Optimize unshimmed volume by varying current to each channel
@@ -258,17 +293,16 @@ class LsqOptimizer(Optimizer):
 
         # Check for sizing errors
         self._check_sizing(mask)
-
         # Define coil profiles
         n_channels = self.merged_coils.shape[3]
-
         mask_vec = mask.reshape((-1,))
-
-        # Reshape coil profile: X, Y, Z, N --> [mask.shape], N
-        #   --> N, [mask.shape] --> N, mask.size --> mask.size, N --> masked points, N
-        coil_mat = np.reshape(np.transpose(self.merged_coils, axes=(3, 0, 1, 2)),
-                              (n_channels, -1)).T[mask_vec != 0, :]  # masked points x N
-        unshimmed_vec = np.reshape(self.unshimmed, (-1,))[mask_vec != 0]  # mV'
+        # # Reshape coil profile: X, Y, Z, N --> [mask.shape], N
+        # #   --> N, [mask.shape] --> N, mask.size --> mask.size, N --> masked points, N
+        merged_coils_reshaped = np.reshape(np.transpose(self.merged_coils, axes=(3, 0, 1, 2)),
+                                           (n_channels, -1))
+        masked_points_indices = np.where(mask_vec != 0)
+        coil_mat = merged_coils_reshaped[:, masked_points_indices[0]].T  # masked points x N
+        unshimmed_vec = np.reshape(self.unshimmed, (-1,))[masked_points_indices[0]]  # mV'
         scipy_constraints = self._define_scipy_constraints()
 
         # Set up output currents
@@ -287,19 +321,20 @@ class LsqOptimizer(Optimizer):
             # scipy minimize expects the return value of the residual function to be ~10^0 to 10^1
             # --> aiming for 1 then optimizing will lower that. We are using an initial guess of 0s so that the
             # regularization on the currents has no affect on the output stability factor.
-            stability_factor = self._criteria_func(self._initial_guess_zeros(), unshimmed_vec, np.zeros_like(coil_mat),
-                                                   factor=1)
             if self.opt_criteria == 'mse':
-                # This factor is used to calculate the Jacobian of the mse function
-                self.b = (2 / (unshimmed_vec.size * stability_factor))
+                stability_factor = self._initial_guess_mse(self._initial_guess_zeros(), unshimmed_vec,
+                                                           np.zeros_like(coil_mat),
+                                                           factor=1)
+            else:
+                stability_factor = self._criteria_func(self._initial_guess_zeros(), unshimmed_vec,
+                                                       np.zeros_like(coil_mat),
+                                                       factor=1)
             currents_sp = self._scipy_minimize(currents_0, unshimmed_vec, coil_mat, scipy_constraints,
                                                factor=stability_factor)
-
         if not currents_sp.success:
             raise RuntimeError(f"Optimization failed due to: {currents_sp.message}")
 
         currents = currents_sp.x
-
         return currents
 
 
@@ -419,11 +454,23 @@ class PmuLsqOptimizer(LsqOptimizer):
 
     def _scipy_minimize(self, currents_0, unshimmed_vec, coil_mat, scipy_constraints, factor):
         """Redefined from super() since normal bounds are now constraints"""
+        if self.opt_criteria == 'mse':
+            inv_factor = 1 / (len(unshimmed_vec) * factor)
+            a = (coil_mat.T @ coil_mat) * inv_factor + np.diag(self.reg_vector)
+            b = 2 * inv_factor * (unshimmed_vec @ coil_mat)
+            c = inv_factor * (unshimmed_vec @ unshimmed_vec)
+            currents_sp = opt.minimize(self._criteria_func, currents_0,
+                                       args=(a, b, c),
+                                       method='SLSQP',
+                                       constraints=tuple(scipy_constraints),
+                                       jac=self._jacobian_func,
+                                       options={'maxiter': 500})
+        else:
+            currents_sp = opt.minimize(self._criteria_func, currents_0,
+                                       args=(unshimmed_vec, coil_mat, factor),
+                                       method='SLSQP',
+                                       constraints=tuple(scipy_constraints),
+                                       jac=self._jacobian_func,
+                                       options={'maxiter': 500})
 
-        currents_sp = opt.minimize(self._criteria_func, currents_0,
-                                   args=(unshimmed_vec, coil_mat, factor),
-                                   method='SLSQP',
-                                   constraints=tuple(scipy_constraints),
-                                   jac=self._jacobian_func,
-                                   options={'maxiter': 500})
         return currents_sp

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -303,11 +303,12 @@ class ShimSequencer(Sequencer):
 
     def get_resampled_masks(self):
         """
-        This function resample the mask on the differents elements needed for the optimization and the evaluation
+        This function resample the mask on the different elements needed for the optimization and the evaluation
+
         Returns:
             (tuple) : tuple containing:
-                * nib.Nifti1Image: Mask resampled  and dilated on the fieldmap for the optimization
-                * nib.Nifti1Image: Mask resampled on the original fieldmap.
+            * nib.Nifti1Image: Mask resampled  and dilated on the fieldmap for the optimization
+            * nib.Nifti1Image: Mask resampled on the original fieldmap.
         """
 
         nii_mask_anat = self.nii_mask_anat

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -4,6 +4,7 @@
 import copy
 import math
 import numpy as np
+from joblib import delayed, Parallel
 from typing import List
 from sklearn.linear_model import LinearRegression
 import nibabel as nib
@@ -98,10 +99,11 @@ class Sequencer(object):
         dilation_kernel = self.mask_dilation_kernel
         dilation_kernel_size = self.mask_dilation_kernel_size
         path_output = self.path_output
-        results = []
-        for i in range(n_shims):
-            result = self.opt(i, optimizer, nii_mask_anat, slices, dilation_kernel, dilation_kernel_size, path_output)
-            results.append(result)
+        
+        results = Parallel(-1, backend='loky')(
+            delayed(self.opt)(i, optimizer, nii_mask_anat, slices, dilation_kernel, dilation_kernel_size,
+                              path_output)
+            for i in range(n_shims))
 
         return np.array(results)
 
@@ -1091,12 +1093,11 @@ class RealTimeSequencer(Sequencer):
         dilation_kernel_size = self.mask_dilation_kernel_size
         path_output = self.path_output
         bounds = self.bounds
-        results = []
-        for i in range(n_shims):
-            result = self.opt_riro(i, optimizer, nii_mask_anat, slices, dilation_kernel, dilation_kernel_size,
-                                   path_output,
-                                   bounds)
-            results.append(result)
+        
+        results = Parallel(-1, backend='loky')(
+            delayed(self.opt_riro)(i, optimizer, nii_mask_anat, slices, dilation_kernel, dilation_kernel_size,
+                              path_output, bounds)
+            for i in range(n_shims))
 
         return np.array(results)
 


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer



## Description
This PR is made to make the optimization faster thanks to joblib multiprocessing. On a Mac computer 10.15 with a RAM of 16 Go, and 8 hearts, and a dataset of :
coil ( 32 channels) ;
anatomic image ([174,174,50] );
fieldmap([112,112,70]);
mask ([112,112,70]).
The optimization went from around 23 seconds to 9 seconds. And is now taking 15 % of the total time of the B0 shimming. It would be interesting in the future to have better usages of mask and resampling, and to make the figures for the user in a faster way

