### PR TITLE
Add unwrap CLI

### DIFF
--- a/docs/source/cli_reference/cli.rst
+++ b/docs/source/cli_reference/cli.rst
@@ -15,6 +15,10 @@ Field mapping
 .. click:: shimmingtoolbox.cli.prepare_fieldmap:prepare_fieldmap_cli
    :prog: st_prepare_fieldmap
 
+.. click:: shimmingtoolbox.cli.unwrap:unwrap_cli
+   :prog: st_unwrap
+
+
 Shimming
 --------
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
             "st_maths=shimmingtoolbox.cli.maths:maths_cli",
             "st_b0shim=shimmingtoolbox.cli.b0shim:b0shim_cli",
             "st_create_coil_profiles=shimmingtoolbox.cli.create_coil_profiles:coil_profiles_cli",
-            "st_sort_dicoms=shimmingtoolbox.cli.sort_dicoms:sort_dicoms"
+            "st_sort_dicoms=shimmingtoolbox.cli.sort_dicoms:sort_dicoms",
+            "st_unwrap=shimmingtoolbox.cli.unwrap:unwrap_cli"
         ]
     },
     packages=find_packages(exclude=["docs"]),

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "raven",
         "joblib",
         "quadprog",
+        "cloup"
     ],
     extras_require={
         'docs': ["sphinx>=1.7", "sphinx_rtd_theme>=1.2.2", "sphinx-click"],

--- a/shimmingtoolbox/cli/unwrap.py
+++ b/shimmingtoolbox/cli/unwrap.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+
+import click
+import json
+import logging
+import math
+import nibabel as nib
+import numpy as np
+import os
+
+from shimmingtoolbox.unwrap.unwrap_phase import unwrap_phase
+from shimmingtoolbox.prepare_fieldmap import get_mask, correct_2pi_offset, VALIDITY_THRESHOLD
+from shimmingtoolbox.utils import create_fname_from_path, set_all_loggers, create_output_dir, save_nii_json
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+FILE_OUTPUT_DEFAULT = 'unwrapped.nii.gz'
+MASK_OUTPUT_DEFAULT = 'mask_unwrap.nii.gz'
+
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+)
+@click.option('-i', '--input', 'fname_data', type=click.Path(exists=True), required=True,
+              help="Input path of data nifti file")
+@click.option('--mag', 'fname_mag', type=click.Path(exists=True), required=True,
+              help="Input path of mag nifti file")
+@click.option('--unwrapper', type=click.Choice(['prelude', 'skimage']), default='prelude',
+              show_default=True,
+              help="Algorithm for unwrapping. skimage is installed by default, prelude requires FSL to be installed.")
+@click.option('-o', '--output', 'fname_output', type=click.Path(),
+              default=os.path.join(os.curdir, FILE_OUTPUT_DEFAULT),
+              show_default=True, help="Output filename for the unwrapped data, supported types : '.nii', '.nii.gz'")
+@click.option('--mask', 'fname_mask', type=click.Path(exists=True),
+              help="Input path for a mask.")
+@click.option('--threshold', 'threshold', type=float, show_default=True, default=0.05,
+              help="Threshold for masking if no mask is provided. Allowed range: [0, 1] where all scaled values lower "
+                   "than the threshold are set to 0.")
+@click.option('--savemask', 'fname_save_mask', type=click.Path(),
+              help="Filename of the mask calculated by the unwrapper")
+@click.option('-v', '--verbose', type=click.Choice(['info', 'debug']), default='info',
+              help="Be more verbose")
+def unwrap_cli(fname_data, fname_mag, unwrapper, fname_output, fname_mask, threshold, fname_save_mask, verbose):
+    """
+    Unwraps images. This algorithm expects the input to have wraps. Edge cases might occur if no wraps are present.
+    The unwrapper tries to correct 2pi ambiguity when unwrapping by bringing the mean closest to 0 in increments of 2pi
+    jumps.
+    """
+    # Set logger level
+    set_all_loggers(verbose)
+
+    # Create filename for the output if it's a path
+    fname_output_v2 = create_fname_from_path(fname_output, FILE_OUTPUT_DEFAULT)
+
+    # Create output directory if it doesn't exist
+    create_output_dir(fname_output_v2, is_file=True)
+
+    # Save mask
+    if fname_save_mask is not None:
+        # If it is a path, add the default filename and create output directory
+        fname_save_mask = create_fname_from_path(fname_save_mask, MASK_OUTPUT_DEFAULT)
+        create_output_dir(fname_save_mask, is_file=True)
+
+    # Scale to radians
+    nii_data = nib.load(fname_data)
+    data = nii_data.get_fdata()
+
+    # Scale the input from -pi to pi
+    # If the input is wrapped, the unwrapper will unwrap normally, if not, no unwrapping will be done
+    scalar = get_scalar_to_fit_2pi(data)
+    data_mean = np.mean(data * scalar)
+    data_scaled = (data * scalar) - data_mean  # [-pi, pi]
+    nii_scaled = nib.Nifti1Image(data_scaled, nii_data.affine, header=nii_data.header)
+
+    # Load magnitude
+    mag = nib.load(fname_mag).get_fdata()
+
+    # Load mask
+    if fname_mask is not None:
+        nii_mask = nib.load(fname_mask)
+    else:
+        nii_mask = None
+
+    # Returns a mask. If a mask is provided, use that mask. If not, create a mask using the threshold.
+    mask = get_mask(nii_scaled, mag, nii_mask, threshold)
+
+    # Unwrap
+    unwrapped_rad = unwrap_phase(nii_scaled, unwrapper, mag, mask, fname_save_mask=fname_save_mask)
+
+    # Correct for 2pi offset between timepoints if in 4d, bring closest to the mean if in 3D
+    unwrapped_rad = correct_2pi_offset(unwrapped_rad, mag, mask, VALIDITY_THRESHOLD)
+
+    # Scale back to original range
+    unwrapped = (unwrapped_rad + data_mean) / scalar
+    nii_unwrapped = nib.Nifti1Image(unwrapped.astype(nii_data.get_data_dtype()),
+                                    nii_data.affine,
+                                    header=nii_data.header)
+
+    # Open and save JSON file
+    # Save unwrapped nii
+    json_path = fname_data.split('.nii')[0] + '.json'
+    if os.path.isfile(json_path):
+        with open(json_path, 'r') as json_file:
+            json_data = json.load(json_file)
+        # Save NIfTI and json file to their respective filenames
+        save_nii_json(nii_unwrapped, json_data, fname_output_v2)
+    else:
+        # Save NIfTI
+        nib.save(nii_unwrapped, fname_output_v2)
+
+    # Log output file
+    logger.info(f"Filename of the unwrapped data is located: {fname_output_v2}")
+
+
+def get_scalar_to_fit_2pi(data):
+    """Return the scalar that scales the data to a range of 2pi"""
+    # Scale to radians
+    extent = np.max(data) - np.min(data)
+    scale = 2 * math.pi / extent
+    return scale

