### PR TITLE
Add single file output for real-time shimming (chronological-coil/slicewise-coil)

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
@@ -635,14 +635,18 @@ def _save_to_text_file_static(coil, coefs, list_slices, path_output, o_format, o
 @click.option('-o', '--output', 'path_output', type=click.Path(), default=os.path.abspath(os.curdir),
               show_default=True, help="Directory to output coil text file(s).")
 @click.option('--output-file-format-coil', 'o_format_coil',
-              type=click.Choice(['slicewise-ch', 'chronological-ch']), default='slicewise-ch', show_default=True,
+              type=click.Choice(['slicewise-ch', 'chronological-ch', 'chronological-coil', 'slicewise-coil']),
+              default='slicewise-ch', show_default=True,
               help="Syntax used to describe the sequence of shim events. "
                    "Use 'slicewise' to output in row 1, 2, 3, etc. the shim coefficients for slice "
                    "1, 2, 3, etc. Use 'chronological' to output in row 1, 2, 3, etc. the shim value "
                    "for trigger 1, 2, 3, etc. The trigger is an event sent by the scanner and "
-                   "captured by the controller of the shim amplifier. For both 'slicewice' and 'chronological', "
+                   "captured by the controller of the shim amplifier. For 'XXXXX-ch', "
                    "there will be one output file per coil channel (coil1_ch1.txt, coil1_ch2.txt, etc.). The static, "
-                   "time-varying and mean pressure are encoded in the columns of each file.")
+                   "time-varying and mean pressure are encoded in the columns of each file. For XXXXX-coil, there will "
+                   "be a single file per coil. The static and time-varying coefficients are encoded one after the "
+                   "other as columns (static-ch1, rt-ch1, static-ch2, rt-ch2, etc.). The mean pressure is encoded as "
+                   "the last row.")
 @click.option('--output-file-format-scanner', 'o_format_sph',
               type=click.Choice(['slicewise-ch', 'chronological-ch', 'gradient']), default='slicewise-ch',
               show_default=True,
@@ -1038,6 +1042,43 @@ def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_sli
                     if currents_riro is not None:
                         f.write(f"{currents_riro[i_shim, i_channel]:.12f}, ")
                     f.write(f"{mean_p:.4f},\n")
+
+        elif o_format == 'chronological-coil':
+            fname_output = os.path.join(path_output, f"coefs_coil{coil_number}_{coil.name}.txt")
+            with open(fname_output, 'w', encoding='utf-8') as f:
+                for i_shim in range(len(list_slices)):
+                    if options['fatsat']:
+                        for i_channel in range(n_channels):
+                            if default_st_coefs is None:
+                                # Output 0 (delta)
+                                f.write(f"{0:.1f}, {0:.1f}, ")
+                            else:
+                                # Output initial coefs (absolute)
+                                f.write(f"{default_st_coefs[i_channel]:.1f}, {0:.1f}, ")
+                        f.write("\n")
+
+                    for i_channel in range(n_channels):
+                        if currents_static is not None:
+                            f.write(f"{currents_static[i_shim, i_channel]:.6f}, ")
+                        if currents_riro is not None:
+                            f.write(f"{currents_riro[i_shim, i_channel]:.12f}, ")
+                    f.write("\n")
+                f.write(f"{mean_p:.4f},\n")
+
+        elif o_format == 'slicewise-coil':
+            fname_output = os.path.join(path_output, f"coefs_coil{coil_number}_{coil.name}.txt")
+            with open(fname_output, 'w', encoding='utf-8') as f:
+                # Each row will have one coef representing the static, riro and mean_p in slicewise order
+                n_slices = np.sum([len(a_tuple) for a_tuple in list_slices])
+                for i_slice in range(n_slices):
+                    i_shim = [list_slices.index(i) for i in list_slices if i_slice in i][0]
+                    for i_channel in range(n_channels):
+                        if currents_static is not None:
+                            f.write(f"{currents_static[i_shim, i_channel]:.6f}, ")
+                        if currents_riro is not None:
+                            f.write(f"{currents_riro[i_shim, i_channel]:.12f}, ")
+                    f.write("\n")
+                f.write(f"{mean_p:.4f},\n")
 
         else:  # o_format == 'gradient':
             f0 = 'f0'

--- a/shimming-toolbox/test/cli/test_cli_b0shim.py
+++ b/shimming-toolbox/test/cli/test_cli_b0shim.py
@@ -1148,6 +1148,98 @@ class TestCLIRealtime(object):
             for i_channel in range(9):
                 assert os.path.isfile(os.path.join(tmp, f"coefs_coil0_ch{i_channel}_Dummy_coil.txt"))
 
+    def test_cli_rt_custom_coil_chr_coil(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
+        with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+            # Save the inputs to the new directory
+            fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
+            fname_fm_json = os.path.join(tmp, 'fmap.json')
+            fname_mask = os.path.join(tmp, 'mask.nii.gz')
+            fname_anat = os.path.join(tmp, 'anat.nii.gz')
+            fname_anat_json = os.path.join(tmp, 'anat.json')
+            _save_inputs(nii_fmap=nii_fmap, fname_fmap=fname_fmap,
+                         nii_anat=nii_anat, fname_anat=fname_anat,
+                         nii_mask=nii_mask, fname_mask=fname_mask,
+                         fm_data=fm_data, fname_fm_json=fname_fm_json,
+                         anat_data=anat_data, fname_anat_json=fname_anat_json)
+
+            # Dummy coil
+            nii_dummy_coil, dummy_coil_constraints = _create_dummy_coil(nii_fmap)
+            fname_dummy_coil = os.path.join(tmp, 'dummy_coil.nii.gz')
+            nib.save(nii_dummy_coil, fname_dummy_coil)
+
+            # Save json
+            fname_constraints = os.path.join(tmp, 'dummy_coil.json')
+            with open(fname_constraints, 'w', encoding='utf-8') as f:
+                json.dump(dummy_coil_constraints, f, indent=4)
+
+            # Input pmu fname
+            fname_resp = os.path.join(__dir_testing__, 'ds_b0', 'derivatives', 'sub-realtime',
+                                      'sub-realtime_PMUresp_signal.resp')
+
+            runner = CliRunner()
+            res = runner.invoke(b0shim_cli, ['realtime-dynamic',
+                                             '--coil', fname_dummy_coil, fname_constraints,
+                                             '--coil-riro', fname_dummy_coil, fname_constraints,
+                                             '--fmap', fname_fmap,
+                                             '--anat', fname_anat,
+                                             '--mask-static', fname_mask,
+                                             '--mask-riro', fname_mask,
+                                             '--resp', fname_resp,
+                                             '--optimizer-method', 'pseudo_inverse',
+                                             '--output-file-format-coil', 'chronological-coil',
+                                             '--slice-factor', '2',
+                                             '--output', tmp],
+                                catch_exceptions=False)
+
+            assert res.exit_code == 0
+            assert os.path.isfile(os.path.join(tmp, f"coefs_coil0_Dummy_coil.txt"))
+
+    def test_cli_rt_custom_coil_sli_coil(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
+        with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+            # Save the inputs to the new directory
+            fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
+            fname_fm_json = os.path.join(tmp, 'fmap.json')
+            fname_mask = os.path.join(tmp, 'mask.nii.gz')
+            fname_anat = os.path.join(tmp, 'anat.nii.gz')
+            fname_anat_json = os.path.join(tmp, 'anat.json')
+            _save_inputs(nii_fmap=nii_fmap, fname_fmap=fname_fmap,
+                         nii_anat=nii_anat, fname_anat=fname_anat,
+                         nii_mask=nii_mask, fname_mask=fname_mask,
+                         fm_data=fm_data, fname_fm_json=fname_fm_json,
+                         anat_data=anat_data, fname_anat_json=fname_anat_json)
+
+            # Dummy coil
+            nii_dummy_coil, dummy_coil_constraints = _create_dummy_coil(nii_fmap)
+            fname_dummy_coil = os.path.join(tmp, 'dummy_coil.nii.gz')
+            nib.save(nii_dummy_coil, fname_dummy_coil)
+
+            # Save json
+            fname_constraints = os.path.join(tmp, 'dummy_coil.json')
+            with open(fname_constraints, 'w', encoding='utf-8') as f:
+                json.dump(dummy_coil_constraints, f, indent=4)
+
+            # Input pmu fname
+            fname_resp = os.path.join(__dir_testing__, 'ds_b0', 'derivatives', 'sub-realtime',
+                                      'sub-realtime_PMUresp_signal.resp')
+
+            runner = CliRunner()
+            res = runner.invoke(b0shim_cli, ['realtime-dynamic',
+                                             '--coil', fname_dummy_coil, fname_constraints,
+                                             '--coil-riro', fname_dummy_coil, fname_constraints,
+                                             '--fmap', fname_fmap,
+                                             '--anat', fname_anat,
+                                             '--mask-static', fname_mask,
+                                             '--mask-riro', fname_mask,
+                                             '--resp', fname_resp,
+                                             '--optimizer-method', 'pseudo_inverse',
+                                             '--output-file-format-coil', 'slicewise-coil',
+                                             '--slice-factor', '2',
+                                             '--output', tmp],
+                                catch_exceptions=False)
+
+            assert res.exit_code == 0
+            assert os.path.isfile(os.path.join(tmp, f"coefs_coil0_Dummy_coil.txt"))
+
     def test_cli_rt_debug(self, nii_fmap, nii_anat, nii_mask, fm_data, anat_data):
         with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
             # Save the inputs to the new directory


### PR DESCRIPTION
## Description
Add single file output for real-time shimming. The output will be in the format for slice wise-coil will be:

```
static_sli1_ch1, rt_sli1_ch1, static_sli1_ch2, rt_sli1_ch2, ..., static_sli1_chN, rt_sli1_chN,
static_sli2_ch1, rt_sli2_ch1, static_sli2_ch2, rt_sli2_ch2, ..., static_sli2_chN, rt_sli2_chN,
...
static_sliM_ch1, rt_sliM_ch1, static_sliM_ch2, rt_sliM_ch2, ..., static_sliM_chN, rt_sliM_chN,
mean_pressure
```
where M is the number of slices and N is the number of channels.

For chronological-coil, the output will be:

```
static_shim1_ch1, rt_shim1_ch1, static_shim1_ch2, rt_shim1_ch2, ..., static_shim1_chN, rt_shim1_chN,
static_shim2_ch1, rt_shim2_ch1, static_shim2_ch2, rt_shim2_ch2, ..., static_shim2_chN, rt_shim2_chN,
...
static_shimM_ch1, rt_shimM_ch1, static_shimM_ch2, rt_shimM_ch2, ..., static_shimM_chN, rt_shimM_chN,
mean_pressure
```
where M is the number of shim events and N is the number of channels.

## Linked issues
Progress towards #482 
