### PR TITLE
Add fix when dicom files have the same name

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/cli/sort_dicoms.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/sort_dicoms.py
@@ -37,6 +37,7 @@ def sort_dicoms(path_input, is_recursive, recursive_depth, path_output, verbose)
     # Create output directory
     create_output_dir(path_output)
 
+    extra = {}
     # For loop on all DICOMs in the directory
     for fname_dcm in sorted(list_dicoms):
         # Create the file path
@@ -50,7 +51,18 @@ def sort_dicoms(path_input, is_recursive, recursive_depth, path_output, verbose)
         if not os.path.isdir(path_folder_output):
             create_output_dir(path_folder_output)
 
-        fname_output = os.path.join(path_folder_output, os.path.basename(fname_dcm))
+        dcm_basename = os.path.basename(fname_dcm)
+        fname_output = os.path.join(path_folder_output, dcm_basename)
+        if os.path.exists(fname_output):
+            if extra.get(folder_name) is None:
+                extra[folder_name] = 0
+                logger.debug(f"Multiple files have the same name for acquisition {folder_name}. "
+                               f"Adding a suffix to the acquisition names.")
+
+            dcm_stem, dcm_ext = os.path.splitext(dcm_basename)
+            fname_output = os.path.join(path_output, folder_name, dcm_stem + f"_{extra[folder_name]}" + dcm_ext)
+            extra[folder_name] += 1
+
         # Copy files to the new folder
         shutil.copyfile(fname_dcm, fname_output)
 

--- a/shimming-toolbox/test/cli/test_cli_sort_dicoms.py
+++ b/shimming-toolbox/test/cli/test_cli_sort_dicoms.py
@@ -49,3 +49,21 @@ def test_sort_dicoms_cli_recursive():
         outputs = os.listdir(path_output)
         assert '06-a_gre_DYNshim' in outputs
         assert '07-a_gre_DYNshim' in outputs
+
+
+def test_sort_dicoms_cli_recursive_same_name():
+    path = os.path.join(__dir_testing__, 'dicom_unsorted')
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        path_subfolder = copy.deepcopy(tmp)
+        for i_subfolder in range(1, 5):
+            path_subfolder = os.path.join(path_subfolder, 'subfolder' + str(i_subfolder))
+            os.mkdir(path_subfolder)
+
+        path_new_dicoms = os.path.join(path_subfolder, 'dicoms')
+        shutil.copytree(path, path_new_dicoms)
+        shutil.copyfile(os.path.join(path_new_dicoms, "001_000001_000001.dcm"), os.path.join(path_subfolder, "001_000001_000001.dcm"))
+
+        path_output = os.path.join(tmp, 'sorted')
+        result = CliRunner().invoke(sort_dicoms, ['-i', tmp, '-r', '-o', path_output], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert os.path.isfile(os.path.join(path_output, '06-a_gre_DYNshim', "001_000001_000001_0.dcm"))


### PR DESCRIPTION
## Description
If the input DICOMS are in different folders (using -r option) and that they have the same name, they will be copied in the same directory and will create a name conflict (only one of the two files will be copied). To fix that, we check that the output file does not already exist, if it does, we append a suffix.