### PR TITLE
Simplify BET mask output file

### DIFF
--- a/fsleyes-plugin-shimming-toolbox/fsleyes_plugin_shimming_toolbox/components/run_component.py
+++ b/fsleyes-plugin-shimming-toolbox/fsleyes_plugin_shimming_toolbox/components/run_component.py
@@ -116,18 +116,7 @@ class RunComponent(Component):
                     self.panel.terminal_component.log_to_terminal(
                         "Could not fetch subject and/or path to load to overlay"
                     )
-                    
-            if self.st_function == "st_mask bet":
-                # Remove extension from output
-                fname_output = self.output
-                path = pathlib.Path(fname_output)
-                while path.suffix:
-                    path = path.with_suffix('')
 
-                mask = str(path) + '_mask.nii.gz'
-                self.output_paths.clear()
-                self.output_paths.append(mask)
-                
             self.send_output_to_overlay()
 
             self.output_paths.clear()

--- a/fsleyes-plugin-shimming-toolbox/test/gui/test_mask_tab.py
+++ b/fsleyes-plugin-shimming-toolbox/test/gui/test_mask_tab.py
@@ -23,33 +23,33 @@ def test_st_plugin_mask_threshold():
     options = {
         'threshold': '0.1',
     }
-    
+
     def _test_st_plugin_mask_threshold(view, overlayList, displayCtx, options=options):
         __test_st_plugin_mask_threshold(view, overlayList, displayCtx, options=options)
     run_with_orthopanel(_test_st_plugin_mask_threshold)
-    
-    
+
+
 def test_st_plugin_mask_rectangle():
     options = {
         'size': '3',
         'center': '0',
     }
-    
+
     def _test_st_plugin_mask_rectangle(view, overlayList, displayCtx, options=options):
         __test_st_plugin_mask_shape(view, overlayList, displayCtx, options=options, shape='Rectangle')
     run_with_orthopanel(_test_st_plugin_mask_rectangle)
-    
+
 
 def test_st_plugin_mask_box():
     options = {
         'size': '3',
         'center': '0',
     }
-    
+
     def _test_st_plugin_mask_box(view, overlayList, displayCtx, options=options):
         __test_st_plugin_mask_shape(view, overlayList, displayCtx, options=options, shape='Box')
     run_with_orthopanel(_test_st_plugin_mask_box)
-    
+
 
 def test_st_plugin_mask_sphere():
     options = {
@@ -57,7 +57,7 @@ def test_st_plugin_mask_sphere():
         'center': '0',
         'size': None,
     }
-    
+
     def _test_st_plugin_mask_sphere(view, overlayList, displayCtx, options=options):
         __test_st_plugin_mask_shape(view, overlayList, displayCtx, options=options, shape='Sphere')
     run_with_orthopanel(_test_st_plugin_mask_sphere)
@@ -69,19 +69,19 @@ def test_st_plugin_mask_bet():
         'f_param': '1',
         'g_param': '0.2',
     }
-    
+
     def _test_st_plugin_mask_bet(view, overlayList, displayCtx, options=options):
         __test_st_plugin_mask_bet(view, overlayList, displayCtx, options=options)
     run_with_orthopanel(_test_st_plugin_mask_bet)
 
-   
+
 def test_st_plugin_mask_erode():
     options = {
         'operation': 'Erode',
         'shape': 'Cube',
         'size': '3',
     }
-    
+
     def _test_st_plugin_mask_modify(view, overlayList, displayCtx, options=options):
         __test_st_plugin_mask_modify(view, overlayList, displayCtx, options=options)
     run_with_orthopanel(_test_st_plugin_mask_modify)
@@ -93,30 +93,30 @@ def test_st_plugin_mask_dilate():
         'shape': 'Sphere',
         'size': '3',
     }
-    
+
     def _test_st_plugin_mask_modify(view, overlayList, displayCtx, options=options):
         __test_st_plugin_mask_modify(view, overlayList, displayCtx, options=options)
     run_with_orthopanel(_test_st_plugin_mask_modify)
 
