### PR TITLE
Temp fix for dcm2niix no building wheel bug

### DIFF
--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -40,7 +40,7 @@ function edit_shellrc() {
 source "${ST_DIR}/${PYTHON_DIR}/bin/activate"
 
 print info "Installing python"
-"$ST_DIR"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge python=3.10
+"$ST_DIR"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge python=3.10 dcm2niix=1.0.20241211
 
 print info "Installing shimming-toolbox"
 cp "${ST_PACKAGE_DIR}/shimmingtoolbox/config/dcm2bids.json" "${ST_DIR}/dcm2bids.json"

--- a/shimming-toolbox/requirements_st.txt
+++ b/shimming-toolbox/requirements_st.txt
@@ -2,7 +2,6 @@ click
 cloup
 dataclasses
 dcm2bids>=3.0.1
-dcm2niix>=1.0.20241211
 importlib-metadata
 joblib
 matplotlib>=3.5


### PR DESCRIPTION
## Description
dcm2niix is failing when installing through pypi. This makes it impossible to install Shimming Toolbox the normal way. This PR uses conda to circumvent the problem. Note that this means that dcm2niix is not in the requirement file anymore, which is a problem. The real fix should come from dcm2niix.

## To install using this branch
```
git clone https://github.com/shimming-toolbox/shimming-toolbox.git
cd shimming-toolbox
git checkout ad/dcm2niix-wheel
make install
```

## Linked issues
#602 
