### PR TITLE
Fix MSE jacobian regularization

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/optimizer/lsq_optimizer.py
+++ b/shimming-toolbox/shimmingtoolbox/optimizer/lsq_optimizer.py
@@ -294,7 +294,7 @@ class LsqOptimizer(OptimizerUtils):
         # The first version was :
         # 2/(len(unshimmed_vec * factor) * (unshimmed_vec + coil_mat @ coef) @ coil_mat + np.sign(coef) * self.reg_vector
         # The new version uses the quadratic terms implemented with PR#451
-        return 2 * a @ coef + b + np.sign(coef) * self.reg_vector
+        return 2 * a @ coef + b
 
     def _define_scipy_constraints(self):
         return self._define_scipy_coef_sum_max_constraint()

--- a/shimming-toolbox/test/cli/test_cli_b0shim.py
+++ b/shimming-toolbox/test/cli/test_cli_b0shim.py
@@ -150,7 +150,7 @@ class TestCliDynamic(object):
                 line = lines[8].strip().split(',')
                 values = [float(val) for val in line if val.strip()]
 
-            assert values == [1.373283, -11.059556, -61.822843, -2.538095, -0.014962, -3.914447, 0.551654, -0.370477]
+            assert values == [1.716835, -11.083139, -61.813942, -3.325865, -0.440464, -4.319224, 0.832832, -0.092054]
 
     def test_cli_dynamic_external_scanner_constraint(self, nii_fmap, nii_target, nii_mask, fm_data, target_data):
         """Test cli with scanner coil profiles of order 1 with default constraints"""


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR. (You need to choose: the scope of the PR, 1 or more (pale brown), the main reason for the PR, only 1 (dark purple) and if applicable, the CLI affected (dark cyan))
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

## Description
After merging PR #626, we observed the Jacobian for MSE residuals added the regularization vector, but it is already included in the `a` quadratic term, so we removed it.