### PR TITLE
Fix broken link in st_download_data data_create_coil_profiles

### DIFF
--- a/shimmingtoolbox/cli/download_data.py
+++ b/shimmingtoolbox/cli/download_data.py
@@ -27,7 +27,7 @@ URL_DICT: Dict[str, Tuple[List[str], str]] = {
         "B0 dynamic shimming dataset.",
     ),
     "data_create_coil_profiles": (
-        ["https://github.com/shimming-toolbox/data-create-coil-profiles/releases/download/r20230929/dicoms.zip"],
+        ["https://github.com/shimming-toolbox/data-create-coil-profiles/releases/download/r20230815/dicoms.zip"],
         ["https://github.com/shimming-toolbox/data-create-coil-profiles/archive/refs/tags/r20230929.zip"],
         "B0 coil profile dataset.",
     ),

--- a/test/cli/test_cli_download_data.py
+++ b/test/cli/test_cli_download_data.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*
+
+import requests
+from shimmingtoolbox.cli.download_data import URL_DICT
+
+
+def test_links():
+    for key in URL_DICT:
+        for url in URL_DICT[key][0]:
+            assert requests.head(url).status_code != 404


### PR DESCRIPTION
## Description
The link for `st_download_data data_create_coil_profiles` was broken. This PR fixes that and adds a test that checks that links in `st_download_data` do not return a 404 error.
