### PR TITLE
Add mp2rage, and more field maps to dcm2bids config file and update to version >= 2.1.7

### DIFF
--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -101,6 +101,35 @@
             }
         },
         {
+            "dataType": "anat",
+            "modalityLabel": "mp2rage_inv1",
+            "criteria": {
+                "SequenceName": "*tfl3d1_16ns",
+                "ProtocolName": "*mp2rage*",
+                "SeriesDescription": "*_INV1",
+                "ImageType": ["*", "*", "M", "*", "NORM"]
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "mp2rage_inv2",
+            "criteria": {
+                "SequenceName": "*tfl3d1_16ns",
+                "ProtocolName": "*mp2rage*",
+                "SeriesDescription": "*_INV2",
+                "ImageType": ["*", "*", "M", "*", "NORM"]
+            }
+        },
+        {
+            "dataType": "anat",
+            "modalityLabel": "mp2rage_uni",
+            "criteria": {
+                "SequenceName": "*tfl3d1_16ns",
+                "ProtocolName": "*mp2rage*",
+                "ImageType": ["*", "*", "M", "*", "UNI"]
+            }
+        },
+        {
             "dataType": "fmap",
             "modalityLabel": "magnitude1",
             "criteria": {

--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -102,7 +102,7 @@
         },
         {
             "dataType": "anat",
-            "modalityLabel": "mp2rage_inv1",
+            "modalityLabel": "inv-1_MP2RAGE",
             "criteria": {
                 "SequenceName": "*tfl3d1_16ns",
                 "ProtocolName": "*mp2rage*",
@@ -112,7 +112,7 @@
         },
         {
             "dataType": "anat",
-            "modalityLabel": "mp2rage_inv2",
+            "modalityLabel": "inv-2_MP2RAGE",
             "criteria": {
                 "SequenceName": "*tfl3d1_16ns",
                 "ProtocolName": "*mp2rage*",
@@ -122,7 +122,7 @@
         },
         {
             "dataType": "anat",
-            "modalityLabel": "mp2rage_uni",
+            "modalityLabel": "UNIT1",
             "criteria": {
                 "SequenceName": "*tfl3d1_16ns",
                 "ProtocolName": "*mp2rage*",

--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -169,7 +169,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude1",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "1"
             }
@@ -178,7 +178,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude2",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "2"
             }
@@ -187,7 +187,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude3",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "3"
             }
@@ -196,7 +196,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude4",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "4"
             }
@@ -205,7 +205,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude5",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "5"
             }
@@ -214,7 +214,7 @@
             "dataType": "fmap",
             "modalityLabel": "magnitude6",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
                 "EchoNumber": "6"
             }
@@ -223,7 +223,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase1",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "1"
             }
@@ -232,7 +232,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase2",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "2"
             }
@@ -241,7 +241,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase3",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "3"
             }
@@ -250,7 +250,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase4",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "4"
             }
@@ -259,7 +259,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase5",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "5"
             }
@@ -268,7 +268,7 @@
             "dataType": "fmap",
             "modalityLabel": "phase6",
             "criteria": {
-                "SequenceName": "*fl2d[2-6]",
+                "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
                 "EchoNumber": "6"
             }

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(exclude=["docs"]),
     install_requires=[
         "click",
-        "dcm2bids==2.1.4",
+        "dcm2bids>=2.1.7",
         'importlib-metadata ~= 4.0 ; python_version < "3.8"',
         "numpy>=1.21",
         "phantominator~=0.6.4",

--- a/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimmingtoolbox/dicom_to_nifti.py
@@ -46,22 +46,10 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
     # Create bids structure for data
     run_subprocess(['dcm2bids_scaffold', '-o', path_nifti])
 
-    # # Copy original dicom files into nifti_path/sourcedata
+    # Copy original dicom files into nifti_path/sourcedata
     copy_tree(path_dicom, os.path.join(path_nifti, 'sourcedata'))
-    #
-    # # Call the dcm2bids_helper
-    run_subprocess(['dcm2bids_helper', '-d', path_dicom, '-o', path_nifti])
-    #
-    # Check if the helper folder has been created
-    path_helper = os.path.join(path_nifti, 'tmp_dcm2bids', 'helper')
-    if not os.path.isdir(path_helper):
-        raise ValueError('dcm2bids_helper could not create directory helper')
 
-    # Make sure there is data in nifti_path / tmp_dcm2bids / helper
-    helper_file_list = os.listdir(path_helper)
-    if not helper_file_list:
-        raise ValueError('No data to process')
-
+    # Run dcm2bids
     run_subprocess(['dcm2bids', '-d', path_dicom, '-o', path_nifti, '-p', subject_id, '-c', fname_config_dcm2bids])
 
     # In the special case where a phasediff should be created but the filename is phase instead. Find the file and


### PR DESCRIPTION
## Description
Add MP2RAGE to the automatically detected acquisitions in the dcm2bids config file. Also support more field maps. This PR also updates the dcm2bids version to be >= 2.1.7. This was required since the patch allowing to use dcm2bids on LAN was introduced in this [PR](https://github.com/UNFmontreal/Dcm2Bids/pull/154) which is on version 2.1.7.
