### PR TITLE
Add env executables to the PATH when necessary

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Set path for Shimming Toolbox
         run: |
           echo "$HOME/shimming-toolbox/bin" >> $GITHUB_PATH
+          echo "ST_DIR=$HOME\shimming-toolbox" >> $GITHUB_ENV
 
       - name: Spinal Cord Toolbox clone
         run: |
@@ -162,8 +163,9 @@ jobs:
       - name: Set up environment variables
         shell: bash
         run: |
-          echo "$USERPROFILE\shimming-toolbox\python\Scripts" >> $GITHUB_PATH
+          echo "$USERPROFILE\shimming-toolbox\bin" >> $GITHUB_PATH
           echo "CONDA=$USERPROFILE\shimming-toolbox\python" >> $GITHUB_ENV
+          echo "ST_DIR=$USERPROFILE\shimming-toolbox" >> $GITHUB_ENV
 
       - uses: conda-incubator/setup-miniconda@v3
         with:

--- a/installer/windows_install.bat
+++ b/installer/windows_install.bat
@@ -6,9 +6,10 @@ REM The installation path cannot have spaces
 REM Todo: Make the installation path a script argument so that users with spaces in their paths have an alternative
 
 set "ST_DIR=%userprofile%\shimming-toolbox"
+echo Installing Shimming Toolbox in %ST_DIR%
 set "PYTHON_DIR=python"
 for %%d in ("%~dp0..") do set "ST_REPO=%%~fd"
-echo %ST_REPO%
+echo Shimming Toolbox repo: %ST_REPO%
 set "ST_SOURCE_FILES=%ST_REPO%\shimming-toolbox"
 pushd "%CD%"
 
@@ -68,6 +69,9 @@ if "%PATH_NO_ST%"=="%OLD_PATH%" (
 	set "NEW_ST_PATH=!LIST_PATH!%ST_DIR%\%BIN_DIR%\;"
 	REG ADD "HKEY_CURRENT_USER\Environment" /v path /d "!NEW_ST_PATH!" /t REG_EXPAND_SZ /f
 	)
+
+REM Add ST_DIR to the environment variables
+REG ADD "HKEY_CURRENT_USER\Environment" /v ST_DIR /d "%ST_DIR%" /t REG_EXPAND_SZ /f
 
 echo To use Shimming Toolbox's scripts, either reboot your computer or follow these instructions:
 echo:

--- a/shimming-toolbox/shimmingtoolbox/cli/check_env.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/check_env.py
@@ -99,8 +99,6 @@ def check_dependencies():
 def check_prelude_installation():
     """Checks that ``prelude`` is installed.
 
-    This function calls ``which prelude`` and checks the exit code to verify that ``prelude`` is installed.
-
     Returns:
         bool: True if prelude is installed, False if not.
     """
@@ -116,8 +114,6 @@ def check_prelude_installation():
 
 def check_bet_installation():
     """Checks that ``bet`` is installed.
-
-    This function calls ``which bet`` and checks the exit code to verify that ``bet`` is installed.
 
     Returns:
         bool: True if bet is installed, False if not.
@@ -136,8 +132,6 @@ def check_bet_installation():
 def check_dcm2niix_installation():
     """Checks that ``dcm2niix`` is installed.
 
-    This function calls ``which dcm2niix`` and checks the exit code to verify that ``dcm2niix`` is installed.
-
     Returns:
         bool: True if dcm2niix is installed, False if not.
     """
@@ -152,12 +146,10 @@ def check_dcm2niix_installation():
 
 
 def check_spec2nii_installation():
-    """Checks that ``dcm2niix`` is installed.
-
-    This function calls ``which dcm2niix`` and checks the exit code to verify that ``dcm2niix`` is installed.
+    """Checks that ``spec2nii`` is installed.
 
     Returns:
-        bool: True if dcm2niix is installed, False if not.
+        bool: True if spec2nii is installed, False if not.
     """
     if check_exe('spec2nii', must_be_within_env=True):
         print_ok()
