### PR TITLE
Update dcm2niix to v1.0.20250506

### DIFF
--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -40,7 +40,7 @@ function edit_shellrc() {
 source "${ST_DIR}/${PYTHON_DIR}/bin/activate"
 
 print info "Installing python"
-"$ST_DIR"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge python=3.10 dcm2niix=1.0.20241211
+"$ST_DIR"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge python=3.10
 
 print info "Installing shimming-toolbox"
 cp "${ST_PACKAGE_DIR}/shimmingtoolbox/config/dcm2bids.json" "${ST_DIR}/dcm2bids.json"

--- a/shimming-toolbox/requirements_st.txt
+++ b/shimming-toolbox/requirements_st.txt
@@ -11,7 +11,7 @@ numpy>=1.21
 phantominator~=0.6.4
 pillow>=9.0.0
 psutil>=5.8.0
-pydicom
+pydicom~=2.4.4
 pytest>=6.2.5
 pytest-cov>=2.5.1
 quadprog

--- a/shimming-toolbox/requirements_st.txt
+++ b/shimming-toolbox/requirements_st.txt
@@ -2,6 +2,7 @@ click
 cloup
 dataclasses
 dcm2bids>=3.0.1
+dcm2niix>=1.0.20250506
 importlib-metadata
 joblib
 matplotlib>=3.5


### PR DESCRIPTION
## Description
This PR updates to the latest dcm2niix version: v1.0.20250506. The PR also installs dcm2niix from pypi to revert a temporary fix done in #603 while we were waiting for this release.

The PR also fixed pydicom to v2.4.4 to avoid a dependency conflict with XNAT v0.7.2 that arises when installing the plugin and ST in the same venv.

## Linked issues
Fixes #602 
