### PR TITLE
Add output B1 shim weights as a machine friendly text file

### DIFF
--- a/shimmingtoolbox/cli/b1shim.py
+++ b/shimmingtoolbox/cli/b1shim.py
@@ -38,9 +38,16 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               help="Factor (=> 1) to which the shimmed max local SAR can exceed the phase-only shimming max local SAR."
                    "Values between 1 and 1.5 should work with Siemens scanners. High factors allow more shimming "
                    "liberty but are more likely to result in SAR excess at the scanner.")
+@click.option('--output-file-format', 'o_format',
+              type=click.Choice(['human', 'machine']),
+              default='human',
+              show_default=True, help="Specifies how the output text file will be formatted. Either 'human' readable "
+                                      "where more information will be displayed or a more crude 'machine' version to be"
+                                      " easily copy/pasted. 'machine' will output in this format: mag1 phase1 mag2 "
+                                      "phase2...")
 @click.option('-o', '--output', 'path_output', type=click.Path(), default=os.path.join(os.curdir, 'b1_shim_results'),
               show_default=True, help="Output directory for shim weights, B1+ maps and figures.")
-def b1shim_cli(fname_b1, fname_mask, algorithm, target, fname_vop, sar_factor, path_output):
+def b1shim_cli(fname_b1, fname_mask, algorithm, target, fname_vop, sar_factor, o_format, path_output):
     """ Perform static B1+ shimming over the volume defined by the mask. This function will generate a text file
     containing shim weights for each transmit element.
     """
@@ -82,10 +89,15 @@ def b1shim_cli(fname_b1, fname_mask, algorithm, target, fname_vop, sar_factor, p
     # Write to a text file
     fname_output_weights = os.path.join(path_output, 'b1_shim_weights.txt')
     with open(fname_output_weights, 'w') as file_rf_shim_weights:
-        file_rf_shim_weights.write(f'Channel\tmag\tphase (\u00b0)\n')
-        for i_channel in range(len(shim_weights)):
-            file_rf_shim_weights.write(f'Tx{i_channel + 1}\t{np.abs(shim_weights[i_channel]):.3f}\t'
-                                       f'{np.rad2deg(np.angle(shim_weights[i_channel])):.3f}\n')
+        if o_format == 'human':
+            file_rf_shim_weights.write(f'Channel\tmag\tphase (\u00b0)\n')
+            for i_channel in range(len(shim_weights)):
+                file_rf_shim_weights.write(f'Tx{i_channel + 1}\t{np.abs(shim_weights[i_channel]):.3f}\t'
+                                           f'{np.rad2deg(np.angle(shim_weights[i_channel])):.3f}\n')
+        else:  # 'machine'
+            for i_channel in range(len(shim_weights)):
+                file_rf_shim_weights.write(f"{np.abs(shim_weights[i_channel]):.3f} "
+                                           f"{np.rad2deg(np.angle(shim_weights[i_channel])):.3f} ")
 
     # Plot B1+ shimming results
     b1_shimmed = montage(combine_maps(b1_map, shim_weights))  # B1+ shimming result

--- a/test/cli/test_cli_b1shim.py
+++ b/test/cli/test_cli_b1shim.py
@@ -77,8 +77,7 @@ def test_b1shim_output_machine_cli():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         path_output = os.path.join(tmp, 'b1_shim_results')
         # Run the CLI
-        result = CliRunner().invoke(b1shim_cli, ['--b1', fname_b1_nii_axial, '--output-file-format', 'machine',
-                                                 '--output', path_output],
+        result = CliRunner().invoke(b1shim_cli, ['--b1', fname_b1_nii_axial, '--output', path_output],
                                     catch_exceptions=True)
         assert len(os.listdir(path_output)) != 0
         assert result.exit_code == 0

--- a/test/cli/test_cli_b1shim.py
+++ b/test/cli/test_cli_b1shim.py
@@ -70,3 +70,19 @@ def test_b1shim_cli_sagittal():
                                                  '--output', path_output], catch_exceptions=True)
         assert len(os.listdir(path_output)) != 0
         assert result.exit_code == 0
+
+
+def test_b1shim_output_machine_cli():
+    """Test CLI for performing RF shimming with machine output format"""
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        path_output = os.path.join(tmp, 'b1_shim_results')
+        # Run the CLI
+        result = CliRunner().invoke(b1shim_cli, ['--b1', fname_b1_nii_axial, '--output-file-format', 'machine',
+                                                 '--output', path_output],
+                                    catch_exceptions=True)
+        assert len(os.listdir(path_output)) != 0
+        assert result.exit_code == 0
+        with open(os.path.join(path_output, 'b1_shim_weights.txt'), 'r') as f:
+            txt = f.readline()
+
+        assert txt[:12] == "0.501 0.000 "


### PR DESCRIPTION
## Description
This PR adds a second shim weight text file to the output of b1 shimming that is formatted to be more easily copy/pasted on the scanner. There is now a machine friendly text file: "b1_shim_weights.txt" and a human readable text file: "b1_shim_weights_hrd.txt"

## Linked issues
Fixes #455 