### PR TITLE
Change phase range in field mapping calculations

### DIFF
--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -182,11 +182,12 @@ def read_nii(fname_nifti, auto_scale=True):
 
             if np.amin(image) < 0 and (0.95 * 2 * PHASE_SCALING_SIEMENS < extent < 2 * PHASE_SCALING_SIEMENS * 1.05):
                 # Siemens' scaling: [-4096, 4095] --> [-pi, pi)
-                image = image * math.pi / PHASE_SCALING_SIEMENS
+                image = (image * math.pi / PHASE_SCALING_SIEMENS)
+                image = np.angle(np.exp(1j * image))
             elif np.amin(image) >= 0 and (0.95 * PHASE_SCALING_SIEMENS < extent < PHASE_SCALING_SIEMENS * 1.05):
                 # Siemens' scaling [0, 4095] --> [0, 2pi)
                 # We want: [-pi, pi]
-                image = image * 2 * math.pi / PHASE_SCALING_SIEMENS
+                image = (image * 2 * math.pi / PHASE_SCALING_SIEMENS) - math.pi
                 image = np.angle(np.exp(1j * image))
             else:
                 logger.info("Could not scale phase data")

--- a/shimmingtoolbox/load_nifti.py
+++ b/shimmingtoolbox/load_nifti.py
@@ -181,14 +181,11 @@ def read_nii(fname_nifti, auto_scale=True):
             extent = (np.amax(image) - np.amin(image))
 
             if np.amin(image) < 0 and (0.95 * 2 * PHASE_SCALING_SIEMENS < extent < 2 * PHASE_SCALING_SIEMENS * 1.05):
-                # Siemens' scaling: [-4096, 4095] --> [-pi, pi)
+                # Siemens' scaling: [-4096, 4095] --> [-pi, pi[
                 image = (image * math.pi / PHASE_SCALING_SIEMENS)
-                image = np.angle(np.exp(1j * image))
             elif np.amin(image) >= 0 and (0.95 * PHASE_SCALING_SIEMENS < extent < PHASE_SCALING_SIEMENS * 1.05):
-                # Siemens' scaling [0, 4095] --> [0, 2pi)
-                # We want: [-pi, pi]
+                # Siemens' scaling [0, 4095] --> [-pi, pi[
                 image = (image * 2 * math.pi / PHASE_SCALING_SIEMENS) - math.pi
-                image = np.angle(np.exp(1j * image))
             else:
                 logger.info("Could not scale phase data")
 


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've applied the relevant labels to this PR
- [x] I've updated the documentation and/or added the correct docstrings
- [x] I've assigned a reviewer


## Description
Siemens outputs phase value in different formats ([0, 4095], [-4096, 4095]). We previously thought that [0, 4095] would map to [0, 2pi]. With experiments, we realized that it is mapped to [-pi, pi] for at least one sequence (gre_fm). This created a shift of f0 when calculating the field maps. This PR fixes this problem by subtracting pi when the phase values are between [0, 4095].

