### PR TITLE
Shimmed field map plotting for real time shimming by averaging over time dimension

### DIFF
--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -1523,7 +1523,6 @@ class RealTimeSequencer(Sequencer):
         fig.subplots_adjust(top=0.85)
 
         # Save
-        print("---------------------------------------------------------------- \n SAVING")
         fname_figure = os.path.join(self.path_output, 'fig_shimmed_vs_unshimmed.png')
         fig.savefig(fname_figure, bbox_inches='tight')
 

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -1479,8 +1479,7 @@ class RealTimeSequencer(Sequencer):
         mt_unshimmed = montage(unshimmed_avg)
         mt_unshimmed_masked = montage(unshimmed_avg * mask)
         mt_shimmed_masked = montage(shimmed_masked_avg)
-        print("----------------------------------------------------------------")
-        print(mt_unshimmed.shape, mt_shimmed_masked.shape, mt_shimmed_masked.shape)
+        
         metric_unshimmed_std = calculate_metric_within_mask(unshimmed_avg, mask, metric='std')
         metric_shimmed_std = calculate_metric_within_mask(shimmed_masked_avg, mask, metric='std')
         metric_unshimmed_mean = calculate_metric_within_mask(unshimmed_avg, mask, metric='mean')

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -1248,10 +1248,11 @@ class RealTimeSequencer(Sequencer):
             i_shim += 1
             if i_shim >= n_shim - 1:
                 break
-
+        
         if logger.level <= getattr(logging, 'DEBUG') and self.path_output is not None:
             # Plot before vs after shimming averaged on PMU signal and time