-   
+
 def __test_st_plugin_mask_threshold(view, overlayList, displayCtx, options):
     """
     Test the Mask tab with the threshold option.
     """
     nb_terminal = get_notebook(view)
-    
+
     # Select the mask tab
     assert set_notebook_page(nb_terminal, "Mask")
-    
+
     # Get the mask tab
     mask_tab = get_tab(nb_terminal, MaskTab)
     assert mask_tab is not None
-    
+
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         # fname for target
         fname_target = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
         nii_target = nib.load(fname_target)
-        
+
         # Fill the widgets with the Mask tab options
         list_widgets = []
         get_all_children(mask_tab.sizer_run, list_widgets)
@@ -124,7 +124,7 @@ def __test_st_plugin_mask_threshold(view, overlayList, displayCtx, options):
             if isinstance(widget, wx.Choice) and widget.IsShown():
                 if widget.GetName() == 'mask_algorithms':
                     assert set_dropdown_selection(widget, 'Threshold')
-        
+
         # Fill the widgets with the BET options
         list_widgets = []
         get_all_children(mask_tab.sizer_run, list_widgets)
@@ -135,10 +135,10 @@ def __test_st_plugin_mask_threshold(view, overlayList, displayCtx, options):
                 widget.SetValue(options['threshold'])
             elif widget.GetName() == 'output':
                 widget.SetValue(os.path.join(tmp, 'mask.nii.gz'))
-                
+
         # Run the mask
         mask_tab.run_component_thr.run()
-        
+
         # Search for the output for a maximum of 20 seconds
         for _ in range(20):
             realYield()
@@ -146,7 +146,7 @@ def __test_st_plugin_mask_threshold(view, overlayList, displayCtx, options):
             time.sleep(1)
             if ovrlay_file:
                 break
-        
+
         # Make sure the output is correct
         assert ovrlay_file is not None
         assert os.path.exists(ovrlay_file.dataSource)
@@ -157,19 +157,19 @@ def __test_st_plugin_mask_shape(view, overlayList, displayCtx, options, shape):
     Test the Mask tab with the rectangle/box option.
     """
     nb_terminal = get_notebook(view)
-    
+
     # Select the mask tab
     assert set_notebook_page(nb_terminal, "Mask")
-    
+
     # Get the mask tab
     mask_tab = get_tab(nb_terminal, MaskTab)
     assert mask_tab is not None
-    
+
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         # fname for target
         fname_target = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
         nii_target = nib.load(fname_target)
-        
+
         # Fill the widgets with the Mask tab options
         list_widgets = []
         get_all_children(mask_tab.sizer_run, list_widgets)
@@ -177,7 +177,7 @@ def __test_st_plugin_mask_shape(view, overlayList, displayCtx, options, shape):
             if isinstance(widget, wx.Choice) and widget.IsShown():
                 if widget.GetName() == 'mask_algorithms':
                     assert set_dropdown_selection(widget, shape)
-        
+
         # Fill the widgets with the BET options
         list_widgets = []
         get_all_children(mask_tab.sizer_run, list_widgets)
@@ -192,10 +192,10 @@ def __test_st_plugin_mask_shape(view, overlayList, displayCtx, options, shape):
                 widget.SetValue(options['radius'])
             elif widget.GetName() == 'output':
                 widget.SetValue(os.path.join(tmp, 'mask.nii.gz'))
-                
+
         # Run the mask
         mask_tab.run_component_thr.run()
-        
+
         # Search for the output for a maximum of 20 seconds
         for _ in range(20):
             realYield()
@@ -203,7 +203,7 @@ def __test_st_plugin_mask_shape(view, overlayList, displayCtx, options, shape):
             time.sleep(1)
             if ovrlay_file:
                 break
-        
+
         # Make sure the output is correct
         assert ovrlay_file is not None
         assert os.path.exists(ovrlay_file.dataSource)
@@ -214,19 +214,19 @@ def __test_st_plugin_mask_bet(view, overlayList, displayCtx, options):
     Test the Mask tab with the BET option.
     """
     nb_terminal = get_notebook(view)
