### PR TITLE
Unify regularization methods. Use L2 regularization in all optimization methods.

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/optimizer/bfgs_optimizer.py
+++ b/shimming-toolbox/shimmingtoolbox/optimizer/bfgs_optimizer.py
@@ -18,9 +18,9 @@ class BFGSOpt(LsqOptimizer):
         """ Minimize the criteria function using scipy's minimize function. """
 
         if self.opt_criteria == 'mse':
-            a, b, c = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
+            a, b, c, e = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
             currents_sp = opt.minimize(self._criteria_func, currents_0,
-                                       args=(a, b, c),
+                                       args=(a, b, c, e),
                                        method='L-BFGS-B',
                                        bounds=self.merged_bounds,
                                        jac=self._jacobian_func,
@@ -56,9 +56,9 @@ class PmuBFGSOpt(PmuLsqOptimizer):
         """ Minimize the criteria function using scipy's minimize function. """
 
         if self.opt_criteria == 'mse':
-            a, b, c = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
+            a, b, c, e = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
             currents_sp = opt.minimize(self._criteria_func, currents_0,
-                                       args=(a, b, c),
+                                       args=(a, b, c, e),
                                        method='L-BFGS-B',
                                        bounds=self.rt_bounds,
                                        jac=self._jacobian_func,

--- a/shimming-toolbox/shimmingtoolbox/optimizer/bfgs_optimizer.py
+++ b/shimming-toolbox/shimmingtoolbox/optimizer/bfgs_optimizer.py
@@ -18,18 +18,18 @@ class BFGSOpt(LsqOptimizer):
         """ Minimize the criteria function using scipy's minimize function. """
 
         if self.opt_criteria == 'mse':
-            a, b, c, e = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
+            a, b, c = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
             currents_sp = opt.minimize(self._criteria_func, currents_0,
-                                       args=(a, b, c, e),
+                                       args=(a, b, c),
                                        method='L-BFGS-B',
                                        bounds=self.merged_bounds,
                                        jac=self._jacobian_func,
                                        options={'maxiter': 10000, 'ftol': 1e-9})
 
         elif self.opt_criteria == 'mse_signal_recovery':
-            a, b, c, e = self.get_quadratic_term_grad(unshimmed_vec, coil_mat, factor)
+            a, b, c = self.get_quadratic_term_grad(unshimmed_vec, coil_mat, factor)
             currents_sp = opt.minimize(self._criteria_func, currents_0,
-                                       args=(a, b, c, e),
+                                       args=(a, b, c),
                                        method='L-BFGS-B',
                                        bounds=self.merged_bounds,
                                        jac=self._jacobian_func,
@@ -56,9 +56,9 @@ class PmuBFGSOpt(PmuLsqOptimizer):
         """ Minimize the criteria function using scipy's minimize function. """
 
         if self.opt_criteria == 'mse':
-            a, b, c, e = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
+            a, b, c = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
             currents_sp = opt.minimize(self._criteria_func, currents_0,
-                                       args=(a, b, c, e),
+                                       args=(a, b, c),
                                        method='L-BFGS-B',
                                        bounds=self.rt_bounds,
                                        jac=self._jacobian_func,

--- a/shimming-toolbox/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimming-toolbox/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -190,6 +190,14 @@ class LsqOptimizer(OptimizerUtils):
         # The first version was :
         # np.mean((unshimmed_vec + np.sum(coil_mat * coef, axis=1, keepdims=False))**2) / factor + \ (
         # self.reg_factor * np.mean(np.abs(coef) / self.reg_factor_channel))
+        # For the second version we switched np.sum(coil_mat*coef,axis=1,keepdims=False) by coil_mat@coef
+        # which is way faster Then for a vector, mean(x**2) is equivalent to x.dot( x)/n
+        # it's faster to do this operation instead of a np.mean Finally np.abs(coef).dot(self.reg_vector) is
+        # equivalent and faster to self.reg_factor*np.mean(np.abs(coef) / self.reg_factor_channel) For the
+        # mathematical demonstration see : https://github.com/shimming-toolbox/shimming-toolbox/pull/432
+        # This gave us the following expression for the residuals mse :
+        # shimmed_vec = unshimmed_vec + coil_mat @ coef
+        # mse = (shimmed_vec).dot(shimmed_vec) / len(unshimmed_vec) / factor + np.abs(coef).dot(self.reg_vector)
         # The new expression is the fastest way to optimize since quadratic terms a, b and c are computed
         # only once in scipy_minimize. See PR#451 for more details.
         return coef.T @ a @ coef + b @ coef + c

--- a/shimming-toolbox/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimming-toolbox/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -377,8 +377,8 @@ class LsqOptimizer(OptimizerUtils):
 
     def get_quadratic_term_grad(self, unshimmed_vec, coil_mat, factor):
         """
-        Returns all the quadratic terms used in MSE signal recovery objective function used in the least
-        squares optimization method
+        Returns all the quadratic terms used in the MSE signal recovery objective function used in the
+        least squares and BFGS optimization methods.
 
         Args:
             unshimmed_vec (np.ndarray): 1D flattened array (point) of the masked unshimmed map
@@ -424,7 +424,7 @@ class LsqOptimizer(OptimizerUtils):
 
         # Combining the terms
         # Adding the regularization vector to 'a' ensures L2 regularization
-        # (sum of squares of the regularization terms) since 'a' is multiplied
+        # (sum of the squared regularization terms) since 'a' is multiplied
         # twice with 'coef' in _residuals_mse()
         a = a1 + a2 + a3 + a4 + np.diag(self.reg_vector)
         b = b1 + b2 + b3 + b4

--- a/shimming-toolbox/shimmingtoolbox/optimizer/optimizer_utils.py
+++ b/shimming-toolbox/shimmingtoolbox/optimizer/optimizer_utils.py
@@ -143,8 +143,8 @@ class OptimizerUtils(Optimizer):
 
     def get_quadratic_term(self, unshimmed_vec, coil_mat, factor):
         """
-        Returns all the quadratic terms used in MSE objective function used in the least squares,
-        quadprog and BFGS optimization methods. For more details see PR#451.
+        Returns all the quadratic terms used in the MSE objective function used in the least squares,
+        quadprog and BFGS optimization methods. For more details, see PR#451.
 
         Args:
             unshimmed_vec (np.ndarray): 1D flattened array (point) of the masked unshimmed map
@@ -163,7 +163,7 @@ class OptimizerUtils(Optimizer):
 
         inv_factor = 1 / (len(unshimmed_vec) * factor)
         # Adding the regularization vector to 'a' ensures L2 regularization
-        # (sum of squares of the regularization terms) since 'a' is multiplied
+        # (sum of the squared regularization terms) since 'a' is multiplied
         # twice with 'coef' in _residuals_mse()
         a = (coil_mat.T @ coil_mat) * inv_factor + np.diag(self.reg_vector)
         b = 2 * inv_factor * (unshimmed_vec @ coil_mat)

--- a/shimming-toolbox/shimmingtoolbox/optimizer/optimizer_utils.py
+++ b/shimming-toolbox/shimmingtoolbox/optimizer/optimizer_utils.py
@@ -158,17 +158,18 @@ class OptimizerUtils(Optimizer):
                 * np.ndarray: 2D array using for the optimization
                 * np.ndarray: 1D flattened array used for the optimization
                 * float : Float used for the least squares optimizer
-                * np.ndarray : 1D array used to regularize the optimization
 
         """
 
         inv_factor = 1 / (len(unshimmed_vec) * factor)
-        a = (coil_mat.T @ coil_mat) * inv_factor
+        # Adding the regularization vector to 'a' ensures L2 regularization
+        # (sum of squares of the regularization terms) since 'a' is multiplied
+        # twice with 'coef' in _residuals_mse()
+        a = (coil_mat.T @ coil_mat) * inv_factor + np.diag(self.reg_vector)
         b = 2 * inv_factor * (unshimmed_vec @ coil_mat)
         c = inv_factor * (unshimmed_vec @ unshimmed_vec)
-        e = self.reg_vector
 
-        return a, b, c, e
+        return a, b, c
 
     @abstractmethod
     def _get_currents(self, unshimmed_vec, coil_mat, currents_0):

--- a/shimming-toolbox/shimmingtoolbox/optimizer/optimizer_utils.py
+++ b/shimming-toolbox/shimmingtoolbox/optimizer/optimizer_utils.py
@@ -143,8 +143,8 @@ class OptimizerUtils(Optimizer):
 
     def get_quadratic_term(self, unshimmed_vec, coil_mat, factor):
         """
-        Returns all the quadratic terms used in the lsq_optimizer for the mse method, and for the quadprog optimizer,
-        for more details see PR#451
+        Returns all the quadratic terms used in MSE objective function used in the least squares,
+        quadprog and BFGS optimization methods. For more details see PR#451.
 
         Args:
             unshimmed_vec (np.ndarray): 1D flattened array (point) of the masked unshimmed map
@@ -158,15 +158,17 @@ class OptimizerUtils(Optimizer):
                 * np.ndarray: 2D array using for the optimization
                 * np.ndarray: 1D flattened array used for the optimization
                 * float : Float used for the least squares optimizer
+                * np.ndarray : 1D array used to regularize the optimization
 
         """
 
         inv_factor = 1 / (len(unshimmed_vec) * factor)
-        a = (coil_mat.T @ coil_mat) * inv_factor + np.diag(self.reg_vector)
+        a = (coil_mat.T @ coil_mat) * inv_factor
         b = 2 * inv_factor * (unshimmed_vec @ coil_mat)
         c = inv_factor * (unshimmed_vec @ unshimmed_vec)
+        e = self.reg_vector
 
-        return a, b, c
+        return a, b, c, e
 
     @abstractmethod
     def _get_currents(self, unshimmed_vec, coil_mat, currents_0):

--- a/shimming-toolbox/shimmingtoolbox/optimizer/quadprog_optimizer.py
+++ b/shimming-toolbox/shimmingtoolbox/optimizer/quadprog_optimizer.py
@@ -108,7 +108,7 @@ class QuadProgOpt(OptimizerUtils):
             float: Residuals for quad_prog optimization
         """
         shimmed_vec = unshimmed_vec + coil_mat @ coef
-        return shimmed_vec.dot(shimmed_vec) / len(unshimmed_vec) / factor + np.abs(coef).dot(self.reg_vector)
+        return shimmed_vec.dot(shimmed_vec) / len(unshimmed_vec) / factor + np.square(coef).dot(self.reg_vector)
 
     def _get_currents(self, unshimmed_vec, coil_mat, currents_0):
         """
@@ -165,7 +165,7 @@ class QuadProgOpt(OptimizerUtils):
 
         initial_guess = np.zeros(2 * n)
         initial_guess[:n] = currents_0
-        a, b, _, _ = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
+        a, b, _ = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
         epsilon = 1e-6
         cost_matrix = np.block([[a, np.zeros([n, n])], [np.zeros([n, n]), np.zeros([n, n])]]) + epsilon * np.eye(2*n)
         cost_matrix = 2 * cost_matrix

--- a/shimming-toolbox/shimmingtoolbox/optimizer/quadprog_optimizer.py
+++ b/shimming-toolbox/shimmingtoolbox/optimizer/quadprog_optimizer.py
@@ -165,7 +165,7 @@ class QuadProgOpt(OptimizerUtils):
 
         initial_guess = np.zeros(2 * n)
         initial_guess[:n] = currents_0
-        a, b, _ = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
+        a, b, _, _ = self.get_quadratic_term(unshimmed_vec, coil_mat, factor)
         epsilon = 1e-6
         cost_matrix = np.block([[a, np.zeros([n, n])], [np.zeros([n, n]), np.zeros([n, n])]]) + epsilon * np.eye(2*n)
         cost_matrix = 2 * cost_matrix

--- a/shimming-toolbox/test/cli/test_cli_b0shim.py
+++ b/shimming-toolbox/test/cli/test_cli_b0shim.py
@@ -113,7 +113,7 @@ class TestCliDynamic(object):
                 line = lines[8].strip().split(',')
                 values = [float(val) for val in line if val.strip()]
 
-            assert values == [0.002985, -14.587414, -57.016499, -2.745062, -0.401786, -3.580623, 0.668977, -0.105560]
+            assert values == [4.690057, -8.291199, -65.703276, -3.320815, -0.68741, -7.032426, 1.85338, -0.311091]
 
     def test_cli_dynamic_bfgs(self, nii_fmap, nii_target, nii_mask, fm_data, target_data):
         """Test cli with scanner coil profiles of order 1 with default constraints"""
@@ -150,7 +150,7 @@ class TestCliDynamic(object):
                 line = lines[8].strip().split(',')
                 values = [float(val) for val in line if val.strip()]
 
-            assert values == [1.716835, -11.083139, -61.813942, -3.325865, -0.440464, -4.319224, 0.832832, -0.092054]
+            assert values == [17.507848, 26.353976, -66.885465, -43.5857, -162.701991, -539.847684, 350.550789, -185.954958]
 
     def test_cli_dynamic_external_scanner_constraint(self, nii_fmap, nii_target, nii_mask, fm_data, target_data):
         """Test cli with scanner coil profiles of order 1 with default constraints"""

--- a/shimming-toolbox/test/cli/test_cli_b0shim.py
+++ b/shimming-toolbox/test/cli/test_cli_b0shim.py
@@ -113,7 +113,7 @@ class TestCliDynamic(object):
                 line = lines[8].strip().split(',')
                 values = [float(val) for val in line if val.strip()]
 
-            assert values == [4.690057, -8.291199, -65.703276, -3.320815, -0.68741, -7.032426, 1.85338, -0.311091]
+            assert values == [0.002985, -14.587414, -57.016499, -2.745062, -0.401786, -3.580623, 0.668977, -0.105560]
 
     def test_cli_dynamic_bfgs(self, nii_fmap, nii_target, nii_mask, fm_data, target_data):
         """Test cli with scanner coil profiles of order 1 with default constraints"""
@@ -150,7 +150,7 @@ class TestCliDynamic(object):
                 line = lines[8].strip().split(',')
                 values = [float(val) for val in line if val.strip()]
 
-            assert values == [17.507848, 26.353976, -66.885465, -43.5857, -162.701991, -539.847684, 350.550789, -185.954958]
+            assert values == [1.373283, -11.059556, -61.822843, -2.538095, -0.014962, -3.914447, 0.551654, -0.370477]
 
     def test_cli_dynamic_external_scanner_constraint(self, nii_fmap, nii_target, nii_mask, fm_data, target_data):
         """Test cli with scanner coil profiles of order 1 with default constraints"""

--- a/shimming-toolbox/test/optimizer/test_optimizer.py
+++ b/shimming-toolbox/test/optimizer/test_optimizer.py
@@ -96,11 +96,11 @@ class TestResiduals:
                            unshimmed=self.unshimmed,
                            affine=np.eye(4))
         opt.reg_vector = self.reg_vector
-        a, b, c, e = opt.get_quadratic_term(self.unshimmed_vec, self.coil_mat, self.factor)
-        res = opt._residuals_mse(self.coef, a, b, c, e)
+        a, b, c = opt.get_quadratic_term(self.unshimmed_vec, self.coil_mat, self.factor)
+        res = opt._residuals_mse(self.coef, a, b, c)
 
         shimmed_vec = self.unshimmed_vec + self.coil_mat @ self.coef
         mse = np.sum(np.square(shimmed_vec)) / len(self.mask_coefficients)
-        ref = mse / self.factor + np.abs(self.coef).dot(self.reg_vector)
+        ref = mse / self.factor + np.square(self.coef).dot(self.reg_vector)
 
         assert np.isclose(res, ref, atol=1e-12)

--- a/shimming-toolbox/test/optimizer/test_optimizer.py
+++ b/shimming-toolbox/test/optimizer/test_optimizer.py
@@ -81,10 +81,10 @@ class TestResiduals:
         # Coefficients
         self.coef = np.random.rand(nb_channels)
 
-        # Regularisation vector
+        # Regularization vector
         self.reg_vector = np.ones(nb_channels)
 
-        # Refularisation factor
+        # Regularization factor
         self.factor = 1
 
         # Delta variable for ps_huber residuals


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR. (You need to choose: the scope of the PR, 1 or more (pale brown), the main reason for the PR, only 1 (dark purple) and if applicable, the CLI affected (dark cyan))
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

## Description

With PR #451, quadratic terms were implemented to accelerate the optimization process with the MSE objective function. In the process, the regularization method was changed from L1 (sum of the absolute values of the terms) to L2 (sum of the squared terms). Since then, (nearly) all objective functions use L1 regularization, but the MSE objective function uses L2 regularization. This PR corrects this issue by unifying regularization methods to L2 for all objectif functions and documents its effects on implicated optimization methods.

## Changes in optimization methods

The dataset used includes the following elements: 
- Configuration files for a custom 32-channel coil
- Target EPI of a brain (dimensions : 174 x 174 x 50 px)
- Fieldmap acquired using a GRE sequence (dimensions : 112 x 112 x 70 px)
- Brain mask (dimensions : 112 x 112 x 70 px)

All tests have been used with the following parameters : 
- `--mask-dilation-kernel-size` = 3
- `--regularization-factor`= 0.3

### Least squares method (objective function : MAE)
Master : 
<details>
<summary>fig_currents</summary>
<img width="1000" height="1000" alt="fig_currents" src="https://github.com/user-attachments/assets/ccca4221-0979-4cfd-9a2d-991d29570e2b" />
</details>
<details>
<summary>fig_shimmed_vs_unshimmed</summary>
<img width="1230" height="686" alt="fig_shimmed_vs_unshimmed" src="https://github.com/user-attachments/assets/f9d59792-8d5a-43ec-b02b-3edf428d9db7" />
</details>

PR #626 :
<details>
<summary>fig_currents</summary>
<img width="1000" height="1000" alt="fig_currents" src="https://github.com/user-attachments/assets/a6a780c2-cac3-4751-bec0-686d86a42d5a" />
</details>
<details>
<summary>fig_shimmed_vs_unshimmed</summary>
<img width="1230" height="686" alt="fig_shimmed_vs_unshimmed" src="https://github.com/user-attachments/assets/e76e2906-d004-47a2-bcc5-b65faa57068d" />
</details>

### Least squares method (objective function : RMSE)
Master : 
<details>
<summary>fig_currents</summary>
<img width="1000" height="1000" alt="fig_currents" src="https://github.com/user-attachments/assets/40c2a913-c98d-437f-93cc-27df575d2e54" />
</details>
<details>
<summary>fig_shimmed_vs_unshimmed</summary>
<img width="1230" height="686" alt="fig_shimmed_vs_unshimmed" src="https://github.com/user-attachments/assets/dfe6344c-da2d-427b-8960-1c9fbf6901b5" />
</details>

PR #626 :
<details>
<summary>fig_currents</summary>
<img width="1000" height="1000" alt="fig_currents" src="https://github.com/user-attachments/assets/67532411-7539-4407-a651-362e6f14fe46" />
</details>
<details>
<summary>fig_shimmed_vs_unshimmed</summary>
<img width="1230" height="686" alt="fig_shimmed_vs_unshimmed" src="https://github.com/user-attachments/assets/0ae7ca3f-ee05-44da-849e-565f612558d9" />
</details>

### Least squares method (objective function : ps-huber)
Master : 
<details>
<summary>fig_currents</summary>
<img width="1000" height="1000" alt="fig_currents" src="https://github.com/user-attachments/assets/a7fb96ee-69ea-4ee1-aa36-34565a4e9065" />
</details>
<details>
<summary>fig_shimmed_vs_unshimmed</summary>
<img width="1230" height="686" alt="fig_shimmed_vs_unshimmed" src="https://github.com/user-attachments/assets/304c4f79-7325-40cb-981f-6711eec0dba7" />
</details>

PR #626 :
<details>
<summary>fig_currents</summary>
<img width="1000" height="1000" alt="fig_currents" src="https://github.com/user-attachments/assets/dea659ed-bdd4-4291-acb1-8f89be4ec322" />
</details>
<details>
<summary>fig_shimmed_vs_unshimmed</summary>
<img width="1230" height="686" alt="fig_shimmed_vs_unshimmed" src="https://github.com/user-attachments/assets/2c1c0d12-03b8-4623-886e-4405b34a28a7" />
</details>

> [!NOTE]
> A similar analysis could be done with the BFGS method