-            self.plot_full_mask(unshimmed, masked_shim_static_riro, mask_full_binary)
+            shimmed_mask = np.divide(np.sum(np.mean(masked_shim_static_riro, axis=3), axis=3), np.sum(mask_fmap_cs, axis=3), where=mask_full_binary.astype(bool))
+            self.plot_full_mask(np.mean(unshimmed, axis=3), shimmed_mask, mask_full_binary)
             
             self.plot_static_riro(masked_unshimmed, masked_shim_static, masked_shim_static_riro, unshimmed,
                                   shimmed_static,
@@ -1473,19 +1474,17 @@ class RealTimeSequencer(Sequencer):
             mask (np.ndarray): Binary mask in the fieldmap space
         """
         # Plot
-        unshimmed_avg = np.mean(unshimmed, axis=3)
-        shimmed_masked_avg = np.mean(shimmed_masked, axis=(3, 4))
      
-        mt_unshimmed = montage(unshimmed_avg)
-        mt_unshimmed_masked = montage(unshimmed_avg * mask)
-        mt_shimmed_masked = montage(shimmed_masked_avg)
+        mt_unshimmed = montage(unshimmed)
+        mt_unshimmed_masked = montage(unshimmed * mask)
+        mt_shimmed_masked = montage(shimmed_masked)
         
-        metric_unshimmed_std = calculate_metric_within_mask(unshimmed_avg, mask, metric='std')
-        metric_shimmed_std = calculate_metric_within_mask(shimmed_masked_avg, mask, metric='std')
-        metric_unshimmed_mean = calculate_metric_within_mask(unshimmed_avg, mask, metric='mean')
-        metric_shimmed_mean = calculate_metric_within_mask(shimmed_masked_avg, mask, metric='mean')
-        metric_unshimmed_absmean = calculate_metric_within_mask(np.abs(unshimmed_avg), mask, metric='mean')
-        metric_shimmed_absmean = calculate_metric_within_mask(np.abs(shimmed_masked_avg), mask, metric='mean')
+        metric_unshimmed_std = calculate_metric_within_mask(unshimmed, mask, metric='std')
+        metric_shimmed_std = calculate_metric_within_mask(shimmed_masked, mask, metric='std')
+        metric_unshimmed_mean = calculate_metric_within_mask(unshimmed, mask, metric='mean')
+        metric_shimmed_mean = calculate_metric_within_mask(shimmed_masked, mask, metric='mean')
+        metric_unshimmed_absmean = calculate_metric_within_mask(np.abs(unshimmed), mask, metric='mean')
+        metric_shimmed_absmean = calculate_metric_within_mask(np.abs(shimmed_masked), mask, metric='mean')
 
         min_value = min(mt_unshimmed_masked.min(), mt_shimmed_masked.min())
         max_value = max(mt_unshimmed_masked.max(), mt_shimmed_masked.max())

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -1249,10 +1249,10 @@ class RealTimeSequencer(Sequencer):
             if i_shim >= n_shim - 1:
                 break
 
-        # Plot before vs after shimming averaged on PMU signal and time
-        self.plot_full_mask(unshimmed, masked_shim_static_riro, mask_full_binary)
-
         if logger.level <= getattr(logging, 'DEBUG') and self.path_output is not None:
+            # Plot before vs after shimming averaged on PMU signal and time
+            self.plot_full_mask(unshimmed, masked_shim_static_riro, mask_full_binary)
+            
             self.plot_static_riro(masked_unshimmed, masked_shim_static, masked_shim_static_riro, unshimmed,
                                   shimmed_static,
                                   shimmed_static_riro, i_slice=i_slice, i_shim=i_shim, i_t=i_t)

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -1248,16 +1248,16 @@ class RealTimeSequencer(Sequencer):
             i_shim += 1
             if i_shim >= n_shim - 1:
                 break
+            
+        # Plot before vs after shimming averaged on time
+        shimmed_mask_avg = np.zeros(mask_full_binary.shape)
+        np.divide(np.sum(np.mean(masked_shim_static_riro, axis=3), axis=3), np.sum(mask_fmap_cs, axis=3), where=mask_full_binary.astype(bool), out=shimmed_mask_avg)
+        self.plot_full_mask(np.mean(unshimmed, axis=3), shimmed_mask_avg, mask_full_binary)
         
-        if logger.level <= getattr(logging, 'DEBUG') and self.path_output is not None:
-            # Plot before vs after shimming averaged on time
-            shimmed_mask_avg = np.zeros(mask_full_binary.shape)
-            np.divide(np.sum(np.mean(masked_shim_static_riro, axis=3), axis=3), np.sum(mask_fmap_cs, axis=3), where=mask_full_binary.astype(bool), out=shimmed_mask_avg)
-            self.plot_full_mask(np.mean(unshimmed, axis=3), shimmed_mask_avg, mask_full_binary)
-            
-            # Plot STD over time before and after shimming
-            self.plot_full_time_std(unshimmed, masked_shim_static_riro, mask_fmap_cs, mask_full_binary)
-            
+        # Plot STD over time before and after shimming
+        self.plot_full_time_std(unshimmed, masked_shim_static_riro, mask_fmap_cs, mask_full_binary)
+        
+        if logger.level <= getattr(logging, 'DEBUG') and self.path_output is not None:            
             self.plot_static_riro(masked_unshimmed, masked_shim_static, masked_shim_static_riro, unshimmed,
                                   shimmed_static,
                                   shimmed_static_riro, i_slice=i_slice, i_shim=i_shim, i_t=i_t)

--- a/shimmingtoolbox/shim/sequencer.py
+++ b/shimmingtoolbox/shim/sequencer.py
@@ -1239,25 +1239,25 @@ class RealTimeSequencer(Sequencer):
         shim_trace_static_riro = np.array(shim_trace_static_riro).reshape(n_shim, nt)
         shim_trace_riro = np.array(shim_trace_riro).reshape(n_shim, nt)
         unshimmed_trace = np.array(unshimmed_trace).reshape(n_shim, nt)
-
-        # plot results
-        i_slice = 0
-        i_shim = 0
-        i_t = 0
-        while np.all(masked_unshimmed[..., i_slice, i_t, i_shim] == np.zeros(masked_unshimmed.shape[:2])):
-            i_shim += 1
-            if i_shim >= n_shim - 1:
-                break
             
-        # Plot before vs after shimming averaged on time
-        shimmed_mask_avg = np.zeros(mask_full_binary.shape)
-        np.divide(np.sum(np.mean(masked_shim_static_riro, axis=3), axis=3), np.sum(mask_fmap_cs, axis=3), where=mask_full_binary.astype(bool), out=shimmed_mask_avg)
-        self.plot_full_mask(np.mean(unshimmed, axis=3), shimmed_mask_avg, mask_full_binary)
-        
-        # Plot STD over time before and after shimming
-        self.plot_full_time_std(unshimmed, masked_shim_static_riro, mask_fmap_cs, mask_full_binary)
+        if self.path_output is not None:    
+            # Plot before vs after shimming averaged on time
+            shimmed_mask_avg = np.zeros(mask_full_binary.shape)
+            np.divide(np.sum(np.mean(masked_shim_static_riro, axis=3), axis=3), np.sum(mask_fmap_cs, axis=3), where=mask_full_binary.astype(bool), out=shimmed_mask_avg)
+            self.plot_full_mask(np.mean(unshimmed, axis=3), shimmed_mask_avg, mask_full_binary)
+            
+            # Plot STD over time before and after shimming
+            self.plot_full_time_std(unshimmed, masked_shim_static_riro, mask_fmap_cs, mask_full_binary)
         
         if logger.level <= getattr(logging, 'DEBUG') and self.path_output is not None:            
+            # plot results
+            i_slice = 0
+            i_shim = 0
+            i_t = 0
+            while np.all(masked_unshimmed[..., i_slice, i_t, i_shim] == np.zeros(masked_unshimmed.shape[:2])):
+                i_shim += 1
+                if i_shim >= n_shim - 1:
+                    break
             self.plot_static_riro(masked_unshimmed, masked_shim_static, masked_shim_static_riro, unshimmed,
                                   shimmed_static,
                                   shimmed_static_riro, i_slice=i_slice, i_shim=i_shim, i_t=i_t)


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've applied the relevant labels to this PR
- [ ] I've added relevant tests for my contribution
- [ ] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->

- Correction of an error for `shimmingtoolbox/shim/sequencer.py at line 931` where the return order was opposite to what was expected in the code

- Adaptation of ShimSequencer.plot_full_mask() for RealTimeSequencer. The shimmed field map was averaged over the fourth dimension (time) and fifth (not sure what it is @po09i). Here is the current state result from a subject using coil + first order real time shimming (results seem too good):

<img width="770" alt="image" src="https://github.com/shimming-toolbox/shimming-toolbox/assets/55560824/4a590b27-7771-44c4-924e-074226dfdd29">

