### PR TITLE
Fix test issues coming from incompatibility with fsl bet2

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,7 +89,7 @@ html_theme = "sphinx_rtd_theme"
 #
 html_theme_options = {
     "collapse_navigation": False,
-    "display_version": False,
+    "display_version": True,
     "navigation_depth": 4,
 }
 html_logo = "_static/img/shimming_toolbox_logo.png"

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -39,7 +39,7 @@ else
     exit 1
 fi
 
-CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/latest/download/"$CONDA_INSTALLER"
+CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/tag/24.5.0-0/"$CONDA_INSTALLER"
 
 installConda() {
     curl -L --url $CONDA_INSTALLER_URL --output $TMP_DIR/$CONDA_INSTALLER

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -39,7 +39,7 @@ else
     exit 1
 fi
 
-CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/tag/24.5.0-0/"$CONDA_INSTALLER"
+CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/download/24.5.0-0/"$CONDA_INSTALLER"
 
 installConda() {
     curl -L --url $CONDA_INSTALLER_URL --output $TMP_DIR/$CONDA_INSTALLER

--- a/shimming-toolbox/setup.py
+++ b/shimming-toolbox/setup.py
@@ -60,7 +60,7 @@ setup(
         "cloup",
     ],
     extras_require={
-        'docs': ["sphinx>=1.7", "sphinx_rtd_theme>=1.2.2", "sphinx-click", "myst_parser"],
+        'docs': ["sphinx>=1.7", "sphinx_rtd_theme==2.0.0", "sphinx-click", "myst_parser"],
         'dev': ["pre-commit>=2.10.0"]
     },
 )


### PR DESCRIPTION
Fix testing issues for documentation and fsl compatibility by:
* Fixing mamba's version to 24.5.0-0
* Fixing sphinx_rtd_theme's version to 2.0.0

Other changes:
* Display sphinx's version