### PR TITLE
Remove hard requirement of SoftwareVersion tag the field map JSON sidecar

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
@@ -246,7 +246,7 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
     if slices == 'auto':
         list_slices = parse_slices(fname_target)
     else:
-        list_slices = define_slices(n_slices, slice_factor, slices, nif_fmap.get_json_info('SoftwareVersions'))
+        list_slices = define_slices(n_slices, slice_factor, slices, nif_fmap.get_json_info('SoftwareVersions', required=False))
     logger.info(f"The slices to shim are:\n{list_slices}")
     # Get shimming coefficients
     # 1 ) Create the Shimming sequencer object
@@ -739,7 +739,7 @@ def realtime_dynamic(fname_fmap, fname_target, fname_mask_target_static, fname_m
     if slices == 'auto':
         list_slices = parse_slices(fname_target)
     else:
-        list_slices = define_slices(n_slices, slice_factor, slices, nif_fmap.get_json_info('SoftwareVersions'))
+        list_slices = define_slices(n_slices, slice_factor, slices, nif_fmap.get_json_info('SoftwareVersions', required=False))
 
     logger.info(f"The slices to shim are: {list_slices}")
 

--- a/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
@@ -2193,6 +2193,7 @@ def define_slices(n_slices: int, factor=1, method='ascending', software_version=
         factor (int): Number of slices per shim.
         method (str): Defines how the slices should be sorted, supported methods include: 'interleaved', 'ascending',
                       'descending', 'volume'. See Examples for more details.
+        software_version (str): Software version of the scanner.
 
     Returns:
         list: 1D list containing tuples of dim3 slices to shim. (dim1, dim2, dim3)
@@ -2235,7 +2236,7 @@ def define_slices(n_slices: int, factor=1, method='ascending', software_version=
             leftover = n_slices % factor
 
         else:
-            if software_version != 'syngo MR E11':
+            if software_version is None or software_version != 'syngo MR E11':
                 logger.warning("SMS has only been tested with syngo MR E11. If you are using a different software "
                                "version, the slices might not be interleaved or grouped correctly.")
 


### PR DESCRIPTION
## Description
When using --slices with anything other than auto, there was a hard requirement on the BIDS tag `SoftwareVersion` to be present. That tag is only used for logging and should not be a hard requirement. This removes the error being thrown if that tag is not present.
