### PR TITLE
Restrict numpy version < 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "click",
         "dcm2bids>=3.0.1",
         'importlib-metadata ~= 4.0 ; python_version < "3.8"',
-        "numpy>=1.21",
+        "numpy<2",
         "phantominator~=0.6.4",
         "nibabel>=3.2.1",
         "requests",


### PR DESCRIPTION
The latest tests today failed,

https://github.com/shimming-toolbox/shimming-toolbox/actions/runs/9555207840

https://github.com/shimming-toolbox/shimming-toolbox/actions/runs/9555207840/job/26337937508#step:14:91

I believe due to the major version update of numpy: https://pypi.org/project/numpy/#history