### PR TITLE
Upgrade to python 3.11

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache pip dependencies
         id: cache-pip-dependencies
         uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,8 +167,9 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-activate-base: true
-          activate-environment: ""
+          channels: conda-forge,defaults
+          auto-activate: true
+          activate-environment: base
           auto-update-conda: false
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           - 'ubuntu-24.04'
           - 'ubuntu-22.04'
         python-version:
-          - '3.10'
+          - '3.11'
         tests:
           - 'fsleyes-plugin-shimming-toolbox'
           - 'shimming-toolbox'
@@ -186,7 +186,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Finished
       run: |
         pip3 install --upgrade coveralls

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -37,7 +37,7 @@ source "${ST_DIR}/${PYTHON_DIR}/bin/activate"
 
 # Install fsleyes
 print info "Installing fsleyes"
-"${ST_DIR}"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge fsleyes=1.12.4 python=3.10
+"${ST_DIR}"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge fsleyes=1.16.3 python=3.11
 
 # Install fsleyes-plugin-shimming-toolbox
 print info "Installing fsleyes-plugin-shimming-toolbox"

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -40,7 +40,7 @@ function edit_shellrc() {
 source "${ST_DIR}/${PYTHON_DIR}/bin/activate"
 
 print info "Installing python"
-"$ST_DIR"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge python=3.10
+"$ST_DIR"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge python=3.11
 
 print info "Installing shimming-toolbox"
 cp "${ST_PACKAGE_DIR}/shimmingtoolbox/config/dcm2bids.json" "${ST_DIR}/dcm2bids.json"

--- a/installer/windows_install.bat
+++ b/installer/windows_install.bat
@@ -37,7 +37,7 @@ del "%UNIQUE_TMP_INSTALLER%"
 
 REM Installing python
 echo Installing python
-call "%ST_DIR%\%PYTHON_DIR%\condabin\mamba.bat" install -y -c conda-forge python=3.10 || goto error
+call "%ST_DIR%\%PYTHON_DIR%\condabin\mamba.bat" install -y -c conda-forge python=3.11 || goto error
 
 REM Installing Shimming Toolbox
 echo Installing Shimming Toolbox

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/shimming-toolbox/requirements_st.txt
+++ b/shimming-toolbox/requirements_st.txt
@@ -21,3 +21,4 @@ scikit-learn>=1.1.2
 scipy>=1.7
 spec2nii
 tqdm
+urllib3

--- a/shimming-toolbox/requirements_st.txt
+++ b/shimming-toolbox/requirements_st.txt
@@ -8,10 +8,10 @@ joblib
 matplotlib>=3.5
 nibabel>=3.2.1
 numpy>=1.21
-phantominator~=0.6.4
+phantominator>=0.6.4
 pillow>=9.0.0
 psutil>=5.8.0
-pydicom~=2.4.4
+pydicom>=2.4.4
 pytest>=6.2.5
 pytest-cov>=2.5.1
 quadprog

--- a/shimming-toolbox/setup.py
+++ b/shimming-toolbox/setup.py
@@ -27,7 +27,7 @@ else:
 
 setup(
     name="shimmingtoolbox",
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     version=version,
     description="Code for performing real-time shimming using external MRI shim coils",
     long_description=long_description,

--- a/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
@@ -727,7 +727,7 @@ def realtime_dynamic(fname_fmap, fname_target, fname_mask_target_static, fname_m
     logger.info(f"The slices to shim are: {list_slices}")
 
     # Load PMU
-    if time_offset is 'auto':
+    if time_offset == 'auto':
         is_pmu_time_offset_auto = True
         time_offset = 0
     else:

--- a/shimming-toolbox/shimmingtoolbox/cli/b1shim.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/b1shim.py
@@ -52,7 +52,7 @@ def b1shim_cli(fname_b1, fname_mask, algorithm, target, fname_vop, sar_factor, p
     nii_b1 = nib.load(fname_b1)
     with open(fname_b1.split('.nii')[0] + '.json') as json_b1_file:
         json_b1 = json.load(json_b1_file)
-    b1_map = np.array(nii_b1.dataobj)
+    b1_map = np.asanyarray(nii_b1.dataobj)
 
     # Load static mask
     if fname_mask is not None:

--- a/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
@@ -181,7 +181,7 @@ def fix_tfl_b1(nii_b1, json_data):
     Returns:
         nib.Nifti1Image: NIfTI object containing the complex rescaled B1+ maps (x, y, n_slices, n_channels).
     """
-    image = np.array(nii_b1.dataobj)
+    image = np.asanyarray(nii_b1.dataobj)
     # The number of slices corresponds to the 3rd dimension of the shuffled NIfTI volume.
     n_slices = image.shape[2]
     # The number of Tx channels corresponds to the 4th dimension of the shuffled NIfTI of the shuffled NIfTI volume.

--- a/shimming-toolbox/shimmingtoolbox/download.py
+++ b/shimming-toolbox/shimmingtoolbox/download.py
@@ -12,7 +12,7 @@ import zipfile
 import requests
 from email.message import Message
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util import Retry
+from urllib3.util import Retry
 
 from shimmingtoolbox.utils import st_progress_bar
 

--- a/shimming-toolbox/shimmingtoolbox/download.py
+++ b/shimming-toolbox/shimmingtoolbox/download.py
@@ -5,12 +5,12 @@
 import os
 import shutil
 import logging
-import cgi
 import tempfile
 import urllib.parse
 import tarfile
 import zipfile
 import requests
+from email.message import Message
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util import Retry
 
@@ -45,8 +45,9 @@ def download_data(urls):
 
             filename = os.path.basename(urllib.parse.urlparse(url).path)
             if "Content-Disposition" in response.headers:
-                _, content = cgi.parse_header(response.headers['Content-Disposition'])
-                filename = content["filename"]
+                m = Message()
+                m['content-type'] = response.headers['Content-Disposition']
+                filename = dict(m.get_params()).get('filename', filename)
 
             # protect against directory traversal
             filename = os.path.basename(filename)

--- a/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
@@ -541,7 +541,7 @@ class ShimSequencer(Sequencer):
         mask_weight = np.sum(self.masks_fmap, axis=3)
 
         # Divide by the weighted mask. This is done so that the edges of the soft mask can be shimmed appropriately
-        full_correction_scaled = np.divide(full_correction, mask_weight, where=mask_full_binary.astype(bool))
+        full_correction_scaled = np.divide(full_correction, mask_weight, where=mask_full_binary.astype(bool), out=None)
 
         # Apply the correction to the unshimmed image
         shimmed_masked = (full_correction_scaled + unshimmed) * mask_full_binary
@@ -572,7 +572,7 @@ class ShimSequencer(Sequencer):
         mask_weight = np.sum(self.masks_fmap, axis=3)
 
         # Divide by the weighted mask. This is done so that the edges of the soft mask can be shimmed appropriately
-        full_correction_scaled = np.divide(full_correction, mask_weight, where=mask_full_binary.astype(bool))
+        full_correction_scaled = np.divide(full_correction, mask_weight, where=mask_full_binary.astype(bool), out=None)
 
         # Apply the correction to the unshimmed image
         shimmed_masked = full_correction_scaled * mask_full_binary

--- a/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
@@ -698,7 +698,7 @@ class ShimSequencer(Sequencer):
                     # If its volume shim (len(slices == 1)) and a scanner coil
                     # Dump the shim coefficients as ShimSettingsCurrent + calculated shimmed coefs
                     if 0 in coil.orders:
-                        json_shimmed['ImagingFrequency'] = int(coil.coefs_used['0'] + coefs[0, i]) / 1e6
+                        json_shimmed['ImagingFrequency'] = int(coil.coefs_used['0'][0] + coefs[0, i]) / 1e6
                         j += 1
                     shim_settings_output = []
                     for order in (1, 2, 3):


### PR DESCRIPTION
## Description
Upgrade to Python 3.11. I had to do other things to make it work:
- Upgrade FSLeyes to 1.16.3
- Unpin pydicom and phantominator
- I resolved a few warnings that were thrown in Pytest, the majority coming from the python 3.11 upgrade.

This fixes scipy 3.13.1 crashing the installation.

## Linked issues
Fixes #639 
Fixes #640 
