### PR TITLE
Update conda installer, FSLeyes and python versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.x'
       - name: Cache pip dependencies
         id: cache-pip-dependencies
         uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           - 'ubuntu-24.04'
           - 'ubuntu-22.04'
         python-version:
-          - '3.11'
+          - '3.x'
         tests:
           - 'fsleyes-plugin-shimming-toolbox'
           - 'shimming-toolbox'
@@ -189,7 +189,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.x'
     - name: Finished
       run: |
         pip3 install --upgrade coveralls

--- a/installer/install_conda.sh
+++ b/installer/install_conda.sh
@@ -17,9 +17,9 @@ cd "$ST_DIR"
 set -e
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    CONDA_INSTALLER=Mambaforge-Linux-x86_64.sh
+    CONDA_INSTALLER=Miniforge3-Linux-x86_64.sh
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    CONDA_INSTALLER=Mambaforge-Darwin-x86_64.sh
+    CONDA_INSTALLER=Miniforge3-Darwin-x86_64.sh
 elif [[ "$OSTYPE" == "cygwin" ]]; then
     # POSIX compatibility layer and Linux environment emulation for Windows
     echo "Invalid operating system"
@@ -39,7 +39,7 @@ else
     exit 1
 fi
 
-CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/download/24.5.0-0/"$CONDA_INSTALLER"
+CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/latest/download/"$CONDA_INSTALLER"
 
 installConda() {
     curl -L --url $CONDA_INSTALLER_URL --output $TMP_DIR/$CONDA_INSTALLER

--- a/installer/install_plugin.sh
+++ b/installer/install_plugin.sh
@@ -37,7 +37,7 @@ source "${ST_DIR}/${PYTHON_DIR}/bin/activate"
 
 # Install fsleyes
 print info "Installing fsleyes"
-"${ST_DIR}"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge fsleyes=1.16.3 python=3.11
+"${ST_DIR}"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge fsleyes=1.19.0
 
 # Install fsleyes-plugin-shimming-toolbox
 print info "Installing fsleyes-plugin-shimming-toolbox"

--- a/installer/install_shimming_toolbox.sh
+++ b/installer/install_shimming_toolbox.sh
@@ -39,9 +39,6 @@ function edit_shellrc() {
 
 source "${ST_DIR}/${PYTHON_DIR}/bin/activate"
 
-print info "Installing python"
-"$ST_DIR"/"${PYTHON_DIR}"/bin/mamba install -y -c conda-forge python=3.11
-
 print info "Installing shimming-toolbox"
 cp "${ST_PACKAGE_DIR}/shimmingtoolbox/config/dcm2bids.json" "${ST_DIR}/dcm2bids.json"
 cp "${ST_PACKAGE_DIR}/shimmingtoolbox/config/custom_coil_constraints.json" "${ST_DIR}/custom_coil_constraints.json"

--- a/installer/windows_install.bat
+++ b/installer/windows_install.bat
@@ -21,7 +21,7 @@ mkdir "%ST_DIR%\%PYTHON_DIR%"
 echo Installing conda in %ST_DIR%\%PYTHON_DIR%
 REM Test for other OSs
 set "CONDA_INSTALLER=Miniforge3-Windows-x86_64.exe"
-set "CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/download/24.5.0-0/%CONDA_INSTALLER%"
+set "CONDA_INSTALLER_URL=https://github.com/conda-forge/miniforge/releases/latest/download/%CONDA_INSTALLER%"
 
 :uniqLoop
 set "UNIQUE_TMP_INSTALLER=%tmp%\st_%RANDOM%_%CONDA_INSTALLER%"
@@ -35,10 +35,6 @@ echo Installing ...
 start /wait "" "%UNIQUE_TMP_INSTALLER%" /RegisterPython=0 /S /D=%ST_DIR%\%PYTHON_DIR%
 
 del "%UNIQUE_TMP_INSTALLER%"
-
-REM Installing python
-echo Installing python
-call "%ST_DIR%\%PYTHON_DIR%\condabin\mamba.bat" install -y -c conda-forge python=3.11 || goto error
 
 REM Installing Shimming Toolbox
 echo Installing Shimming Toolbox

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.x"
+    python: "latest"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.x"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
## Description
This PR
- Unpins the conda/mamba/miniforge version being installed
- Unpins python 3.11 being installed (we let the base python version get used)
- Unpin the CI's python version to 3.x
- Updates to FSLeyes 1.19.0