@@ -171,8 +163,6 @@ def check_spec2nii_installation():
 
 def check_sct_installation():
     """Checks that ``SCT`` is installed.
-
-    This function calls ``which sct_check_dependencies`` and checks the exit code to verify that ``sct`` is installed.
 
     Returns:
         bool: True if sct is installed, False if not.
@@ -237,11 +227,7 @@ def get_spec2nii_version() -> str:
     Returns:
         str: Version of the ``spec2nii`` installation.
     """
-    # `spec2nii --version` returns an error code and output is in stderr
     spec2nii_version: str = subprocess.run(["spec2nii", "--version"], capture_output=True, encoding="utf-8")
-    # If the behaviour of spec2nii changes to output help with a 0 exit code,
-    # this function must fail loudly so we can update its behaviour
-    # accordingly:
     assert spec2nii_version.returncode == 0
     version_output: str = spec2nii_version.stdout.rstrip()
     return version_output

--- a/shimming-toolbox/shimmingtoolbox/cli/check_env.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/check_env.py
@@ -14,7 +14,7 @@ import psutil
 import sys
 
 from shimmingtoolbox import __version__, __dir_repo__
-from shimmingtoolbox.utils import check_exe
+from shimmingtoolbox.utils import check_exe, add_executable_dir_to_path_if_necessary
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -54,6 +54,8 @@ def check_dependencies():
     """Verifies dependencies are installed by calling helper functions and
     formatting output accordingly.
     """
+    add_executable_dir_to_path_if_necessary()
+
     check_name = "Check if {} is installed"
 
     # Shimming Toolbox
@@ -70,18 +72,21 @@ def check_dependencies():
     prelude_check_msg = check_name.format("prelude")
     print_line(prelude_check_msg)
     check_prelude_installation()
-    
+
     # Bet
     bet_check_msg = check_name.format("bet")
     print_line(bet_check_msg)
     check_bet_installation()
 
-    # # dcm2niix
-    # dcm2niix now comes bundled with shimming toolbox. Therefore we don't need to check if it is in the path since it
-    # is already in the environment
-    # dcm2niix_check_msg = check_name.format("dcm2niix")
-    # print_line(dcm2niix_check_msg)
-    # check_dcm2niix_installation()
+    # dcm2niix
+    dcm2niix_check_msg = check_name.format("dcm2niix")
+    print_line(dcm2niix_check_msg)
+    check_dcm2niix_installation()
+
+    # spec2nii
+    spec2nii_check_msg = check_name.format("spec2nii")
+    print_line(spec2nii_check_msg)
+    check_spec2nii_installation()
 
     # SCT
     sct_check_msg = check_name.format("Spinal Cord Toolbox")
@@ -111,27 +116,22 @@ def check_prelude_installation():
 
 def check_bet_installation():
     """Checks that ``bet`` is installed.
-    
+
     This function calls ``which bet`` and checks the exit code to verify that ``bet`` is installed.
-    
+
     Returns:
         bool: True if bet is installed, False if not.
     """
