### PR TITLE
Fix Windows tests failing due to mismatch in Python and conda version

### DIFF
--- a/installer/windows_install.bat
+++ b/installer/windows_install.bat
@@ -21,7 +21,7 @@ mkdir "%ST_DIR%\%PYTHON_DIR%"
 echo Installing conda in %ST_DIR%\%PYTHON_DIR%
 REM Test for other OSs
 set "CONDA_INSTALLER=Miniforge3-Windows-x86_64.exe"
-set "CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/latest/download/%CONDA_INSTALLER%"
+set "CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/download/24.5.0-0/%CONDA_INSTALLER%"
 
 :uniqLoop
 set "UNIQUE_TMP_INSTALLER=%tmp%\st_%RANDOM%_%CONDA_INSTALLER%"


### PR DESCRIPTION
## Description
#647 and #646 Windows tests are failing during Conda commands. I dug around and it seems to be because Conda installations rely on the "base" environment for it to work. When the Python version of the base environment is changed, that can cause conflicts... I have pinned a previous Conda version to fix the issue until a more permanent solution is implemented, I suspect the long term solution is to not use the base environment or skip packaging Conda entirely.