--- a/shimmingtoolbox/conversion.py
+++ b/shimmingtoolbox/conversion.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+
+import math
+
+GYROMAGNETIC_RATIO = 42.577478518e+6  # [Hz/T]
+
+
+def hz_to_rad_per_sec(hz):
+    """ Convert Hz to rad/s """
+    return hz * 2 * math.pi
+
+
+def rad_per_sec_to_hz(rad_per_sec):
+    """ Convert rad/s to Hz """
+    return rad_per_sec / (2 * math.pi)
+
+
+def hz_to_tesla(hz):
+    """ Convert Hz to Tesla """
+    return hz / GYROMAGNETIC_RATIO
+
+
+def tesla_to_hz(tesla):
+    """ Convert Tesla to Hz """
+    return tesla * GYROMAGNETIC_RATIO
+
+
+def rad_per_sec_to_rad(rad_per_sec, dt):
+    """ Convert rad/s to rad """
+    return rad_per_sec * dt
+
+
+def rad_to_rad_per_sec(rad, dt):
+    """ Convert rad to rad/s """
+    return rad / dt
+
+
+def hz_to_rad(hz, dt):
+    """ Convert Hz to rad """
+    rad_per_sec = hz_to_rad_per_sec(hz)
+    rad = rad_per_sec_to_rad(rad_per_sec, dt)
+    return rad
+
+
+def rad_to_hz(rad, dt):
+    """ Convert rad to Hz """
+    rad_per_sec = rad_to_rad_per_sec(rad, dt)
+    hz = rad_per_sec_to_hz(rad_per_sec)
+    return hz
+
+
+def tesla_to_rad(tesla, dt):
+    """ Convert Tesla to rad """
+    hz = tesla_to_hz(tesla)
+    rad = hz_to_rad(hz, dt)
+    return rad
+
+
+def rad_to_tesla(rad, dt):
+    """ Convert rad to Tesla """
+    hz = rad_to_hz(rad, dt)
+    tesla = hz_to_tesla(hz)
+    return tesla
+
+
+def milli_tesla_to_tesla(milli_tesla):
+    """ Convert milliTesla to Tesla """
+    return milli_tesla * 1e-3
+
+
+def tesla_to_milli_tesla(tesla):
+    """ Convert Tesla to milliTesla """
+    return tesla * 1e3
+
+
+def milli_tesla_to_rad(milli_tesla, dt):
+    """ Convert milliTesla to rad """
+    tesla = milli_tesla_to_tesla(milli_tesla)
+    rad = tesla_to_rad(tesla, dt)
+    return rad
+
+
+def rad_to_milli_tesla(rad, dt):
+    """ Convert rad to milliTesla """
+    tesla = rad_to_tesla(rad, dt)
+    milli_tesla = tesla_to_milli_tesla(tesla)
+    return milli_tesla
+
+
+def gauss_to_tesla(gauss):
+    """ Convert Gauss to Tesla """
+    return gauss * 1e-4
+
+
+def tesla_to_gauss(tesla):
+    """ Convert Tesla to Gauss """
+    return tesla * 1e4
+
+
+def gauss_to_rad(gauss, dt):
+    """ Convert Gauss to rad """
+    tesla = gauss_to_tesla(gauss)
+    rad = tesla_to_rad(tesla, dt)
+    return rad
+
+
+def rad_to_gauss(rad, dt):
+    """ Convert rad to Gauss """
+    tesla = rad_to_tesla(rad, dt)
+    gauss = tesla_to_gauss(tesla)
+    return gauss

