### PR TITLE
Update GitHub Actions to more recent versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Cache pip dependencies
         id: cache-pip-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # Ubuntu-specific, see
           # https://github.com/actions/cache/blob/main/examples.md#python---pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'macos-12'
           - 'macos-13'
+          - 'macos-14'
+          - 'macos-15'
+          - 'ubuntu-24.04'
           - 'ubuntu-22.04'
           - 'ubuntu-20.04'
         python-version:
@@ -29,7 +31,9 @@ jobs:
           - 'fsleyes-plugin-shimming-toolbox'
           - 'shimming-toolbox'
         exclude:
-          - os: 'macos-12'
+          - os: 'macos-15'
+            tests: 'fsleyes-plugin-shimming-toolbox'
+          - os: 'macos-14'
             tests: 'fsleyes-plugin-shimming-toolbox'
           - os: 'macos-13'
             tests: 'fsleyes-plugin-shimming-toolbox'
@@ -39,10 +43,10 @@ jobs:
         run: |
           echo ~
           echo $HOME
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -73,7 +77,7 @@ jobs:
 
       - name: Cache SCT
         id: cache-sct
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/work/spinalcordtoolbox
           # Use commit hash file from previous step as key
@@ -146,13 +150,13 @@ jobs:
   coveralls:
     name: Finish Coveralls
     needs: test
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-24.04'
     steps:
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.10'
     - name: Finished
       run: |
         pip3 install --upgrade coveralls


### PR DESCRIPTION
## Description
This PR:

- Updates to actions/cache@v4
- Updates to actions/checkout@v4
- Updates to actions/setup-python@v5
- Removes macOS 12 testing
- Adds macOS 14 and macOS 15, Ubuntu 24.04 testing