-    
-    try:
-        if sys.platform == 'win32':
-            subprocess.check_call(['where', 'bet2'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        else:
-            subprocess.check_call(['which', 'bet2'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    except subprocess.CalledProcessError as error:
-        print_fail()
-        print(f"Error {error.returncode}: bet is not installed or not in your PATH.")
-        return False
-    else:
+
+    if check_exe('bet2'):
         print_ok()
         print("    " + "\n    ".join(get_bet_version().split("\n")[1:3]))
         return True
-    
+    else:
+        print_fail()
+        print(f"Error: bet is not installed or not in your PATH.")
+        return False
+
 
 def check_dcm2niix_installation():
     """Checks that ``dcm2niix`` is installed.
@@ -141,13 +141,31 @@ def check_dcm2niix_installation():
     Returns:
         bool: True if dcm2niix is installed, False if not.
     """
-    if check_exe('dcm2niix'):
+    if check_exe('dcm2niix', must_be_within_env=True):
         print_ok()
         print("    " + get_dcm2niix_version().replace("\n", "\n    "))
         return True
     else:
         print_fail()
         print(f"Error: dcm2niix is not installed or not in your PATH.")
+        return False
+
+
+def check_spec2nii_installation():
+    """Checks that ``dcm2niix`` is installed.
+
+    This function calls ``which dcm2niix`` and checks the exit code to verify that ``dcm2niix`` is installed.
+
+    Returns:
+        bool: True if dcm2niix is installed, False if not.
+    """
+    if check_exe('spec2nii', must_be_within_env=True):
+        print_ok()
+        print("    " + get_spec2nii_version().replace("\n", "\n    "))
+        return True
+    else:
+        print_fail()
+        print(f"Error: spec2nii is not installed or not in your PATH.")
         return False
 
 
@@ -207,6 +225,25 @@ def get_dcm2niix_version() -> str:
     # accordingly:
     assert dcm2niix_version.returncode != 0
     version_output: str = dcm2niix_version.stdout.rstrip()
+    return version_output
+
+
+def get_spec2nii_version() -> str:
+    """Gets the ``spec2nii`` installation version.
+
+    This function calls ``spec2nii --version`` and captures the output to
+    obtain the installation version.
+
+    Returns:
+        str: Version of the ``spec2nii`` installation.
+    """
+    # `spec2nii --version` returns an error code and output is in stderr
+    spec2nii_version: str = subprocess.run(["spec2nii", "--version"], capture_output=True, encoding="utf-8")
+    # If the behaviour of spec2nii changes to output help with a 0 exit code,
+    # this function must fail loudly so we can update its behaviour
+    # accordingly:
+    assert spec2nii_version.returncode == 0
+    version_output: str = spec2nii_version.stdout.rstrip()
     return version_output
 
 

--- a/shimming-toolbox/shimmingtoolbox/config/dcm2bids.json
+++ b/shimming-toolbox/shimmingtoolbox/config/dcm2bids.json
@@ -320,7 +320,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "1"
             }
@@ -332,7 +332,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "2"
             }
@@ -344,7 +344,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "3"
             }
@@ -356,7 +356,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "4"
             }
@@ -368,7 +368,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "5"
             }
@@ -380,7 +380,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimmings)$",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "6"
             }
@@ -392,7 +392,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "1"
             }
@@ -404,7 +404,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "2"
             }
@@ -416,7 +416,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "3"
             }
@@ -427,7 +427,7 @@
             "criteria": {
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "4"
@@ -439,7 +439,7 @@
             "criteria": {
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "5"
@@ -451,7 +451,7 @@
             "criteria": {
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL|%CustomerSeq%\\\\gre_shimming)$",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "PulseSequenceName": ".*fl[2-3]d[2-6]",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "6"
@@ -464,7 +464,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "1"
             }
@@ -476,7 +476,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "2"
             }
@@ -488,7 +488,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "3"
             }
@@ -500,7 +500,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "4"
             }
@@ -512,7 +512,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "5"
             }
@@ -524,7 +524,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "6"
             }
@@ -536,7 +536,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "1"
             }
@@ -548,7 +548,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "2"
             }
@@ -560,7 +560,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "3"
             }
@@ -572,7 +572,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "4"
             }
@@ -584,7 +584,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "5"
             }
@@ -596,7 +596,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "6"
             }
@@ -608,7 +608,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "1"
             }
@@ -620,7 +620,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "2"
             }
@@ -632,7 +632,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "3"
             }
@@ -644,7 +644,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "4"
             }
@@ -656,7 +656,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "5"
             }
@@ -668,7 +668,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", "MAGNITUDE"],
                 "EchoNumber": "6"
             }
@@ -680,7 +680,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "1"
             }
@@ -692,7 +692,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "2"
             }
@@ -704,7 +704,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "3"
             }
@@ -716,7 +716,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "4"
             }
@@ -728,7 +728,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "5"
             }
@@ -740,7 +740,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "^(%CustomerSeq%\\\\gre_shimming|%CustomerSeq%\\\\gre_realtime_zshim|%SiemensSeq%\\\\gre|%CustomerSeq%\\\\a_gre_DYNshim|%SiemensSeq%\\\\CV_pTX_638|%CustomerSeq%\\\\a_gre_SSreversal|%CustomerSeq%\\\\a_gre_dyn_realtime_shimming_TTL)$",
                 "SequenceName": ".*fl[2-3]d[2-8]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*"],
                 "EchoNumber": "6"
             }
@@ -752,7 +752,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "1"
             }
@@ -764,7 +764,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "2"
             }
@@ -776,7 +776,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "3"
             }