-    
+
     # Select the mask tab
     assert set_notebook_page(nb_terminal, "Mask")
-    
+
     # Get the mask tab
     mask_tab = get_tab(nb_terminal, MaskTab)
     assert mask_tab is not None
-    
+
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         # fname for target
         fname_target = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
         nii_target = nib.load(fname_target)
-        
+
         # Fill the widgets with the Mask tab options
         list_widgets = []
         get_all_children(mask_tab.sizer_run, list_widgets)
@@ -234,7 +234,7 @@ def __test_st_plugin_mask_bet(view, overlayList, displayCtx, options):
             if isinstance(widget, wx.Choice) and widget.IsShown():
                 if widget.GetName() == 'mask_algorithms':
                     assert set_dropdown_selection(widget, 'BET')
-        
+
         # Fill the widgets with the BET options
         list_widgets = []
         get_all_children(mask_tab.sizer_run, list_widgets)
@@ -246,11 +246,11 @@ def __test_st_plugin_mask_bet(view, overlayList, displayCtx, options):
             elif widget.GetName() == 'input':
                 widget.SetValue(fname_target)
             elif widget.GetName() == 'output':
-                widget.SetValue(os.path.join(tmp, 'bet'))
-                
+                widget.SetValue(os.path.join(tmp, 'bet_mask.nii.gz'))
+
         # Run the mask
         mask_tab.run_component_bet.run()
-        
+
         # Search for the output for a maximum of 20 seconds
         for _ in range(20):
             realYield()
@@ -258,36 +258,36 @@ def __test_st_plugin_mask_bet(view, overlayList, displayCtx, options):
             time.sleep(1)
             if ovrlay_file:
                 break
-        
+
         # Make sure the output is correct
         assert ovrlay_file is not None
         assert os.path.exists(ovrlay_file.dataSource)
-        
+
 
 def __test_st_plugin_mask_modify(view, overlayList, displayCtx, options):
     """
     Test the Mask tab with the Erode option.
     """
     nb_terminal = get_notebook(view)
-    
+
     # Select the mask tab
     assert set_notebook_page(nb_terminal, "Mask")
-    
+
     # Get the mask tab
     mask_tab = get_tab(nb_terminal, MaskTab)
     assert mask_tab is not None
-    
+
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         # fname for target
         fname_target = os.path.join(__dir_testing__, 'ds_b0', 'sub-realtime', 'anat', 'sub-realtime_unshimmed_e1.nii.gz')
         nii_target = nib.load(fname_target)
-        
+
         nx, ny, nz = nii_target.shape
         mask = shapes(nii_target, 'cube',
                   center_dim1=int(nx / 2),
                   center_dim2=int(ny / 2),
                   len_dim1=10, len_dim2=10, len_dim3=nz - 10)
-        
+
         fname_output_file = "mask_modified"
         output_path = os.path.join(tmp, fname_output_file + ".nii.gz")
         # Fill the widgets with the Mask tab options
@@ -297,7 +297,7 @@ def __test_st_plugin_mask_modify(view, overlayList, displayCtx, options):
             if isinstance(widget, wx.Choice) and widget.IsShown():
                 if widget.GetName() == 'mask_algorithms':
                     assert set_dropdown_selection(widget, 'Erode/Dilate')
-        
+
         # Fill the widgets with the Erode options
         list_widgets = []
         get_all_children(mask_tab.sizer_run, list_widgets)
@@ -312,10 +312,10 @@ def __test_st_plugin_mask_modify(view, overlayList, displayCtx, options):
                 widget.SetValue(options['size'])
             elif widget.GetName() == 'output':
                 widget.SetValue(output_path)
