### PR TITLE
Add a constraint file section to the website

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,7 @@ extensions = ["sphinx.ext.githubpages",
 
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 2
+myst_heading_anchors = 3
 
 # Autodoc configuration
 autodoc_mock_imports = [

--- a/docs/source/miscellaneous/constraint_file.md
+++ b/docs/source/miscellaneous/constraint_file.md
@@ -3,10 +3,23 @@ orphan: true
 ---
 
 # All about constraint files
+This page explains how Shimming Toolbox uses constraint files to respect the limits of your shim coil when optimizing the shim solution.
+Both scanner coil and custom coil constraint files are discussed.
 
-## What is in the scanner constraint file?
-The scanner constraint file is a JSON file that lists the different parameters used by Shimming Toolbox
-to generate a scanner-specific shim solution that respects the constraints of the scanner.
+## What are constraint files?
+A constraint file is a JSON file that lists the different parameters used by Shimming Toolbox
+to generate a shim solution that respects the constraints of your shim coil.
+
+## Do I need to use a constraint file?
+Some shim algorithms do not support constraints, see [Which shim algorithms support constraints?](#which-shim-algorithms-support-constraints) for more information.
+If the algorithm you wish to use does not support constraints, then even if you supply a constraint file, the shim solution won't respect them.
+A warning should inform you that the constraints are not being respected. Custom coils require constraint files to be used
+while scanner coils are optional using the `--scanner-coil-constraints` argument.
+See [Do I need to use a scanner constraint file?](#do-i-need-to-use-a-scanner-constraint-file) for more information.
+
+## Scanner constraint files
+### What is in the scanner constraint file?
+The scanner constraint file lists the different hardware limits to respect when optimizing.
 
 The file contains the following fields:
 - `name`: The name of the scanner. This will be used when creating the name of the output shim file.
@@ -15,7 +28,8 @@ The keys of the dictionary are the order of the shim coefficients (`0` for spher
 `1` for order 1 (X, Y, Z), `2` for order 2 (Z2, ZX, ZY, X2 - Y2, XY) and `3` for order 3 (Z3, Z2X, Z2Y, Z(X2 - Y2), XYZ, X(X2 - Y2), Y(X2 - Y2)).
 When using Siemens 3rd order shim (which only have 4 channels), use a list of 4 channels in the order described above.
 - `coef_sum_max`: Number specifying the maximum allowed sum of the absolute values of the shim coefficients.
-This is typically not a concern for scanner constraints, you can write `null` to disregard the constraint.
+Scanner's typically do not have a limit for this, you can write `null` to disregard the constraint.
+This option is usually useful for custom constraint files, not scanner constraint files.
 - `coefs_used`: A dictionary to specify the shim value used when acquiring the B0 map. These values are specified in
 the same order as `coef_channel_minmax`. Use `null` instead of a list of values to let Shimming Toolbox read the
 metadata of the B0 map to figure out these values.
@@ -46,17 +60,23 @@ Here is an example of a scanner constraint file for a Siemens MAGNETOM Prisma Fi
 }
 ```
 
-## Do I need to use a scanner constraint file?
-To generate a scanner-specific shim solution that respects the constraints of a scanner, Shimming Toolbox needs to know
-different parameters of the scanner (i.e.: the minimum and maximum shim coefficient for each channel, the current shim coefficients).
+### Do I need to use a scanner constraint file?
+When using an algorithm that supports constraints (see [Which shim algorithms support constraints?](#which-shim-algorithms-support-constraints)),
+Shimming Toolbox needs to know different scanner parameters to respect the scanner's limits
+(i.e.: the minimum and maximum shim coefficient for each channel, the current shim coefficients).
 There are 2 ways for Shimming Toolbox to know the scanner constraints:
 1. We store the shim constraints of specific scanners internally (no need for a scanner constraint file).
-2. Provide these parameters in a file using the `--scanner-coil-constraints` argument when running `st_b0shim dynamic`. This file will overwrite the internal scanner constraints if provided.
+2. Provide these parameters in a file using the `--scanner-coil-constraints` argument when running `st_b0shim dynamic` or `st_b0shim realtime`.
+This file will overwrite the internal scanner constraints if provided.
 
-## Option 1: How can Shimming Toolbox know the current shim values and scanners constraints automatically (recommended)
-The benefit of this option is that you don't need to fill the current shim coefficients (`coefs_used`) yourself everytime you shim. You also don't need to add the `--scanner-coil-constraints` option to the command.
+### Option 1: How can Shimming Toolbox know the current shim values and scanners constraints automatically (recommended)
+The benefit of this option is that you don't need to fill the current shim coefficients (`coefs_used`) yourself everytime you shim.
+You also don't need to add the `--scanner-coil-constraints` option to the command.
 This reduces the risk of human error and saves you time at the scanner.
-### Siemens
+
+You can inspect the list of currently implemented scanners in "shimming-toolbox/shimmin-toolbox/shimmingtoolbox/coils/coil.py".
+
+#### Siemens
 Since Siemens writes the shim coefficient of orders 0, 1 and 2 in the DICOM metadata, they are also available in the BIDS
 sidecar which Shimming Toolbox can access. The values of orders 1 and 2 are stored using DAC units instead of uT/m and uT/m^2 which needs
 scanner specific conversion factors. These conversion factors can be calculated from running both of these commands in the terminal on the scanner:
@@ -72,21 +92,26 @@ To add your scanner to the internal list of supported scanners, you can send us,
 the output of both `AdjValidate` commands, the order 0 (frequency) minimum and maximum values, and a BIDS JSON
 sidecar of an acquisition on your scanner (to identify your scanner's name and unique number).
 
-### Philips
-Philips does not store the shim coefficients (orders 1, 2 and 3) in the DICOM metadata, it is therefore not possible to automatically read the current shim values automatically from a DICOM to NIfTI conversion.
-We have developped a patch to improve Shimming Toolbox's compatibility with Philips scanners. The patch automatically generates a constraint file for each acquisition.
+For order 3, Siemens does not include the current shim values in the DICOM metadata, you therefore need to fill the current
+values of order 3 in the scanner constraint file yourself.
+See [Option 2: How do I find the values to fill in the scanner constraint file?](#option-2-how-do-i-find-the-values-to-fill-in-the-scanner-constraint-file) for more information.
+
+#### Philips
+Philips does not store the shim coefficients (orders 1, 2 and 3) in the DICOM metadata, it is therefore not possible to
+automatically read the current shim values automatically from a DICOM to NIfTI conversion. We have developped a patch to
+improve Shimming Toolbox's compatibility with Philips scanners. The patch automatically generates a constraint file for each acquisition.
 You can contact us to get this patch and instructions on how to use it.
 
-### GE
+#### GE
 GE only stores the orders 0 and 1 shim coefficients in the DICOM metadata. Contact us by opening an [issue](https://github.com/shimming-toolbox/shimming-toolbox/issues)
 if you want to use Shimming Toolbox with a GE scanner so we can figure out the best way to read the current shim values and store the scanner's constraints.
 
-### Other manufacturers
+#### Other manufacturers
 For other manufacturers, please reach out to us so we can find how to read the current shim values and store the scanner's constraints.
 
-## Option 2: How do I find the values to fill in the scanner constraint file?
-### Siemens
-The order 0 minimum and maximum value can be found in the manual frequency adjustment tab when a protocol is loaded on the scanner.
+### Option 2: How do I find the values to fill in the scanner constraint file?
+#### Siemens
+The order 0 (frequency) minimum and maximum value can be found in the manual frequency adjustment tab when a protocol is loaded on the scanner.
 
 Orders 1 and 2 can be found by using the following command in the terminal on the scanner:
 
@@ -96,18 +121,27 @@ AdjValidate -shim -info -mp
 
 The output will be in the same order as `coef_channel_minmax`.
 
-Orders 0 will automatically be read from the B0 map metadata, `coef_channel_minmax[0]` should therefore be `null`.
-Orders 1, 2 and 3 can be found in the manual shim adjustment tab. The coefficent values to fill in are in the same units as that tab (uT/m, uT/m^2, uT/m^3).
+The current frequency (order 0) will automatically be read from the B0 map metadata, `coef_channel_minmax[0]` should therefore be `null`.
 
-### Philips
+Orders 1, 2 and 3 can be found in two different way. Either in the manual shim adjustment tab or with the following command:
+
+```
+AdjValidate -shim -get -mp
+```
+
+The coefficent values to fill in are in the same units as that tab (uT/m, uT/m^2, uT/m^3).
+
+#### Philips
 We recommend contacting us when using Shimming Toolbox with Philips scanners as we have made a patch to improve
 Shimming Toolbox's compatibility with Philips scanners. The patch automatically generates a constraint file for each acquisition.
 
-### Other manufacturers
+#### Other manufacturers
 For other scanners, please reach out to us so we can help figure out the correct values to fill in.
 
-## The custom coil constraint file
+##Custom coil constraint files
+### What are custom coil constraint files
 The coil constraint file is a JSON file that lists the different parameters used by Shimming Toolbox to respect the custom coils contraints.
+
 Here are the different fields in the coil constraint file:
 - `name`: The name of the coil. This will be used when creating the name of the output shim file.
 - `coef_channel_minmax`: A dictionary that lists the minimum and maximum values for each shim channel.

--- a/docs/source/miscellaneous/constraint_file.md
+++ b/docs/source/miscellaneous/constraint_file.md
@@ -1,0 +1,155 @@
+---
+orphan: true
+---
+
+# All about constraint files
+
+## What is in the scanner constraint file?
+The scanner constraint file is a JSON file that lists the different parameters used by Shimming Toolbox
+to generate a scanner-specific shim solution that respects the constraints of the scanner.
+
+The file contains the following fields:
+- `name`: The name of the scanner. This will be used when creating the name of the output shim file.
+- `coef_channel_minmax`: A dictionary that lists the minimum and maximum values for each shim channel.
+The keys of the dictionary are the order of the shim coefficients (`0` for spherical harmonic order 0 (frequency),
+`1` for order 1 (X, Y, Z), `2` for order 2 (Z2, ZX, ZY, X2 - Y2, XY) and `3` for order 3 (Z3, Z2X, Z2Y, Z(X2 - Y2), XYZ, X(X2 - Y2), Y(X2 - Y2)).
+When using Siemens 3rd order shim (which only have 4 channels), use a list of 4 channels in the order described above.
+- `coef_sum_max`: Number specifying the maximum allowed sum of the absolute values of the shim coefficients.
+This is typically not a concern for scanner constraints, you can write `null` to disregard the constraint.
+- `coefs_used`: A dictionary to specify the shim value used when acquiring the B0 map. These values are specified in
+the same order as `coef_channel_minmax`. Use `null` instead of a list of values to let Shimming Toolbox read the
+metadata of the B0 map to figure out these values.
+
+Here is an example of a scanner constraint file for a Siemens MAGNETOM Prisma Fit.:
+```
+{
+    "name": "MAGNETOM Prisma Fit",
+    "coef_channel_minmax":
+    {
+        "0": [[123100100, 123265000]],
+        "1": [[-2300, 2300],
+              [-2300, 2300],
+              [-2300, 2300]],
+        "2": [[-4959.01, 4959.01],
+              [-3551.29, 3551.29],
+              [-3503.299, 3503.299],
+              [-3551.29, 3551.29],
+              [-3487.302, 3487.302]]
+    },
+    "coef_sum_max": null,
+    "coefs_used":
+    {
+        "0": [0],
+        "1": [0, 0, 0],
+        "2": [0, 0, 0, 0, 0]
+    }
+}
+```
+
+## Do I need to use a scanner constraint file?
+To generate a scanner-specific shim solution that respects the constraints of a scanner, Shimming Toolbox needs to know
+different parameters of the scanner (i.e.: the minimum and maximum shim coefficient for each channel, the current shim coefficients).
+There are 2 ways for Shimming Toolbox to know the scanner constraints:
+1. We store the shim constraints of specific scanners internally (no need for a scanner constraint file).
+2. Provide these parameters in a file using the `--scanner-coil-constraints` argument when running `st_b0shim dynamic`. This file will overwrite the internal scanner constraints if provided.
+
+## Option 1: How can Shimming Toolbox know the current shim values and scanners constraints automatically (recommended)
+The benefit of this option is that you don't need to fill the current shim coefficients (`coefs_used`) yourself everytime you shim. You also don't need to add the `--scanner-coil-constraints` option to the command.
+This reduces the risk of human error and saves you time at the scanner.
+### Siemens
+Since Siemens writes the shim coefficient of orders 0, 1 and 2 in the DICOM metadata, they are also available in the BIDS
+sidecar which Shimming Toolbox can access. The values of orders 1 and 2 are stored using DAC units instead of uT/m and uT/m^2 which needs
+scanner specific conversion factors. These conversion factors can be calculated from running both of these commands in the terminal on the scanner:
+
+```
+AdjValidate -shim -info -mp
+AdjValidate -shim -info
+```
+
+The order 0 minimum and maximum value can be found in the manual frequency adjustment tab when a protocol is loaded on the scanner.
+
+To add your scanner to the internal list of supported scanners, you can send us, by opening an [issue](https://github.com/shimming-toolbox/shimming-toolbox/issues),
+the output of both `AdjValidate` commands, the order 0 (frequency) minimum and maximum values, and a BIDS JSON
+sidecar of an acquisition on your scanner (to identify your scanner's name and unique number).
+
+### Philips
+Philips does not store the shim coefficients (orders 1, 2 and 3) in the DICOM metadata, it is therefore not possible to automatically read the current shim values automatically from a DICOM to NIfTI conversion.
+We have developped a patch to improve Shimming Toolbox's compatibility with Philips scanners. The patch automatically generates a constraint file for each acquisition.
+You can contact us to get this patch and instructions on how to use it.
+
+### GE
+GE only stores the orders 0 and 1 shim coefficients in the DICOM metadata. Contact us by opening an [issue](https://github.com/shimming-toolbox/shimming-toolbox/issues)
+if you want to use Shimming Toolbox with a GE scanner so we can figure out the best way to read the current shim values and store the scanner's constraints.
+
+### Other manufacturers
+For other manufacturers, please reach out to us so we can find how to read the current shim values and store the scanner's constraints.
+
+## Option 2: How do I find the values to fill in the scanner constraint file?
+### Siemens
+The order 0 minimum and maximum value can be found in the manual frequency adjustment tab when a protocol is loaded on the scanner.
+
+Orders 1 and 2 can be found by using the following command in the terminal on the scanner:
+
+```
+AdjValidate -shim -info -mp
+```
+
+The output will be in the same order as `coef_channel_minmax`.
+
+Orders 0 will automatically be read from the B0 map metadata, `coef_channel_minmax[0]` should therefore be `null`.
+Orders 1, 2 and 3 can be found in the manual shim adjustment tab. The coefficent values to fill in are in the same units as that tab (uT/m, uT/m^2, uT/m^3).
+
+### Philips
+We recommend contacting us when using Shimming Toolbox with Philips scanners as we have made a patch to improve
+Shimming Toolbox's compatibility with Philips scanners. The patch automatically generates a constraint file for each acquisition.
+
+### Other manufacturers
+For other scanners, please reach out to us so we can help figure out the correct values to fill in.
+
+## The custom coil constraint file
+The coil constraint file is a JSON file that lists the different parameters used by Shimming Toolbox to respect the custom coils contraints.
+Here are the different fields in the coil constraint file:
+- `name`: The name of the coil. This will be used when creating the name of the output shim file.
+- `coef_channel_minmax`: A dictionary that lists the minimum and maximum values for each shim channel.
+We don't enforce units but your coil profiles need to be consistent (if your coil profiles are in Hz/A, then these
+values are in A, if your coil profiles are in Hz/mA, then these values should be in mA).
+Use `null` to set the limit to infinity.
+- `coef_sum_max`: Number specifying the maximum allowed sum of the absolute values of the shim coefficients. Use `null` to set the limit to infinity.
+- `coefs_used`: A dictionary to specify the shim value used when acquiring the B0 map. These values are specified in
+the same order as `coef_channel_minmax`. These will typically be 0.
+- `Units`: Used for display purposes only and does not affect any shim current output.
+
+```
+{
+    "name": "custom",
+    "coef_channel_minmax":
+    {
+        "coil": [[-2.5, 2.5],
+                 [-2.5, 2.5],
+                 [-2.5, 2.5],
+                 [-2.5, 2.5],
+                 [-2.5, 2.5],
+                 [-2.5, 2.5],
+                 [-2.5, 2.5],
+                 [-2.5, 2.5],
+                 [-2.5, 2.5]]
+    },
+    "coef_sum_max": 20,
+    "coefs_used":
+    {
+        "coil": [0, 0, 0, 0, 0, 0, 0, 0, 0]
+    },
+    "Units": "A"
+}
+```
+
+This file gets populated with the correct values when running `st_create_coil_profiles`. For more information, see the {ref}`create_b0_coil_profiles` tutorial.
+
+## Which shim algorithms support constraints?
+The following algorithms support scanner constraints (--optimizer-method):
+- `least_squares`: Minimum and maximum bounds (coef_channel_minmax), and maximum sum of absolute values (coef_sum_max)
+- `quad_prog`: Minimum and maximum bounds (coef_channel_minmax), and maximum sum of absolute values (coef_sum_max)
+- `bfgs`: Minimum and maximum bounds (coef_channel_minmax)
+
+The following algorithms *do not* support scanner constraints:
+- `pseudo_inverse`

--- a/docs/source/miscellaneous/constraint_file.md
+++ b/docs/source/miscellaneous/constraint_file.md
@@ -3,7 +3,7 @@ orphan: true
 ---
 
 # All about constraint files
-This page explains how Shimming Toolbox uses constraint files to respect the limits of your shim coil when optimizing the shim solution.
+This page explains how Shimming Toolbox uses constraint files to respect the limits of your shim coil when optimizing the shim coefficients.
 Both scanner coil and custom coil constraint files are discussed.
 
 ## What are constraint files?
@@ -32,7 +32,8 @@ Scanner's typically do not have a limit for this, you can write `null` to disreg
 This option is usually useful for custom constraint files, not scanner constraint files.
 - `coefs_used`: A dictionary to specify the shim value used when acquiring the B0 map. These values are specified in
 the same order as `coef_channel_minmax`. Use `null` instead of a list of values to let Shimming Toolbox read the
-metadata of the B0 map to figure out these values.
+metadata of the B0 map to figure out these values. See
+[Option 1: How can Shimming Toolbox know the current shim values and scanners constraints automatically (recommended)](#option-1-how-can-shimming-toolbox-know-the-current-shim-values-and-scanners-constraints-automatically-recommended) for more information.
 
 Here is an example of a scanner constraint file for a Siemens MAGNETOM Prisma Fit.:
 ```
@@ -111,7 +112,7 @@ For other manufacturers, please reach out to us so we can find how to read the c
 
 ### Option 2: How do I find the values to fill in the scanner constraint file?
 #### Siemens
-The order 0 (frequency) minimum and maximum value can be found in the manual frequency adjustment tab when a protocol is loaded on the scanner.
+The order 0 (frequency) minimum and maximum values can be found in the manual frequency adjustment tab when a protocol is loaded on the scanner.
 
 Orders 1 and 2 can be found by using the following command in the terminal on the scanner:
 
@@ -138,7 +139,7 @@ Shimming Toolbox's compatibility with Philips scanners. The patch automatically 
 #### Other manufacturers
 For other scanners, please reach out to us so we can help figure out the correct values to fill in.
 
-##Custom coil constraint files
+## Custom coil constraint files
 ### What are custom coil constraint files
 The coil constraint file is a JSON file that lists the different parameters used by Shimming Toolbox to respect the custom coils contraints.
 
@@ -185,5 +186,5 @@ The following algorithms support scanner constraints (--optimizer-method):
 - `quad_prog`: Minimum and maximum bounds (coef_channel_minmax), and maximum sum of absolute values (coef_sum_max)
 - `bfgs`: Minimum and maximum bounds (coef_channel_minmax)
 
-The following algorithms *do not* support scanner constraints:
+The following algorithms **do not** support scanner constraints:
 - `pseudo_inverse`

--- a/docs/source/user_section/faq.rst
+++ b/docs/source/user_section/faq.rst
@@ -24,3 +24,9 @@ FAQ
 
     The mathematical foundations and equations used in the optimization algorithms are documented here:
     :doc:`Objective Function Equations for Magnetic Field Shimming Optimization <../miscellaneous/residuals_eq>`.
+
+6. **How can I make sure my constraints are respected when optimizing?**
+
+    The st_b0shim CLI includes options to set constraints on the coil currents. To find out more about how to fill the
+    constraint files (for custom coils or canner coils), refer to this document:
+    :doc:`All about constraint files <../miscellaneous/constraint_file>`.


### PR DESCRIPTION
## Description
Add information about constraint files on the website.

## How to look at the new doc
To look at the [new doc](https://shimming-toolbox-py--651.org.readthedocs.build/en/651/miscellaneous/constraint_file.html).
It can be accessed through the question 6 in the FAQ.