--- a/test/cli/test_cli_unwrap.py
+++ b/test/cli/test_cli_unwrap.py
@@ -2,8 +2,11 @@
 # -*- coding: utf-8 -*
 
 from click.testing import CliRunner
+import math
+import nibabel as nib
 import os
 import pathlib
+import pytest
 import tempfile
 
 from shimmingtoolbox import __dir_testing__
@@ -12,29 +15,13 @@ from shimmingtoolbox.cli.unwrap import unwrap_cli
 fname_data = os.path.join(__dir_testing__, "ds_b0", "sub-realtime", "fmap", "sub-realtime_phasediff.nii.gz")
 fname_mag = os.path.join(__dir_testing__, "ds_b0", "sub-realtime", "fmap", "sub-realtime_magnitude1.nii.gz")
 
-
-def test_cli_unwrap():
-    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
-        runner = CliRunner()
-
-        fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
-
-        result = runner.invoke(unwrap_cli, ['-i', fname_data,
-                                            '--mag', fname_mag,
-                                            '--unwrapper', 'skimage',
-                                            '--output', fname_output], catch_exceptions=False)
-
-        assert result.exit_code == 0
-        assert os.path.isfile(fname_output)
-        assert os.path.isfile(os.path.join(tmp, 'unwrapped.json'))
+H_GYROMAGNETIC_RATIO = 42.577478518e+6  # [Hz/T]
 
 
 def test_cli_unwrap_range():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
-
         fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