-                
+
         # Run the mask
         mask_tab.run_component_modify.run()
-        
+
         # Search for the output for a maximum of 20 seconds
         for _ in range(20):
             realYield()
@@ -323,8 +323,7 @@ def __test_st_plugin_mask_modify(view, overlayList, displayCtx, options):
             time.sleep(1)
             if ovrlay_file:
                 break
-        
+
         # Make sure the output is correct
         assert ovrlay_file is not None
         assert os.path.exists(ovrlay_file.dataSource)
-        

--- a/shimming-toolbox/shimmingtoolbox/cli/mask.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/mask.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*
 
-import pathlib
 import click
 import logging
-import os
 import nibabel as nib
 import numpy as np
+import os
+import pathlib
+import tempfile
 
 from shimmingtoolbox.masking.shapes import shape_square, shape_cube, shape_sphere
 import shimmingtoolbox.masking.threshold
 from shimmingtoolbox.masking.mask_mrs import mask_mrs
-from shimmingtoolbox.utils import run_subprocess, create_output_dir, set_all_loggers
+from shimmingtoolbox.utils import run_subprocess, create_output_dir, set_all_loggers, splitext
 from shimmingtoolbox.masking.softmasks import save_softmask, create_softmask
 from shimmingtoolbox.masking.mask_utils import modify_binary_mask as modify_binary_mask_api
 
@@ -294,10 +296,10 @@ def sct(fname_input, fname_output, contrast, centerline, file_centerline, brain,
                     "Create a brain mask in the coordinates of the input file. The mask is stored by default "
                        "under the name 'mask.nii.gz' in the output folder.")
 @click.option('-i', '--input', 'fname_input', type=click.Path(exists=True), required=True,
-              help="Input path of the nifti file to mask. This nifti file must be 3D. Supported "
+              help="Input path of the nifti file to mask. This nifti file must be 3D or 4D (it will be averaged). Supported "
                    "extensions are .nii or .nii.gz.")
