### PR TITLE
Update dcm2bids to version 3.0.1

### DIFF
--- a/config/dcm2bids.json
+++ b/config/dcm2bids.json
@@ -2,45 +2,45 @@
     "searchMethod": "fnmatch",
     "descriptions": [
         {
-            "dataType": "anat",
-            "modalityLabel": "T1w",
+            "datatype": "anat",
+            "suffix": "T1w",
             "criteria": {
                 "SeriesDescription": "*T1W_3D*"
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "T2w",
+            "datatype": "anat",
+            "suffix": "T2w",
             "criteria": {
                 "SidecarFilename": "007*",
                 "EchoTime": 0.1
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "PD",
+            "datatype": "anat",
+            "suffix": "PD",
             "criteria": {
                 "SeriesDescription": "*TSE*",
                 "EchoTime": 0.008
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "FLAIR",
+            "datatype": "anat",
+            "suffix": "FLAIR",
             "criteria": {
                 "SeriesDescription": "*FLAIR*"
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "SWI",
+            "datatype": "anat",
+            "suffix": "SWI",
             "criteria": {
                 "SeriesDescription": "*SWI*"
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "unshimmed_e1",
+            "datatype": "anat",
+            "suffix": "unshimmed_e1",
             "criteria": {
                 "SeriesDescription": "*gre*realtime*",
                 "ImageType": ["*", "*", "M", "*"],
@@ -48,8 +48,8 @@
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "unshimmed_e2",
+            "datatype": "anat",
+            "suffix": "unshimmed_e2",
             "criteria": {
                 "SeriesDescription": "*gre*realtime*",
                 "ImageType": ["*", "*", "M", "*"],
@@ -57,8 +57,8 @@
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "unshimmed_e3",
+            "datatype": "anat",
+            "suffix": "unshimmed_e3",
             "criteria": {
                 "SeriesDescription": "*gre*realtime*",
                 "ImageType": ["*", "*", "M", "*"],
@@ -66,8 +66,8 @@
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "unshimmed_phase_e1",
+            "datatype": "anat",
+            "suffix": "unshimmed_phase_e1",
             "criteria": {
                 "SeriesDescription": "*gre*realtime*",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -75,8 +75,8 @@
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "unshimmed_phase_e2",
+            "datatype": "anat",
+            "suffix": "unshimmed_phase_e2",
             "criteria": {
                 "SeriesDescription": "*gre*realtime*",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -84,8 +84,8 @@
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "unshimmed_phase_e3",
+            "datatype": "anat",
+            "suffix": "unshimmed_phase_e3",
             "criteria": {
                 "SeriesDescription": "*gre*realtime*",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -93,16 +93,16 @@
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "epi",
+            "datatype": "anat",
+            "suffix": "epi",
             "criteria": {
                 "SequenceName": "*epfid2d*",
                 "ImageType": ["*", "*", "M", "*", "*"]
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "inv-1_MP2RAGE",
+            "datatype": "anat",
+            "suffix": "inv-1_MP2RAGE",
             "criteria": {
                 "SequenceName": "*tfl3d1_16ns",
                 "ProtocolName": "*mp2rage*",
@@ -111,8 +111,8 @@
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "inv-2_MP2RAGE",
+            "datatype": "anat",
+            "suffix": "inv-2_MP2RAGE",
             "criteria": {
                 "SequenceName": "*tfl3d1_16ns",
                 "ProtocolName": "*mp2rage*",
@@ -121,8 +121,8 @@
             }
         },
         {
-            "dataType": "anat",
-            "modalityLabel": "UNIT1",
+            "datatype": "anat",
+            "suffix": "UNIT1",
             "criteria": {
                 "SequenceName": "*tfl3d1_16ns",
                 "ProtocolName": "*mp2rage*",
@@ -130,8 +130,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude1",
+            "datatype": "fmap",
+            "suffix": "magnitude1",
             "criteria": {
                 "SequenceName": "fm2d2",
                 "ImageType": ["*", "*", "M", "*"],
@@ -139,8 +139,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude2",
+            "datatype": "fmap",
+            "suffix": "magnitude2",
             "criteria": {
                 "SequenceName": "fm2d2",
                 "ImageType": ["*", "*", "M", "*"],
@@ -148,8 +148,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase1",
+            "datatype": "fmap",
+            "suffix": "phase1",
             "criteria": {
                 "SequenceName": "fm2d2",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -157,8 +157,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase2",
+            "datatype": "fmap",
+            "suffix": "phase2",
             "criteria": {
                 "SequenceName": "fm2d2",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -166,8 +166,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude1",
+            "datatype": "fmap",
+            "suffix": "magnitude1",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
@@ -175,8 +175,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude2",
+            "datatype": "fmap",
+            "suffix": "magnitude2",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
@@ -184,8 +184,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude3",
+            "datatype": "fmap",
+            "suffix": "magnitude3",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
@@ -193,8 +193,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude4",
+            "datatype": "fmap",
+            "suffix": "magnitude4",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
@@ -202,8 +202,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude5",
+            "datatype": "fmap",
+            "suffix": "magnitude5",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
@@ -211,8 +211,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude6",
+            "datatype": "fmap",
+            "suffix": "magnitude6",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "M", "*"],
@@ -220,8 +220,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase1",
+            "datatype": "fmap",
+            "suffix": "phase1",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -229,8 +229,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase2",
+            "datatype": "fmap",
+            "suffix": "phase2",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -238,8 +238,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase3",
+            "datatype": "fmap",
+            "suffix": "phase3",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -247,8 +247,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase4",
+            "datatype": "fmap",
+            "suffix": "phase4",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -256,8 +256,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase5",
+            "datatype": "fmap",
+            "suffix": "phase5",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -265,8 +265,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase6",
+            "datatype": "fmap",
+            "suffix": "phase6",
             "criteria": {
                 "SequenceName": "*fl[2-3]d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*"],
@@ -274,8 +274,8 @@
             }
         },
                 {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude1",
+            "datatype": "fmap",
+            "suffix": "magnitude1",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "M", "*", "*", "*"],
@@ -283,8 +283,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude2",
+            "datatype": "fmap",
+            "suffix": "magnitude2",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "M", "*", "*", "*"],
@@ -292,8 +292,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude3",
+            "datatype": "fmap",
+            "suffix": "magnitude3",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "M", "*", "*", "*"],
@@ -301,8 +301,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude4",
+            "datatype": "fmap",
+            "suffix": "magnitude4",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "M", "*", "*", "*"],
@@ -310,8 +310,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude5",
+            "datatype": "fmap",
+            "suffix": "magnitude5",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "M", "*", "*", "*"],
@@ -319,8 +319,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude6",
+            "datatype": "fmap",
+            "suffix": "magnitude6",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "M", "*", "*", "*"],
@@ -328,8 +328,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase1",
+            "datatype": "fmap",
+            "suffix": "phase1",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*", "*"],
@@ -337,8 +337,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase2",
+            "datatype": "fmap",
+            "suffix": "phase2",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*", "*"],
@@ -346,8 +346,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase3",
+            "datatype": "fmap",
+            "suffix": "phase3",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*", "*"],
@@ -355,8 +355,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase4",
+            "datatype": "fmap",
+            "suffix": "phase4",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*", "*"],
@@ -364,8 +364,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase5",
+            "datatype": "fmap",
+            "suffix": "phase5",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*", "*"],
@@ -373,8 +373,8 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "phase6",
+            "datatype": "fmap",
+            "suffix": "phase6",
             "criteria": {
                 "SequenceName": "*fl2d[2-6]",
                 "ImageType": ["*", "*", "P", "*", "*", "*"],
@@ -382,44 +382,44 @@
             }
         },
         {
-            "dataType": "func",
-            "modalityLabel": "bold",
+            "datatype": "func",
+            "suffix": "bold",
             "criteria": {
                 "SeriesDescription": "*bold*"
             }
         },
         {
-            "dataType": "func",
-            "modalityLabel": "task",
+            "datatype": "func",
+            "suffix": "task",
             "criteria": {
                 "SeriesDescription": "*task-p2-s3*"
             }
         },
         {
-            "dataType": "dwi",
-            "modalityLabel": "dwi",
+            "datatype": "dwi",
+            "suffix": "dwi",
             "criteria": {
                 "SeriesDescription": "*DWI*"
             }
         },
         {
-            "dataType": "rfmap",
-            "modalityLabel": "TB1map",
+            "datatype": "rfmap",
+            "suffix": "TB1map",
             "criteria": {
                 "SequenceName": "*tfl2d1_16"
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "fieldmap",
+            "datatype": "fmap",
+            "suffix": "fieldmap",
             "criteria": {
                 "Manufacturer": "Philips",
                 "ImageType": ["*", "*", "B0 MAP", "B0", "*", "FIELDMAPHZ"]
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude1",
+            "datatype": "fmap",
+            "suffix": "magnitude1",
             "criteria": {
                 "Manufacturer": "Philips",
                 "EchoNumber": "1",
@@ -427,16 +427,16 @@
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "fieldmap",
+            "datatype": "fmap",
+            "suffix": "fieldmap",
             "criteria": {
                 "Manufacturer": "Philips",
                 "ImageType": ["*", "*", "T1", "MIXED", "REAL", "FIELDMAPHZ"]
             }
         },
         {
-            "dataType": "fmap",
-            "modalityLabel": "magnitude1",
+            "datatype": "fmap",
+            "suffix": "magnitude1",
             "criteria": {
                 "Manufacturer": "Philips",
                 "EchoNumber": "1",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "joblib",
     ],
     extras_require={
-        'docs': ["sphinx>=1.6", "sphinx_rtd_theme>=0.2.4", "sphinx-click"],
+        'docs': ["sphinx>=1.7", "sphinx_rtd_theme>=1.2.2", "sphinx-click"],
         'dev': ["pre-commit>=2.10.0"]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(exclude=["docs"]),
     install_requires=[
         "click",
-        "dcm2bids>=2.1.7",
+        "dcm2bids>=3.0.1",
         'importlib-metadata ~= 4.0 ; python_version < "3.8"',
         "numpy>=1.21",
         "phantominator~=0.6.4",

--- a/test/cli/test_cli_b0shim.py
+++ b/test/cli/test_cli_b0shim.py
@@ -891,10 +891,10 @@ class TestCLIRealtime(object):
                                 catch_exceptions=False)
 
             assert res.exit_code == 0
-            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch0_Prisma_fit_gradient_coil.txt"))
-            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch1_Prisma_fit_gradient_coil.txt"))
-            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch2_Prisma_fit_gradient_coil.txt"))
-            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch3_Prisma_fit_gradient_coil.txt"))
+            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch0_Prisma_fit.txt"))
+            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch1_Prisma_fit.txt"))
+            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch2_Prisma_fit.txt"))
+            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_ch3_Prisma_fit.txt"))
 
     def test_cli_realtime_wrong_dim_info(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
         with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:


### PR DESCRIPTION
## Description
This PR fixes some tests that are failing due to dcm2bids updating to version 3.0 which was not backwards compatible with the previous config file.

This PR also adresses a failing test in test_cli_b0shim.

## Related
This PR also introduces the changes of #468 which updated the read the docs theme