-
         result = runner.invoke(unwrap_cli, ['-i', fname_data,
                                             '--mag', fname_mag,
                                             '--range', '4095',
@@ -44,3 +31,163 @@ def test_cli_unwrap_range():
         assert result.exit_code == 0
         assert os.path.isfile(fname_output)
         assert os.path.isfile(os.path.join(tmp, 'unwrapped.json'))
+
+
+def test_cli_unwrap_hz_dte():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        # Scale to Hz
+        dte = 0.00246
+        nii = nib.load(fname_data)
+        data = (nii.get_fdata() / 4096 - 0.5) / dte
+        nii = nib.Nifti1Image(data, nii.affine, header=nii.header)
+        # Save
+        fname_fmap_hz = os.path.join(tmp, 'fieldmap_wrapped_hz.nii.gz')
+        nib.save(nii, os.path.join(tmp, fname_fmap_hz))
+        fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
+
+        result = runner.invoke(unwrap_cli, ['-i', fname_fmap_hz,
+                                            '--mag', fname_mag,
+                                            '--unit', 'Hz',
+                                            '--dte', str(dte),
+                                            '--unwrapper', 'skimage',
+                                            '--output', fname_output], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output)
+        assert math.isclose(nib.load(fname_output).get_fdata()[23, 28, 0, 0], 387.24819, rel_tol=1e-5)
+
+
+def test_cli_unwrap_mt_dte():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        # Scale to Hz
+        dte = 0.00246
+        nii = nib.load(fname_data)
+        data = (nii.get_fdata() / 4096 - 0.5) / dte / H_GYROMAGNETIC_RATIO * 1e3  # [mT]
+        nii = nib.Nifti1Image(data, nii.affine, header=nii.header)
+        # Save
+        fname_fmap_mt = os.path.join(tmp, 'fieldmap_wrapped_mT.nii.gz')
+        nib.save(nii, os.path.join(tmp, fname_fmap_mt))
+        fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
+
+        result = runner.invoke(unwrap_cli, ['-i', fname_fmap_mt,
+                                            '--mag', fname_mag,
+                                            '--unit', 'mT',
+                                            '--dte', str(dte),
+                                            '--unwrapper', 'skimage',
+                                            '--output', fname_output], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output)
+        assert math.isclose(nib.load(fname_output).get_fdata()[23, 28, 0, 0], 387.24819 / H_GYROMAGNETIC_RATIO * 1e3,
+                            rel_tol=1e-5)
+
+
+def test_cli_unwrap_t_dte():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        # Scale to Hz
+        dte = 0.00246
+        nii = nib.load(fname_data)
+        data = (nii.get_fdata() / 4096 - 0.5) / dte / H_GYROMAGNETIC_RATIO  # [T]
+        nii = nib.Nifti1Image(data, nii.affine, header=nii.header)
+        # Save
+        fname_fmap_t = os.path.join(tmp, 'fieldmap_wrapped_T.nii.gz')
+        nib.save(nii, os.path.join(tmp, fname_fmap_t))
+        fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
+
+        result = runner.invoke(unwrap_cli, ['-i', fname_fmap_t,
+                                            '--mag', fname_mag,
+                                            '--unit', 'T',
+                                            '--dte', str(dte),
+                                            '--unwrapper', 'skimage',
+                                            '--output', fname_output], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output)
+        assert math.isclose(nib.load(fname_output).get_fdata()[23, 28, 0, 0], 387.24819 / H_GYROMAGNETIC_RATIO,
+                            rel_tol=1e-5)
+
+
+def test_cli_unwrap_g_dte():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        # Scale to Hz
+        dte = 0.00246
+        nii = nib.load(fname_data)
+        data = (nii.get_fdata() / 4096 - 0.5) / dte / H_GYROMAGNETIC_RATIO * 1e4  # [G]
+        nii = nib.Nifti1Image(data, nii.affine, header=nii.header)
+        # Save
+        fname_fmap_g = os.path.join(tmp, 'fieldmap_wrapped_G.nii.gz')
+        nib.save(nii, os.path.join(tmp, fname_fmap_g))
+        fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
+
+        result = runner.invoke(unwrap_cli, ['-i', fname_fmap_g,
+                                            '--mag', fname_mag,
+                                            '--unit', 'g',
+                                            '--dte', str(dte),
+                                            '--unwrapper', 'skimage',
+                                            '--output', fname_output], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output)
+        assert math.isclose(nib.load(fname_output).get_fdata()[23, 28, 0, 0], 387.24819 / H_GYROMAGNETIC_RATIO * 1e4,
+                            rel_tol=1e-5)
+
+
+def test_cli_unwrap_rads_dte():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        # Scale to Hz
+        dte = 0.00246
+        nii = nib.load(fname_data)
+        data = (nii.get_fdata() / 4096 - 0.5) / dte * 2 * math.pi  # [G]
+        nii = nib.Nifti1Image(data, nii.affine, header=nii.header)
+        # Save
+        fname_fmap_rads = os.path.join(tmp, 'fieldmap_wrapped_G.nii.gz')
+        nib.save(nii, os.path.join(tmp, fname_fmap_rads))
+        fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
+
+        result = runner.invoke(unwrap_cli, ['-i', fname_fmap_rads,
+                                            '--mag', fname_mag,
+                                            '--unit', 'rad/s',
+                                            '--dte', str(dte),
+                                            '--unwrapper', 'skimage',
+                                            '--output', fname_output], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output)
+        assert math.isclose(nib.load(fname_output).get_fdata()[23, 28, 0, 0], 387.24819 * 2 * math.pi,
+                            rel_tol=1e-5)
+
+
+def test_cli_unwrap_no_scalar():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+        fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
+
+        res = runner.invoke(unwrap_cli, ['-i', fname_data,
+                                         '--mag', fname_mag,
+                                         '--unit', 'Hz',
+                                         '--unwrapper', 'skimage',
+                                         '--output', fname_output], catch_exceptions=False)
+        assert res.exit_code == 2
+
+
+def test_cli_unwrap_small_range():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+        fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
+
+        with pytest.raises(ValueError, match="The provided --range is smaller than the range of the data."):
+            runner.invoke(unwrap_cli, ['-i', fname_data,
+                                       '--mag', fname_mag,
+                                       '--range', '1000',
+                                       '--unwrapper', 'skimage',
+                                       '--output', fname_output], catch_exceptions=False)

--- a/test/cli/test_cli_unwrap.py
+++ b/test/cli/test_cli_unwrap.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+
+from click.testing import CliRunner
+import os
+import pathlib
+import tempfile
+
+from shimmingtoolbox import __dir_testing__
+from shimmingtoolbox.cli.unwrap import unwrap_cli
+
+fname_data = os.path.join(__dir_testing__, "ds_b0", "sub-realtime", "fmap", "sub-realtime_phasediff.nii.gz")
+fname_mag = os.path.join(__dir_testing__, "ds_b0", "sub-realtime", "fmap", "sub-realtime_magnitude1.nii.gz")
+
+
+def test_unwrap_cli():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
+
+        result = runner.invoke(unwrap_cli, ['-i', fname_data,
+                                            '--mag', fname_mag,
+                                            '--unwrapper', 'skimage',
+                                            '--output', fname_output], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output)
+        assert os.path.isfile(os.path.join(tmp, 'unwrapped.json'))

--- a/test/cli/test_cli_unwrap.py
+++ b/test/cli/test_cli_unwrap.py
@@ -13,7 +13,7 @@ fname_data = os.path.join(__dir_testing__, "ds_b0", "sub-realtime", "fmap", "sub
 fname_mag = os.path.join(__dir_testing__, "ds_b0", "sub-realtime", "fmap", "sub-realtime_magnitude1.nii.gz")
 
 
-def test_unwrap_cli():
+def test_cli_unwrap():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 
@@ -21,6 +21,23 @@ def test_unwrap_cli():
 
         result = runner.invoke(unwrap_cli, ['-i', fname_data,
                                             '--mag', fname_mag,
+                                            '--unwrapper', 'skimage',
+                                            '--output', fname_output], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output)
+        assert os.path.isfile(os.path.join(tmp, 'unwrapped.json'))
+
+
+def test_cli_unwrap_range():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        fname_output = os.path.join(tmp, 'unwrapped.nii.gz')
+
+        result = runner.invoke(unwrap_cli, ['-i', fname_data,
+                                            '--mag', fname_mag,
+                                            '--range', '4095',
                                             '--unwrapper', 'skimage',
                                             '--output', fname_output], catch_exceptions=False)
 

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+
+"""Test module to test the conversion functions in conversion.py"""
+
+import math
+
+from shimmingtoolbox.conversion import (hz_to_rad_per_sec, rad_per_sec_to_hz, hz_to_tesla, tesla_to_hz,
+                                        rad_per_sec_to_rad, rad_to_rad_per_sec, hz_to_rad, rad_to_hz, tesla_to_rad,
+                                        rad_to_tesla, milli_tesla_to_rad, rad_to_milli_tesla, gauss_to_rad,
+                                        rad_to_gauss)
+
+
+def test_hz_to_rad_per_sec():
+    assert hz_to_rad_per_sec(1) == 2 * math.pi
+    assert hz_to_rad_per_sec(0) == 0
+
+
+def test_rad_per_sec_to_hz():
+    assert rad_per_sec_to_hz(2 * math.pi) == 1
+    assert rad_per_sec_to_hz(0) == 0
+
+
+def test_hz_to_tesla():
+    assert hz_to_tesla(42.577478518e+6) == 1
+    assert hz_to_tesla(0) == 0
+
+
+def test_tesla_to_hz():
+    assert tesla_to_hz(1) == 42.577478518e+6
+    assert tesla_to_hz(0) == 0
+
+
+def test_rad_per_sec_to_rad():
+    assert rad_per_sec_to_rad(1, 0.1) == 0.1
+    assert rad_per_sec_to_rad(0, 0.1) == 0
+
+
+def test_rad_to_rad_per_sec():
+    assert rad_to_rad_per_sec(1, 0.1) == 10
+    assert rad_to_rad_per_sec(0, 0.1) == 0
+
+
+def test_hz_to_rad():
+    assert hz_to_rad(1, 0.1) == 0.2 * math.pi
+    assert hz_to_rad(0, 0.1) == 0
+
+
+def test_rad_to_hz():
+    assert rad_to_hz(2 * math.pi, 0.1) == 10
+    assert rad_to_hz(0, 0.1) == 0
+
+
+def test_tesla_to_rad():
+    assert tesla_to_rad(1, 0.1) == 0.2 * math.pi * 42.577478518e+6
+    assert tesla_to_rad(0, 0.1) == 0
+
+
+def test_rad_to_tesla():
+    assert rad_to_tesla(2 * math.pi, 0.1) == 10 / 42.577478518e+6
+    assert rad_to_tesla(0, 0.1) == 0
+
+
+def test_milli_tesla_to_rad():
+    assert math.isclose(milli_tesla_to_rad(1, 0.1), 0.2e-3 * math.pi * 42.577478518e+6)
+    assert milli_tesla_to_rad(0, 0.1) == 0
+
+
+def test_rad_to_milli_tesla():
+    assert rad_to_milli_tesla(2 * math.pi, 0.1) == 10e3 / 42.577478518e+6
+    assert rad_to_milli_tesla(0, 0.1) == 0
+
+
+def test_gauss_to_rad():
+    assert gauss_to_rad(1, 0.1) == 0.2e-4 * math.pi * 42.577478518e+6
+    assert gauss_to_rad(0, 0.1) == 0
+
+
+def test_rad_to_gauss():
+    assert rad_to_gauss(2 * math.pi, 0.1) == 10e4 / 42.577478518e+6
+    assert rad_to_gauss(0, 0.1) == 0


### PR DESCRIPTION
## Description
This PR adds a CLI to unwrap NIfTIs. The motivation behind this CLI is that some manufacturers directly output field maps from the scanner. These field maps can have wraps which require unwrapping. This CLI aims at unwrapping data (not just phase data).

Prelude requires data to be in the -pi to pi range. The data is scaled to that range, phase unwrapping is performed then scaled back to the initial range. 

Option 1: If possible, provide the unit of the data (Hz, T, G, etc) and the echo time. This will allow to unambiguously scale the data and allow unwrapping.
Option 2: Providing the --range option
Providing the --range of the data is all that is necessary to unambiguously unwrap the data. For datasets that are dimensionless (Siemens phase difference [0, 4095]), this is the only option possible.

Similar features to the prepare_fieldmap pipeline are provided (mask resampling, possibility to input a threshold to calculate the mask, 2npi offset fix, 4d unwrapping)

## How to use example
```
st_unwrap -i /path/to/wrapped.nii.gz --mag /path/to/input.nii.gz -o /path/to/output.nii.gz --unit hz --dte 0.001
```
## Note
There could be a 3rd option that would not require additional inputs from the user. The "range" is calculated from the max() and min() of the data. However, this results in compounding errors if data.max() - data.min() != range. I opted to not allow this option.

## Linked issues
Related to #519