@@ -788,7 +788,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "4"
             }
@@ -800,7 +800,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "5"
             }
@@ -812,7 +812,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "M", ".*", ".*", ".*", "MAGNITUDE"],
                 "EchoNumber": "6"
             }
@@ -824,7 +824,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "1"
             }
@@ -836,7 +836,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "2"
             }
@@ -848,7 +848,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "3"
             }
@@ -860,7 +860,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "4"
             }
@@ -872,7 +872,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "5"
             }
@@ -884,7 +884,7 @@
                 "Manufacturer": "Siemens",
                 "PulseSequenceDetails": "%SiemensSeq%\\\\gre",
                 "SequenceName": ".*fl[2-3]d[2-6]",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "ImageType": [".*", ".*", "P", ".*", ".*", ".*"],
                 "EchoNumber": "6"
             }
@@ -925,7 +925,7 @@
             "suffix": "magnitude1",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "EchoNumber": "1",
                 "ImageType": [".*", ".*", "M", ".*", "M", ".*", "MAGNITUDE"]
             }
@@ -935,7 +935,7 @@
             "suffix": "magnitude2",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "EchoNumber": "2",
                 "ImageType": [".*", ".*", "M", ".*", "M", ".*", "MAGNITUDE"]
             }
@@ -945,7 +945,7 @@
             "suffix": "phase1",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "EchoNumber": "1",
                 "ImageType": [".*", ".*", ".*", "P", "FFE", "PHASE"]
             }
@@ -955,7 +955,7 @@
             "suffix": "phase2",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "EchoNumber": "2",
                 "ImageType": [".*", ".*", ".*", "P", "FFE", "PHASE"]
             }
@@ -973,7 +973,7 @@
             "suffix": "magnitude1",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
+                "ProtocolName": ".*(field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).*",
                 "EchoNumber": "1",
                 "ImageType": [".*", ".*", "T1", "MIXED", "FIELDMAPHZ"]
             }
@@ -1072,7 +1072,7 @@
             "suffix": "FFE",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "",
                 "PulseSequenceName": "FFE",
                 "ImageType": [".*", ".*", "M", "FFE", "M", "FFE"]
@@ -1084,7 +1084,7 @@
             "custom_entities": "echo-1",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "1",
                 "PulseSequenceName": "FFE",
                 "ImageType": [".*", ".*", "M", "FFE", "M", "FFE"]
@@ -1096,7 +1096,7 @@
             "custom_entities": "echo-2",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "2",
                 "PulseSequenceName": "FFE",
                 "ImageType": [".*", ".*", "M", "FFE", "M", "FFE"]
@@ -1108,7 +1108,7 @@
             "custom_entities": "echo-sum",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "",
                 "PulseSequenceName": "FFE",
                 "ImageType": [".*", ".*", "M", "FFE", "M", "FFE", "MAGNITUDE"]
@@ -1120,7 +1120,7 @@
             "custom_entities": "echo-1",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "1",
                 "PulseSequenceName": "FFE",
                 "ImageType": [".*", ".*", "M", "FFE", "M", "FFE", "MAGNITUDE"]
@@ -1132,7 +1132,7 @@
             "custom_entities": "echo-2",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "2",
                 "PulseSequenceName": "FFE",
                 "ImageType": [".*", ".*", "M", "FFE", "M", "FFE", "MAGNITUDE"]
@@ -1144,7 +1144,7 @@
             "custom_entities": "echo-3",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "3",
                 "PulseSequenceName": "FFE",
                 "ImageType": [".*", ".*", "M", "FFE", "M", "FFE", "MAGNITUDE"]
@@ -1156,7 +1156,7 @@
             "custom_entities": "echo-1",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "1",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED"]
@@ -1168,7 +1168,7 @@
             "custom_entities": "echo-2",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "2",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED"]
@@ -1180,7 +1180,7 @@
             "custom_entities": "echo-3",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "3",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED"]
@@ -1192,7 +1192,7 @@
             "custom_entities": "echo-1_part-phase",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "1",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED", "PHASE"]
@@ -1204,7 +1204,7 @@
             "custom_entities": "echo-2_part-phase",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "2",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED", "PHASE"]