-@click.option('-o', '--output', 'fname_output', type=click.Path(), default=os.path.join(os.curdir, 'mask'),
-              show_default=True, help="Name of output mask. Do not add extension")
+@click.option('-o', '--output', 'fname_output', type=click.Path(), default=os.path.join(os.curdir, 'mask.nii.gz'),
+              show_default=True, help="Name of the output mask. Supported extensions are .nii.gz.")
 @click.option('-f', '--f_param', required=False, type=float, default=0.5,
               help="fractional intensity threshold (0->1); default=0.5; smaller values give larger brain outline estimates")
 @click.option('-g', '--g_param', type=float, required=False, default=0,
@@ -306,30 +308,42 @@ def sct(fname_input, fname_output, contrast, centerline, file_centerline, brain,
 def bet(fname_input, fname_output, f_param, g_param, verbose):
 
     set_all_loggers(verbose)
+
     # Prepare the output
     create_output_dir(fname_output, is_file=True)
+
+    if not fname_input.endswith('.nii.gz'):
+        raise ValueError("Input file must be a nifti file with extension .nii.gz")
 
     # Make sure input path exists
     if not os.path.exists(fname_input):
         raise RuntimeError("Input file does not exist")
 
-    # Get the number of dimensions
-    nii_input = nib.load(fname_input)
-    ndim = nii_input.ndim
-    # If 4d, last dimension is time, average last dim for better SNR
-    if ndim == 4:
-        input_3d = np.mean(nii_input.get_fdata(), 3)
-        nii_3d = nib.Nifti1Image(input_3d, affine=nii_input.affine, header=nii_input.header)
-        fname_mean = os.path.join(os.path.dirname(fname_output), 'mean_3d.nii.gz')
-        nib.save(nii_3d, fname_mean)
-        fname_process = fname_mean
-    # If not then only set the processing filename
-    else:
-        fname_process = fname_input
+    # Create tmp directory,run BET in that directory, rename the output mask to fname_output
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
 
-    # Run BET
-    # Create the mask
-    run_subprocess(['bet2', fname_process, fname_output, '-f', str(f_param), '-g', str(g_param), '-m'])
+        # Get the number of dimensions
+        nii_input = nib.load(fname_input)
+        ndim = nii_input.ndim
+        # If 4d, last dimension is time, average last dim for better SNR
+        if ndim == 4:
+            input_3d = np.mean(nii_input.get_fdata(), 3)
+            nii_3d = nib.Nifti1Image(input_3d, affine=nii_input.affine, header=nii_input.header)
+            fname_mean = os.path.join(tmp, 'mean_3d.nii.gz')
+            nib.save(nii_3d, fname_mean)
+            fname_process = fname_mean
+        # If not then only set the processing filename
+        else:
+            fname_process = fname_input
+
+        fname_bet_input = os.path.join(tmp, 'bet')
+        fname_bet_mask_output = os.path.join(tmp, 'bet_mask.nii.gz')
+
+        # Run BET
+        # Create the mask
+        run_subprocess(['bet2', fname_process, fname_bet_input, '-f', str(f_param), '-g', str(g_param), '-m'])
+
+        os.rename(fname_bet_mask_output, fname_output)
 
     return fname_output
 

--- a/shimming-toolbox/test/cli/test_cli_mask.py
+++ b/shimming-toolbox/test/cli/test_cli_mask.py
@@ -377,7 +377,7 @@ def test_cli_softmask_gaussian():
 
 
 @pytest.mark.bet
-def test_sli_mask_bet():
+def test_cli_mask_bet():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 
@@ -395,7 +395,7 @@ def test_sli_mask_bet():
 
 
 @pytest.mark.bet
-def test_sli_mask_bet_4d():
+def test_cli_mask_bet_4d():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()
 

--- a/shimming-toolbox/test/cli/test_cli_mask.py
+++ b/shimming-toolbox/test/cli/test_cli_mask.py
@@ -374,3 +374,46 @@ def test_cli_softmask_gaussian():
                              [[1.0, val1], [1.0, val1], [1.0, val1]]])
 
         assert np.allclose(softmask[58:62, 28:31, 7:9], expected)
+
+
+@pytest.mark.bet
+def test_sli_mask_bet():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        fname_output = os.path.join(tmp, 'bet.nii.gz')
+
+        result = runner.invoke(mask_cli, ["bet",
+                                          "--input", fname_input,
+                                          "--output",  fname_output],
+                               catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output)
+        mask = nib.load(fname_output).get_fdata()
+        assert 0 <= mask.max() <= 1
+
+
+@pytest.mark.bet
+def test_sli_mask_bet_4d():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        fname_output = os.path.join(tmp, 'bet.nii.gz')
+
+        nii = nib.load(fname_input)
+        nii_4d = nib.Nifti1Image(np.repeat(np.expand_dims(nii.get_fdata(), 3), 3, axis=-1),
+                                 nii.affine,
+                                 nii.header)
+        fname_4d = os.path.join(tmp, 'input_4d.nii.gz')
+        nib.save(nii_4d, fname_4d)
+
+        result = runner.invoke(mask_cli, ["bet",
+                                          "--input", fname_4d,
+                                          "--output",  fname_output],
+                               catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(fname_output)
+        mask = nib.load(fname_output).get_fdata()
+        assert 0 <= mask.max() <= 1


### PR DESCRIPTION
## Description
I changed the behaviour of the `-o` argument in `st_mask bet`. It was causing unnecessary confusion. Instead of requiring no extension and a mask be created with that path + _mask.nii.gz (behaviour of BET). Now the path entered will be the name of the output mask file (in line with all other st_mask CLI). Under the hood, we create the mask with a standard name in a tmp directory and rename it to the user's input. We need a `.nii.gz` to stay consistent with BET's output.
