### PR TITLE
Update signal recovery calculation

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
@@ -241,7 +241,7 @@ def dynamic(fname_fmap, fname_anat, fname_mask_anat, method, opt_criteria, slice
         _save_nii_to_new_dir(list_fname, path_output)
 
     # Open json of the fmap
-    fname_json = fname_fmap.split('.nii')[0] + '.json'
+    fname_json = fname_fmap.rsplit('.nii', 1)[0] + '.json'
     # Read from json file
     if os.path.isfile(fname_json):
         with open(fname_json) as json_file:
@@ -279,7 +279,10 @@ def dynamic(fname_fmap, fname_anat, fname_mask_anat, method, opt_criteria, slice
     logger.info(f"The slices to shim are:\n{list_slices}")
     # Get shimming coefficients
     # 1 ) Create the Shimming sequencer object
-    sequencer = ShimSequencer(nii_fmap_orig, nii_anat, nii_mask_anat, list_slices, list_coils,
+    sequencer = ShimSequencer(nii_fmap_orig, json_fm_data,
+                              nii_anat, json_anat_data,
+                              nii_mask_anat,
+                              list_slices, list_coils,
                               method=method,
                               opt_criteria=opt_criteria,
                               mask_dilation_kernel='sphere',

--- a/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
@@ -838,14 +838,20 @@ class ShimSequencer(Sequencer):
 
         # choose selected slices to plot
         nonzero_indices = np.nonzero(np.sum(mask_erode,axis=(0,1)))[0]
-        mt_unshimmed = montage(unshimmed_signal_loss[:,:,nonzero_indices])
         mt_unshimmed_masked = montage(unshimmed_signal_loss[:,:,nonzero_indices]*mask_erode[:,:,nonzero_indices])
         mt_shimmed_masked = montage(shimmed_signal_loss[:,:,nonzero_indices]*mask_erode[:,:,nonzero_indices])
 
         # Save the signal loss maps
-        nib.save(nib.Nifti1Image(unshimmed_signal_loss*mask_erode, affine=self.nii_fieldmap.affine, header=self.nii_fieldmap.header),
+        # nib.save(nib.Nifti1Image(unshimmed_signal_loss*mask_erode, affine=self.nii_fieldmap.affine, header=self.nii_fieldmap.header),
+        #          os.path.join(self.path_output, 'signal_loss_unshimmed.nii.gz'))
+        # nib.save(nib.Nifti1Image(shimmed_signal_loss*mask_erode, affine=self.nii_fieldmap.affine, header=self.nii_fieldmap.header),
+        #          os.path.join(self.path_output, 'signal_loss_shimmed.nii.gz'))
+        # nib.save(nib.Nifti1Image(mask_erode, affine=self.nii_fieldmap.affine, header=self.nii_fieldmap.header),
+        #          os.path.join(self.path_output, 'mask_erode.nii.gz'))
+        
+        nib.save(nib.Nifti1Image(unshimmed_signal_loss, affine=self.nii_fieldmap.affine, header=self.nii_fieldmap.header),
                  os.path.join(self.path_output, 'signal_loss_unshimmed.nii.gz'))
-        nib.save(nib.Nifti1Image(shimmed_signal_loss*mask_erode, affine=self.nii_fieldmap.affine, header=self.nii_fieldmap.header),
+        nib.save(nib.Nifti1Image(shimmed_signal_loss, affine=self.nii_fieldmap.affine, header=self.nii_fieldmap.header),
                  os.path.join(self.path_output, 'signal_loss_shimmed.nii.gz'))
         nib.save(nib.Nifti1Image(mask_erode, affine=self.nii_fieldmap.affine, header=self.nii_fieldmap.header),
                  os.path.join(self.path_output, 'mask_erode.nii.gz'))

--- a/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
@@ -150,7 +150,7 @@ class ShimSequencer(Sequencer):
         masks_fmap (np.ndarray) : Resampled mask on the original fieldmap
     """
 
-    def __init__(self, nii_fieldmap, nii_anat, nii_mask_anat, slices, coils, method='least_squares', opt_criteria='mse',
+    def __init__(self, nii_fieldmap, json_fieldmap, nii_anat, json_anat, nii_mask_anat, slices, coils, method='least_squares', opt_criteria='mse',
                  mask_dilation_kernel='sphere', mask_dilation_kernel_size=3, reg_factor=0, w_signal_loss=None,
                  w_signal_loss_xy=None, epi_te=None, path_output=None):
         """
@@ -189,7 +189,9 @@ class ShimSequencer(Sequencer):
         """
         super().__init__(slices, mask_dilation_kernel, mask_dilation_kernel_size, reg_factor, path_output=path_output)
         self.nii_fieldmap, self.nii_fieldmap_orig, self.fmap_is_extended = self.get_fieldmap(nii_fieldmap)
+        self.json_fieldmap = json_fieldmap
         self.nii_anat = self.get_anat(nii_anat)
+        self.json_anat = json_anat
         self.nii_mask_anat = self.get_mask(nii_mask_anat)
         self.coils = coils
         if opt_criteria not in allowed_opt_criteria:
@@ -823,8 +825,8 @@ class ShimSequencer(Sequencer):
     def _plot_static_signal_recovery_mask(self, unshimmed, shimmed_Gz, mask):
         # Plot signal loss maps
         def calculate_signal_loss(gradient):
-            slice_thickness = self.nii_anat.header['pixdim'][3]
-            B0_map_thickness = self.nii_fieldmap_orig.header['pixdim'][3]
+            slice_thickness = self.json_anat['SliceThickness']
+            B0_map_thickness = self.json_fieldmap['SliceThickness']
             phi = 2 * math.pi * gradient / B0_map_thickness * self.epi_te * slice_thickness
             signal_map = abs(np.sinc(phi/(2*math.pi))) # The /pi is because the sinc function in numpy is sinc(x) = sin(pi*x)/(pi*x)
             signal_loss_map = 1 - signal_map

--- a/shimming-toolbox/test/shim/test_sequencer.py
+++ b/shimming-toolbox/test/shim/test_sequencer.py
@@ -90,6 +90,7 @@ def create_coil(n_x, n_y, n_z, constraints, coil_affine, n_channel=8):
 
 nz = 3  # Must be multiple of 3
 nii_to_shim = create_fieldmap()
+json_fmap = {'SliceThickness': 3}
 
 # Create coil profiles
 unshimmed_affine = create_unshimmed_affine()
@@ -105,6 +106,7 @@ coil2 = create_coil(150, 120, nz + 10, create_constraints(500, -500, 1500), affi
 # Create anat
 anat = np.ones((50, 50, 3))
 nii_anat = nib.Nifti1Image(anat, affine=affine)
+json_anat = {'SliceThickness': 3}
 
 # Create mask
 static_mask = shapes(anat, 'cube', len_dim1=10, len_dim2=10, len_dim3=nz)
@@ -126,7 +128,7 @@ class TestSequencer(object):
     def test_shim_sequencer_lsq(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
         slices = define_slices(nii_anat.shape[2], 1)
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil], method='least_squares')
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil], method='least_squares')
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
         assert_results(nii_fieldmap, nii_anat, nii_mask, [sph_coil], currents, slices)
@@ -134,7 +136,7 @@ class TestSequencer(object):
     def test_shim_sequencer_quad_prog(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
         slices = define_slices(nii_anat.shape[2], 1)
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil], method='quad_prog')
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil], method='quad_prog')
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
         assert_results(nii_fieldmap, nii_anat, nii_mask, [sph_coil], currents, slices)
@@ -142,7 +144,7 @@ class TestSequencer(object):
     def test_shim_sequencer_pseudo(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
         slices = define_slices(nii_anat.shape[2], 1)
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil], method='pseudo_inverse')
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil], method='pseudo_inverse')
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
         assert_results(nii_fieldmap, nii_anat, nii_mask, [sph_coil], currents, slices)
@@ -150,7 +152,7 @@ class TestSequencer(object):
     def test_shim_sequencer_std(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
         slices = define_slices(nii_anat.shape[2], 1)
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil], method='least_squares',
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil], method='least_squares',
                                        opt_criteria='std')
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
@@ -159,7 +161,7 @@ class TestSequencer(object):
     def test_shim_sequencer_mae(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
         slices = define_slices(nii_anat.shape[2], 1)
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil], method='least_squares',
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil], method='least_squares',
                                        opt_criteria='mae')
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
@@ -168,7 +170,7 @@ class TestSequencer(object):
     def test_shim_sequencer_2_coils_lsq(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
         slices = define_slices(nii_anat.shape[2], 1)
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil, sph_coil2],
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil, sph_coil2],
                                        method='least_squares')
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
@@ -177,7 +179,7 @@ class TestSequencer(object):
     def test_shim_sequencer_2_coils_quad_prog(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
         slices = define_slices(nii_anat.shape[2], 1)
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil, sph_coil2],
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil, sph_coil2],
                                        method='quad_prog')
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
@@ -188,7 +190,7 @@ class TestSequencer(object):
         coil = create_coil(5, 5, nz, create_constraints(None, None, None), affine)
         # Optimize
         slices = define_slices(nii_anat.shape[2], 1)
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [coil])
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [coil])
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
         assert_results(nii_fieldmap, nii_anat, nii_mask, [coil], currents, slices)
@@ -197,7 +199,7 @@ class TestSequencer(object):
         """Test for slices arranged as a slab"""
         # Optimize
         slices = define_slices(nii_anat.shape[2], nii_anat.shape[2])
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil])
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil])
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
         assert_results(nii_fieldmap, nii_anat, nii_mask, [sph_coil], currents, slices)
@@ -206,7 +208,7 @@ class TestSequencer(object):
         """Test for slices arranged for dynamic shimming"""
         # Optimize
         slices = [(0,), (1,), (2,)]
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil])
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil])
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
         assert_results(nii_fieldmap, nii_anat, nii_mask, [sph_coil], currents, slices)
@@ -215,7 +217,7 @@ class TestSequencer(object):
         """Test for slices arranged for multi slice"""
         # Optimize
         slices = [(0, 2), (1,)]
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil])
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil])
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
         assert_results(nii_fieldmap, nii_anat, nii_mask, [sph_coil], currents, slices)
@@ -225,7 +227,7 @@ class TestSequencer(object):
         slices = [(0, 2), (1,)]
         method = 'abc'
         with pytest.raises(KeyError, match=f"Method: {method} is not part of the supported optimizers"):
-            ShimSequencer(nii_fieldmap, nii_anat, nii_mask, slices, [sph_coil], method=method).shim()
+            ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil], method=method).shim()
 
     def test_shim_sequencer_wrong_fmap_dim(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
@@ -233,21 +235,21 @@ class TestSequencer(object):
         nii_wrong_fmap = nib.Nifti1Image(nii_fieldmap.get_fdata()[..., np.newaxis], nii_fieldmap.affine,
                                          header=nii_fieldmap.header)
         with pytest.raises(ValueError, match="Fieldmap must be 2d or 3d"):
-            ShimSequencer(nii_wrong_fmap, nii_anat, nii_mask, slices, [sph_coil]).shim()
+            ShimSequencer(nii_wrong_fmap, json_fmap, nii_anat, json_anat, nii_mask, slices, [sph_coil]).shim()
 
     def test_shim_sequencer_wrong_anat_dim(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
         slices = [(0, 2), (1,)]
         nii_wrong_anat = nib.Nifti1Image(nii_anat.get_fdata()[..., 0], nii_anat.affine, header=nii_anat.header)
         with pytest.raises(ValueError, match="Target anatomical image must be in 3d or 4d"):
-            ShimSequencer(nii_fieldmap, nii_wrong_anat, nii_mask, slices, [sph_coil]).shim()
+            ShimSequencer(nii_fieldmap, json_fmap, nii_wrong_anat, json_anat, nii_mask, slices, [sph_coil]).shim()
 
     def test_shim_sequencer_wrong_mask_dim(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2):
         # Optimize
         slices = [(0, 2), (1,)]
         nii_wrong_mask = nib.Nifti1Image(nii_mask.get_fdata()[..., 0], nii_mask.affine, header=nii_mask.header)
         with pytest.raises(ValueError, match="Mask must be in 3d or 4d"):
-            ShimSequencer(nii_fieldmap, nii_anat, nii_wrong_mask, slices, [sph_coil]).shim()
+            ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_wrong_mask, slices, [sph_coil]).shim()
 
     # def test_shim_sequencer_wrong_units(self, nii_fieldmap, nii_anat, nii_mask, sph_coil, sph_coil2, caplog):
     #     # Change the name of the units
@@ -263,7 +265,7 @@ class TestSequencer(object):
         diff_affine[0, 0] = 2
         nii_diff_mask = nib.Nifti1Image(nii_mask.get_fdata(), diff_affine, header=nii_mask.header)
 
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_diff_mask, slices, [sph_coil])
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_diff_mask, slices, [sph_coil])
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
         assert_results(nii_fieldmap, nii_anat, nii_diff_mask, [sph_coil], currents, slices)
@@ -273,7 +275,7 @@ class TestSequencer(object):
         slices = [(0, 2), (1,)]
         nii_diff_mask = nib.Nifti1Image(nii_mask.get_fdata()[5:, ...], nii_mask.affine, header=nii_mask.header)
 
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_anat, nii_diff_mask, slices, [sph_coil])
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_anat, json_anat, nii_diff_mask, slices, [sph_coil])
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
         assert_results(nii_fieldmap, nii_anat, nii_diff_mask, [sph_coil], currents, slices)
@@ -285,7 +287,7 @@ class TestSequencer(object):
         nii_4d_mask = nib.Nifti1Image(mask_4d, nii_mask.affine, header=nii_mask.header)
 
         slices = [(0, 2), (1,)]
-        sequencer_test = ShimSequencer(nii_fieldmap, nii_4d_anat, nii_4d_mask, slices, [sph_coil])
+        sequencer_test = ShimSequencer(nii_fieldmap, json_fmap, nii_4d_anat, json_anat, nii_4d_mask, slices, [sph_coil])
         currents = sequencer_test.shim()
         sequencer_test.eval(currents)
         assert_results(nii_fieldmap, nii_anat, nii_mask, [sph_coil], currents, slices)


### PR DESCRIPTION
## Description
Previous signal loss maps were computed as follows:
phi = gradient * epi_TE, with the gradient in Hz

But phi should be
phi = 2pi * gradient / B0_map_thickness * epi_slice_thickness * epi_TE, with gradient in Hz

Note, in the code a  /pi was added because np.sinc() multiplies input by pi. 