@@ -1216,7 +1216,7 @@
             "custom_entities": "echo-3_part-phase",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "3",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED", "PHASE"]
@@ -1228,7 +1228,7 @@
             "custom_entities": "echo-1_part-imag",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "1",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED", "IMAGINARY"]
@@ -1240,7 +1240,7 @@
             "custom_entities": "echo-2_part-imag",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "2",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED", "IMAGINARY"]
@@ -1252,7 +1252,7 @@
             "custom_entities": "echo-3_part-imag",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "3",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED", "IMAGINARY"]
@@ -1264,7 +1264,7 @@
             "custom_entities": "echo-1_part-real",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "1",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED", "REAL"]
@@ -1276,7 +1276,7 @@
             "custom_entities": "echo-2_part-real",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "2",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED", "REAL"]
@@ -1288,7 +1288,7 @@
             "custom_entities": "echo-3_part-real",
             "criteria": {
                 "Manufacturer": "Philips",
-                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
+                "ProtocolName": "^((?!field_map|fmap|fieldmap|field map|field-map|b0map|B0map|B0_MAP|B0MAP|B0 MAP|B0-MAP|b0_map|B0_map|b0 map|B0 map|b0-map|B0-map|_fm_|-fm-|fm2d|fm3d).)+$",
                 "EchoNumber": "3",
                 "PulseSequenceName": "FFE",
                 "ImageType": ["ORIGINAL", "PRIMARY", "T1", "MIXED", "REAL"]

--- a/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
@@ -66,19 +66,19 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
     # Copy original dicom files into nifti_path/sourcedata
     copytree(path_dicom, os.path.join(path_nifti, 'sourcedata'), dirs_exist_ok=True)
     
+    logger.info(os.environ)
+    logger.info(os.environ['PATH'])
+    
     if platform.system() == "Windows":
-        logger.info(os.environ)
-        if 'ST_DIR' in os.environ:
-            os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', 'Scripts') + os.pathsep + os.environ['PATH']
-        else:
-            os.environ['PATH'] = os.path.join(Path.home(), 'shimming-toolbox', 'python', 'Scripts') + os.pathsep + os.environ['PATH']
+        bin_dir = 'Scripts'
     else:
-        # Update the PATH environment variable to include the dcm2niix executable
-        # TODO: Try this out on Windows, path could be Scripts instead of bin
-        if 'ST_DIR' in os.environ and os.path.exists(os.environ['ST_DIR']):
-            os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', 'bin') + os.pathsep + os.environ['PATH']
-        else:
-            logger.warning("Environment variable ST_DIR not found. Using default path.")
+        bin_dir = 'bin'
+    
+    if 'ST_DIR' in os.environ:
+        os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', bin_dir) + os.pathsep + os.environ['PATH']
+    else:
+        raise EnvironmentError("Environment variable ST_DIR not found. This variable should be set when installing Shimming Toolbox." \
+            "Try restarting your computer if you just installed Shimming Toolbox, or check that the installation was successful.")
 
     logger.info(os.environ['PATH'])
 

--- a/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
@@ -65,22 +65,18 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
 
     # Copy original dicom files into nifti_path/sourcedata
     copytree(path_dicom, os.path.join(path_nifti, 'sourcedata'), dirs_exist_ok=True)
-    
-    logger.info(os.environ)
-    logger.info(os.environ['PATH'])
-    
+
     if platform.system() == "Windows":
         bin_dir = 'Scripts'
     else:
         bin_dir = 'bin'
-    
+
     if 'ST_DIR' in os.environ:
         os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', bin_dir) + os.pathsep + os.environ['PATH']
     else:
-        raise EnvironmentError("Environment variable ST_DIR not found. This variable should be set when installing Shimming Toolbox." \
-            "Try restarting your computer if you just installed Shimming Toolbox, or check that the installation was successful.")
-
-    logger.info(os.environ['PATH'])
+        raise EnvironmentError("Environment variable ST_DIR not found. This variable should be set when installing "
+                               "Shimming Toolbox. Try restarting your computer if you just installed Shimming "
+                               "Toolbox, or check that the installation was successful.")
 
     # Run dcm2bids
     check_latest('dcm2bids')

--- a/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
@@ -69,9 +69,6 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
     # If the CLI is launched from launchers, then we need to add it.
     add_executable_dir_to_path_if_necessary()
 
-    import subprocess
-    subprocess.run(["which", "dcm2bids"], text=True, check=True)
-
     # Run dcm2bids
     check_latest('dcm2bids')
     Dcm2BidsGen(path_dicom, subject_id, fname_config_dcm2bids, path_nifti).run()

--- a/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
@@ -1,6 +1,7 @@
 #!usr/bin/env python3
 # -*- coding: utf-8
 
+import platform
 from shutil import copytree
 import json
 import logging
@@ -63,14 +64,24 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
 
     # Copy original dicom files into nifti_path/sourcedata
     copytree(path_dicom, os.path.join(path_nifti, 'sourcedata'), dirs_exist_ok=True)
-
-    # Update the PATH environment variable to include the dcm2niix executable
-    # TODO: Try this out on Windows, path could be Scripts instead of bin
-    if 'ST_DIR' in os.environ and os.path.exists(os.environ['ST_DIR']):
-        os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', 'bin') + os.pathsep + os.environ['PATH']
+    
+    if platform.system() == "Windows":
+        if 'ST_DIR' in os.environ:
+            os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', 'Scripts') + os.pathsep + os.environ['PATH']
+        elif 'HOME' in os.environ:
+            os.environ['PATH'] = os.path.join(os.environ['HOME'], 'shimming-toolbox', 'python', 'Scripts') + os.pathsep + os.environ['PATH']
     else:
-        logger.warning("Environment variable ST_DIR not found. Using default path.")
+        # Update the PATH environment variable to include the dcm2niix executable
+        # TODO: Try this out on Windows, path could be Scripts instead of bin
+        if 'ST_DIR' in os.environ and os.path.exists(os.environ['ST_DIR']):
+            os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', 'bin') + os.pathsep + os.environ['PATH']
+        else:
+            logger.warning("Environment variable ST_DIR not found. Using default path.")
 
+    #logger.warning(os.environ)
+    logger.warning(os.environ['PATH'])
+    os.environ['PATH'] = os.path.join('C:\\Users\\po09i\\shimming-toolbox', 'python', 'Scripts') + os.pathsep + os.environ['PATH']
+    logger.warning(os.environ['PATH'])
     # Run dcm2bids
     check_latest('dcm2bids')
     Dcm2BidsGen(path_dicom, subject_id, fname_config_dcm2bids, path_nifti).run()

--- a/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
+++ b/shimming-toolbox/shimmingtoolbox/dicom_to_nifti.py
@@ -12,6 +12,7 @@ from dcm2bids.dcm2bids_gen import Dcm2BidsGen
 from dcm2bids.utils.tools import check_latest
 from dcm2bids import version
 import shutil
+from pathlib import Path
 
 from shimmingtoolbox import __config_dcm2bids__
 from shimmingtoolbox.coils.coordinates import get_main_orientation
@@ -66,10 +67,11 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
     copytree(path_dicom, os.path.join(path_nifti, 'sourcedata'), dirs_exist_ok=True)
     
     if platform.system() == "Windows":
+        logger.info(os.environ)
         if 'ST_DIR' in os.environ:
             os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', 'Scripts') + os.pathsep + os.environ['PATH']
-        elif 'HOME' in os.environ:
-            os.environ['PATH'] = os.path.join(os.environ['HOME'], 'shimming-toolbox', 'python', 'Scripts') + os.pathsep + os.environ['PATH']
+        else:
+            os.environ['PATH'] = os.path.join(Path.home(), 'shimming-toolbox', 'python', 'Scripts') + os.pathsep + os.environ['PATH']
     else:
         # Update the PATH environment variable to include the dcm2niix executable
         # TODO: Try this out on Windows, path could be Scripts instead of bin
@@ -78,10 +80,8 @@ def dicom_to_nifti(path_dicom, path_nifti, subject_id='sub-01', fname_config_dcm
         else:
             logger.warning("Environment variable ST_DIR not found. Using default path.")
 
-    #logger.warning(os.environ)
-    logger.warning(os.environ['PATH'])
-    os.environ['PATH'] = os.path.join('C:\\Users\\po09i\\shimming-toolbox', 'python', 'Scripts') + os.pathsep + os.environ['PATH']
-    logger.warning(os.environ['PATH'])
+    logger.info(os.environ['PATH'])
+
     # Run dcm2bids
     check_latest('dcm2bids')
     Dcm2BidsGen(path_dicom, subject_id, fname_config_dcm2bids, path_nifti).run()

--- a/shimming-toolbox/shimmingtoolbox/utils.py
+++ b/shimming-toolbox/shimmingtoolbox/utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8
 # Misc functions
 
+from pathlib import Path
 import platform
 import numpy as np
 import os
@@ -31,7 +32,7 @@ def run_subprocess(cmd):
         if 'ST_DIR' in os.environ:
             os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', 'Scripts') + os.pathsep + os.environ['PATH']
         elif 'HOME' in os.environ:
-            os.environ['PATH'] = os.path.join(os.environ['HOME'], 'shimming-toolbox', 'python', 'Scripts') + os.pathsep + os.environ['PATH']
+            os.environ['PATH'] = os.path.join(Path.home(), 'shimming-toolbox', 'python', 'Scripts') + os.pathsep + os.environ['PATH']
 
     try:
 

--- a/shimming-toolbox/shimmingtoolbox/utils.py
+++ b/shimming-toolbox/shimmingtoolbox/utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8
 # Misc functions
 
+import platform
 import numpy as np
 import os
 import tqdm
@@ -25,6 +26,13 @@ def run_subprocess(cmd):
         cmd (list): list of arguments to be passed to the command line
     """
     logger.debug(f"Command to run on the terminal:\n{' '.join(cmd)}")
+
+    if platform.system() == "Windows":
+        if 'ST_DIR' in os.environ:
+            os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', 'Scripts') + os.pathsep + os.environ['PATH']
+        elif 'HOME' in os.environ:
+            os.environ['PATH'] = os.path.join(os.environ['HOME'], 'shimming-toolbox', 'python', 'Scripts') + os.pathsep + os.environ['PATH']
+
     try:
 
         subprocess.run(

--- a/shimming-toolbox/shimmingtoolbox/utils.py
+++ b/shimming-toolbox/shimmingtoolbox/utils.py
@@ -323,8 +323,8 @@ def are_jsons_equal(json1: dict, json2: dict):
 
 
 def check_exe(name, must_be_within_env=False):
-    """
-    Ensure that a program exists and can be executed.
+    """ Ensure that a program exists and can be executed.
+
     Args:
         name (str): Name of the executable.
         must_be_within_env (bool): If True, check that the executable is within the environment. The environment is

--- a/shimming-toolbox/shimmingtoolbox/utils.py
+++ b/shimming-toolbox/shimmingtoolbox/utils.py
@@ -30,10 +30,12 @@ def run_subprocess(cmd):
 
     if platform.system() == "Windows":
         if 'ST_DIR' in os.environ:
-            os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', 'Scripts') + os.pathsep + os.environ['PATH']
+            os.environ['PATH'] = os.path.join(os.environ['ST_DIR'],
+                                              'python', 'Scripts') + os.pathsep + os.environ['PATH']
         elif 'HOME' in os.environ:
-            raise EnvironmentError("Environment variable ST_DIR not found. This variable should be set when installing Shimming Toolbox." \
-            "Try restarting your computer if you just installed Shimming Toolbox, or check that the installation was successful.")
+            raise EnvironmentError("Environment variable ST_DIR not found. This variable should be set when installing "
+                                   "Shimming Toolbox. Try restarting your computer if you just installed Shimming "
+                                   "Toolbox, or check that the installation was successful.")
 
     try:
 

--- a/shimming-toolbox/shimmingtoolbox/utils.py
+++ b/shimming-toolbox/shimmingtoolbox/utils.py
@@ -322,16 +322,27 @@ def are_jsons_equal(json1: dict, json2: dict):
         hashlib.sha256(json2_bytes).hexdigest()
 
 
-def check_exe(name):
+def check_exe(name, must_be_within_env=False):
     """
-    Ensure that a program exists and can be executed
+    Ensure that a program exists and can be executed.
+    Args:
+        name (str): Name of the executable.
+        must_be_within_env (bool): If True, check that the executable is within the environment. The environment is
+                                   defined as the location of the python executable running this code, which is what
+                                   sys.prefix gives us. If False, check if the executable can be found on the PATH.
     """
     _, filename = os.path.split(name)
-    # Case 1: Check full filepath directly (which may point to a location not on the PATH)
-    if os.path.isfile(name) and os.access(name, os.X_OK):
-        return True
-    # Case 2: Check filename only via the PATH
-    elif shutil.which(filename) and os.access(shutil.which(filename), os.X_OK):
-        return True
+    if must_be_within_env:
+        if shutil.which(filename) is not None and shutil.which(filename).startswith(sys.prefix) and os.access(shutil.which(filename), os.X_OK):
+            return True
+        else:
+            return False
     else:
-        return False
+        # Case 1: Check full filepath directly (which may point to a location not on the PATH)
+        if os.path.isfile(name) and os.access(name, os.X_OK):
+            return True
+        # Case 2: Check filename only via the PATH
+        elif shutil.which(filename) and os.access(shutil.which(filename), os.X_OK):
+            return True
+        else:
+            return False

--- a/shimming-toolbox/shimmingtoolbox/utils.py
+++ b/shimming-toolbox/shimmingtoolbox/utils.py
@@ -32,7 +32,8 @@ def run_subprocess(cmd):
         if 'ST_DIR' in os.environ:
             os.environ['PATH'] = os.path.join(os.environ['ST_DIR'], 'python', 'Scripts') + os.pathsep + os.environ['PATH']
         elif 'HOME' in os.environ:
-            os.environ['PATH'] = os.path.join(Path.home(), 'shimming-toolbox', 'python', 'Scripts') + os.pathsep + os.environ['PATH']
+            raise EnvironmentError("Environment variable ST_DIR not found. This variable should be set when installing Shimming Toolbox." \
+            "Try restarting your computer if you just installed Shimming Toolbox, or check that the installation was successful.")
 
     try:
 

--- a/shimming-toolbox/test/cli/test_cli_check_env.py
+++ b/shimming-toolbox/test/cli/test_cli_check_env.py
@@ -56,6 +56,14 @@ def test_check_dcm2niix_installation():
     assert isinstance(check_dcm2niix_installation_exit, int)
 
 
+def test_check_spec2nii_installation():
+    """Tests that the function returns a bool as expected. it does not depend on sct being
+    installed.
+    """
+    check_spec2nii_installation_exit = st_ce.check_spec2nii_installation()
+    assert isinstance(check_spec2nii_installation_exit, bool)
+
+
 def test_check_sct_installation():
     """Tests that the function returns a bool as expected. it does not depend on sct being
     installed.
@@ -80,6 +88,14 @@ def test_get_dcm2niix_version(test_dcm2niix_installation):
     dcm2niix_version_info = st_ce.get_dcm2niix_version()
     version_regex = r"Chris.*\nv\d\.\d.\d{8}"
     assert re.search(version_regex, dcm2niix_version_info)
+
+
+def test_get_spec2nii_version():
+    """Checks spec2nii version output for expected structure.
+    """
+    spec2nii_version_info = st_ce.get_spec2nii_version()
+    version_regex = "\d\.\d"
+    assert re.search(version_regex, spec2nii_version_info)
 
 
 @pytest.mark.bet

--- a/shimming-toolbox/test/cli/test_cli_check_env.py
+++ b/shimming-toolbox/test/cli/test_cli_check_env.py
@@ -33,7 +33,9 @@ def test_check_installation_errors():
 
     result = runner.invoke(st_ce.check_dependencies, catch_exceptions=False)
     assert result.exit_code == 0
-    assert result.stdout.count('FAIL') == 3
+    # SCT and Prelude should fail here. Bet will pass if installed in the same environment (as done in the CI).
+    # This is why we put >= 2
+    assert result.stdout.count('FAIL') >= 2
 
 
 def test_check_prelude_installation():


### PR DESCRIPTION
## Description
ST runs into an error when running from git bash on Windows if sub commands are launched (dcm2niix, spec2nii). 

Adding the path of these subcommands fixes the problem.

To make sure this does not happen in the future. I tested that dcm2niix and spec2nii are correctly installed in `st_check_dependencies`