### PR TITLE
Remove runner ubuntu-20.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,6 @@ jobs:
           - 'macos-15'
           - 'ubuntu-24.04'
           - 'ubuntu-22.04'
-          - 'ubuntu-20.04'
         python-version:
           - '3.10'
         tests:


### PR DESCRIPTION
## Description
This PR removes the ubuntu-20.04 runner due to its deprecation on April 1st 2025.

## Linked issues
https://github.com/actions/runner-images/issues/11101
