### PR TITLE
Add ability to create masks for single voxel MRS using .sdat/.spar files

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/cli/download_data.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/download_data.py
@@ -15,7 +15,7 @@ from shimmingtoolbox.download import install_data
 
 URL_DICT: Dict[str, Tuple[List[str], str]] = {
     "testing_data": (
-        ["https://github.com/shimming-toolbox/data-testing/archive/r20250120.zip"],
+        ["https://github.com/shimming-toolbox/data-testing/archive/r20260216.zip"],
         "Light-weighted dataset for testing purpose.",
     ),
     "prelude": (

--- a/shimming-toolbox/shimmingtoolbox/cli/mask.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/mask.py
@@ -404,13 +404,15 @@ def mrs(fname_input, output, mrs_data, center, size, verbose):
     Create a NIfTI file mask to shim single voxel MRS in the given --input geometry. Voxel position and size can be
     directly given or these info can be inferred from MRS raw-data given as an argument.
 
+    \b
+    Optional argument:
     MRS_DATA: Input path(s) of the raw-data (Supported inputs: Single .rda file, pair of .SPAR/.SDAT files)
 
+    \b
     Example:
-    st_mask mrs -i target.nii.gz mrs_data.rda -o mask_mrs.nii.gz
+    st_mask mrs mrs_data.rda -i target.nii.gz -o mask_mrs.nii.gz
     st_mask mrs mrs_data.sdat mrs_data.spar -i fieldmap.nii.gz -o mask_mrs.nii.gz
     st_mask mrs -i target.nii.gz -o mask_mrs.nii.gz --size 20 20 20 --center 0 0 0
-
     """
 
     set_all_loggers(verbose)

--- a/shimming-toolbox/shimmingtoolbox/cli/mask.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/mask.py
@@ -388,16 +388,10 @@ def modify_binary_mask(fname_input, fname_output, shape, size, operation, verbos
     return fname_output
 
 
-@mask_cli.command(context_settings=CONTEXT_SETTINGS,
-                  help="Create a mask to shim single voxel MRS. "
-                       "Voxel position and size can be directly given or these info can be read "
-                       "from the siemens raw-data. "
-                       "The mask is stored by default under the name 'mask_mrs.nii.gz' in the output "
-                       "folder. Return an output nifti file to be used as a mask for MRS shimming.")
+@mask_cli.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('mrs_data', nargs=-1, type=click.Path(exists=True), required=False)
 @click.option('-i', '--input', 'fname_input', type=click.Path(), required=True,
-              help="Input path of the fieldmap to be shimmed.")
-@click.option('-r', '--raw', 'raw_data', type=click.Path(),
-              help="Input path of the raw-data (supported extention .rda)")
+              help="Input path of the target geometry to mask.")
 @click.option('-o', '--output', type=click.Path(), default=os.path.join(os.curdir, 'mask_mrs.nii.gz'),
               show_default=True, help="Name of the output mask. Supported extensions are .nii or .nii.gz.")
 @click.option('-c', '--center', nargs=3, type=click.FLOAT, help="Voxel's center position in mm of the x, y and z of "
@@ -405,7 +399,19 @@ def modify_binary_mask(fname_input, fname_output, shape, size, operation, verbos
 @click.option('-s', '--size', nargs=3, type=click.FLOAT, help="Voxel size in mm of the x, y and z of the scanner's "
               "coordinate")
 @click.option('--verbose', type=click.Choice(['info', 'debug']), default='info', help="Be more verbose")
-def mrs(fname_input, output, raw_data, center, size, verbose):
+def mrs(fname_input, output, mrs_data, center, size, verbose):
+    """
+    Create a NIfTI file mask to shim single voxel MRS in the given --input geometry. Voxel position and size can be
+    directly given or these info can be inferred from MRS raw-data given as an argument.
+
+    MRS_DATA: Input path(s) of the raw-data (Supported inputs: Single .rda file, pair of .SPAR/.SDAT files)
+
+    Example:
+    st_mask mrs -i target.nii.gz mrs_data.rda -o mask_mrs.nii.gz
+    st_mask mrs mrs_data.sdat mrs_data.spar -i fieldmap.nii.gz -o mask_mrs.nii.gz
+    st_mask mrs -i target.nii.gz -o mask_mrs.nii.gz --size 20 20 20 --center 0 0 0
+
+    """
 
     set_all_loggers(verbose)
 
@@ -413,7 +419,7 @@ def mrs(fname_input, output, raw_data, center, size, verbose):
     create_output_dir(output, is_file=True)
 
     nii = nib.load(fname_input)
-    output_mask = mask_mrs(fname_input, raw_data, center, size)  # creation of the MRS mask
+    output_mask = mask_mrs(fname_input, mrs_data, center, size)  # creation of the MRS mask
     output_mask = output_mask.astype(np.int32)
     nii_img = nib.Nifti1Image(output_mask, nii.affine, header=nii.header)
     nib.save(nii_img, output)

--- a/shimming-toolbox/shimmingtoolbox/config/dcm2bids.json
+++ b/shimming-toolbox/shimmingtoolbox/config/dcm2bids.json
@@ -1049,6 +1049,26 @@
         },
         {
             "datatype": "anat",
+            "suffix": "T2wTSE2D",
+            "criteria": {
+                "Manufacturer": "Philips",
+                "PulseSequenceName": "TSE",
+                "MRAcquisitionType": "2D",
+                "ImageType": ["ORIGINAL", "PRIMARY", "M", "SE", "M", "SE", "MAGNITUDE"]
+            }
+        },
+                {
+            "datatype": "anat",
+            "suffix": "T2wTSE3D",
+            "criteria": {
+                "Manufacturer": "Philips",
+                "PulseSequenceName": "TSE",
+                "MRAcquisitionType": "3D",
+                "ImageType": ["ORIGINAL", "PRIMARY", "M", "SE", "M", "SE", "MAGNITUDE"]
+            }
+        },
+        {
+            "datatype": "anat",
             "suffix": "FFE",
             "criteria": {
                 "Manufacturer": "Philips",

--- a/shimming-toolbox/shimmingtoolbox/files/NiftiFile.py
+++ b/shimming-toolbox/shimmingtoolbox/files/NiftiFile.py
@@ -343,7 +343,7 @@ class NiftiFile:
         }
 
         # get_shim_orders
-        shim_settings_list = self.get_json_info('ShimSetting')
+        shim_settings_list = self.get_json_info('ShimSetting', required=False)
         if shim_settings_list is not None:
             n_shim_values = len(shim_settings_list)
             if n_shim_values == 3:

--- a/shimming-toolbox/shimmingtoolbox/masking/mask_mrs.py
+++ b/shimming-toolbox/shimmingtoolbox/masking/mask_mrs.py
@@ -13,29 +13,34 @@ import numpy.linalg as npl
 import pathlib
 import tempfile
 
-from shimmingtoolbox.utils import splitext
-from shimmingtoolbox.utils import run_subprocess
+from shimmingtoolbox.utils import splitext, run_subprocess
+from shimmingtoolbox.coils.coordinates import resample_from_to
 
 logger = logging.getLogger(__name__)
 
 
-def mask_mrs(fname_input, raw_data, center, size):
+def mask_mrs(fname_input, raw_datas, center, size):
     """
     Create a mask to shim single voxel MRS
 
     Args:
         fname_input (str): Input path of the fieldmap to be shimmed (supported extension .nii and .nii.gz)
-        raw_data (str): Input path of the siemens raw-data (supported extension .rda)
+        raw_datas (list): Input list of paths of the  raw-data (supported extension .rda, .spar/.sdat)
         center (list): Voxel's center position in mm of the x, y and z scanner coordinates
         size (list): Voxel size in mm of the x, y and z scanner coordinates
     Returns:
         numpy.ndarray: Cubic mask with the same dimensions as the MRS voxel.
+
+    Notes:
+        raw_datas is a list containing the required files for MRS conversion. Here are supported formats:
+        - Single file .rda (Siemens)
+        - Two files .spar/.sdat (Philips)
     """
 
     if fname_input is None:
         raise TypeError(f"The input field map needs to be specified")
 
-    if raw_data is None:
+    if raw_datas is None:
         logger.info("MRS raw data not provided, creating the mask with the given voxel position and size info")
         if center is None or size is None:
             raise TypeError('The raw_data is not provided; the voxel position and size are required to proceed')
@@ -48,21 +53,45 @@ def mask_mrs(fname_input, raw_data, center, size):
     else:
         logger.info("Reading the raw_data")
         with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
-            basename = os.path.basename(raw_data)
-            run_subprocess(['spec2nii', 'rda', '-o', tmp, '-f', basename, raw_data])
+            # Handle rda files
+            if is_rda_file(raw_datas[0]):
+                if len(raw_datas) != 1:
+                    raise ValueError("For .rda files, only one file should be provided")
+
+                basename = os.path.basename(splitext(raw_datas[0])[0])
+                run_subprocess(['spec2nii', 'rda', '-o', tmp, '-f', basename, raw_datas[0]])
+
+            elif ((is_spar_file(raw_datas[0]) and is_sdat_file(raw_datas[1])) or
+                  (is_spar_file(raw_datas[1]) and is_sdat_file(raw_datas[0]))):
+                if len(raw_datas) != 2:
+                    raise ValueError("For .spar/.sdat files, two files should be provided")
+
+                # Order to sdat/spar
+                if is_sdat_file(raw_datas[0]):
+                    raw_data_sdat_spar = [raw_datas[0], raw_datas[1]]
+                else:
+                    raw_data_sdat_spar = [raw_datas[1], raw_datas[0]]
+
+                basename = os.path.basename(splitext(raw_data_sdat_spar[0])[0])
+                run_subprocess(['spec2nii', 'philips', '-o', tmp, '-f', basename, raw_data_sdat_spar[0], raw_data_sdat_spar[1]])
+            else:
+                raise ValueError("Unsupported raw_data format. Supported formats are: .rda, .spar/.sdat")
+
             fname_rawdata_nifti = os.path.join(tmp, basename + '.nii.gz')
             nii = nib.load(fname_rawdata_nifti)
-            header_raw_data = nii.header
-            affine = nii.affine
-        position_sag = header_raw_data['qoffset_x']
-        position_cor = header_raw_data['qoffset_y']
-        position_tra = header_raw_data['qoffset_z']
-        logger.debug(f"raw_data header: {header_raw_data}")
-        logger.debug(f"affine: {affine}")
-        scanner_coordinate = np.array([position_sag, position_cor, position_tra, 1])
-        logger.debug(f"Scanner position is: {scanner_coordinate}")
-        mrs_voxel_size = header_raw_data['pixdim'][1:4]
 
+            if nii.ndim == 4:
+                data = nii.get_fdata()[..., 0]
+            else:
+                data = nii.get_fdata()
+
+            data[data != 0] = 1
+
+            nii_tmp = nib.Nifti1Image(data, nii.affine, nii.header)
+            nii_target = nib.load(fname_input)
+            return resample_from_to(nii_tmp, nii_target, mode='grid-constant', order=0, cval=0).get_fdata()
+
+    # Handle no MRS data case (voxel size and center are given)
     logger.debug('mrs_voxel_size is:', mrs_voxel_size)
     fmap_nii = nib.load(fname_input)
     fmap_array = fmap_nii.get_fdata()
@@ -85,5 +114,25 @@ def mask_mrs(fname_input, raw_data, center, size):
     mask = np.zeros(fmap_array.shape)
 
     # Change the MRS voxel position to have 1 value.
-    mask[i - sd[0]:i + sd[0], j - sd[1]:j + sd[1], k - sd[2]:k + sd[2]] = 1
+    mask[max(0, i - sd[0]):i + sd[0], max(0, j - sd[1]):j + sd[1], max(0, k - sd[2]):k + sd[2]] = 1
+
     return mask
+
+
+def is_supported_file(file_path):
+    return is_rda_file(file_path) or is_spar_file(file_path) or is_sdat_file(file_path)
+
+
+def is_rda_file(file_path):
+    _, ext = splitext(file_path)
+    return ext.lower() == '.rda'
+
+
+def is_spar_file(file_path):
+    _, ext = splitext(file_path)
+    return ext.lower() == '.spar'
+
+
+def is_sdat_file(file_path):
+    _, ext = splitext(file_path)
+    return ext.lower() == '.sdat'

--- a/shimming-toolbox/shimmingtoolbox/masking/mask_mrs.py
+++ b/shimming-toolbox/shimmingtoolbox/masking/mask_mrs.py
@@ -81,11 +81,9 @@ def mask_mrs(fname_input, raw_datas, center, size):
             nii = nib.load(fname_rawdata_nifti)
 
             if nii.ndim == 4:
-                data = nii.get_fdata()[..., 0]
+                data = np.ones_like(nii.get_fdata()[..., 0])
             else:
-                data = nii.get_fdata()
-
-            data[data != 0] = 1
+                data = np.ones_like(nii.get_fdata())
 
             nii_tmp = nib.Nifti1Image(data, nii.affine, nii.header)
             nii_target = nib.load(fname_input)

--- a/shimming-toolbox/shimmingtoolbox/masking/mask_mrs.py
+++ b/shimming-toolbox/shimmingtoolbox/masking/mask_mrs.py
@@ -40,7 +40,7 @@ def mask_mrs(fname_input, raw_datas, center, size):
     if fname_input is None:
         raise TypeError(f"The input field map needs to be specified")
 
-    if raw_datas is None:
+    if raw_datas is None or len(raw_datas) == 0:
         logger.info("MRS raw data not provided, creating the mask with the given voxel position and size info")
         if center is None or size is None:
             raise TypeError('The raw_data is not provided; the voxel position and size are required to proceed')

--- a/shimming-toolbox/shimmingtoolbox/shim/shim_utils.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/shim_utils.py
@@ -449,15 +449,29 @@ class ScannerShimSettings:
                                                shim_settings_dac)
 
     def concatenate_shim_settings(self, orders=[2]):
-        coefs = []
+        return concatenate_shim_settings(self.shim_settings, orders=orders)
 
-        if any(order >= 0 for order in orders):
-            for order in sorted(orders):
-                if self.shim_settings.get(str(order)) is not None:
-                    # Concatenate 2 lists
-                    coefs.extend(self.shim_settings.get(str(order)))
-                else:
-                    n_coefs = channels_per_order(order)
-                    coefs.extend([0] * n_coefs)
 
-        return coefs
+def concatenate_shim_settings(shim_settings, orders=[2]):
+    """
+
+    Args:
+        shim_settings (dict): Dictionary of shimSettings.
+        orders (list): List of orders to concatenate.
+
+    Returns:
+        list: List of coefficients concatenated in the order of the orders. If an order is not available,
+              it will be filled with zeros.
+    """
+    coefs = []
+
+    if any(order >= 0 for order in orders):
+        for order in sorted(orders):
+            if shim_settings.get(str(order)) is not None:
+                # Concatenate 2 lists
+                coefs.extend(shim_settings.get(str(order)))
+            else:
+                n_coefs = channels_per_order(order)
+                coefs.extend([0] * n_coefs)
+
+    return coefs


### PR DESCRIPTION
## Description
In `st_mask mrs`, allow to input .sdat/.spar files and output a mask in the MRS region accordingly. Other minor modifications were also made.

- Changed the MRS input from an option to an argument to allow the input of different number of files (.rda --> 1 file, .sdat/.spar --> 2 files)
- Use resampling when masking from the mrs geometry to the target geometry. The previous implementation did not work for all orientations.
- Improved code readability
- Add a test with .SDAT/.SPAR data

Also fixed an issue where scanner constraint files with coefs)used generated errors.

## Linked issues
Fixes #637 
