### PR TITLE
Sort non acquisition related DICOM files

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/cli/sort_dicoms.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/sort_dicoms.py
@@ -42,9 +42,15 @@ def sort_dicoms(path_input, is_recursive, recursive_depth, path_output, verbose)
     for fname_dcm in sorted(list_dicoms):
         # Create the file path
         ds = dcmread(fname_dcm)
-        series_number = ds["SeriesNumber"].value
-        series_description = ds["SeriesDescription"].value
-        folder_name = f"{series_number:02d}-" + series_description
+
+        if ds.get("SeriesNumber") is None or ds.get("SeriesDescription") is None:
+            logger.debug(f"{fname_dcm} has no SeriesNumber or SeriesDescription")
+            folder_name = ""
+        else:
+            series_number = ds["SeriesNumber"].value
+            series_description = ds["SeriesDescription"].value
+            folder_name = f"{series_number:02d}-" + series_description
+
         path_folder_output = os.path.join(path_output, folder_name)
 
         # Create output directory with the new name if it does not exist
@@ -96,5 +102,6 @@ def get_dicom_paths(path, is_recursive, subfolder_depth=0, max_depth=DEFAULT_REC
             continue
 
         list_dicoms.append(fname_tmp)
+        logger.debug(f"Found DICOM: {fname_tmp}")
 
     return list_dicoms

--- a/shimming-toolbox/shimmingtoolbox/utils.py
+++ b/shimming-toolbox/shimmingtoolbox/utils.py
@@ -194,7 +194,7 @@ def create_fname_from_path(path, file_default):
     return os.path.abspath(fname)
 
 
-def set_all_loggers(verbose, list_exclude=('matplotlib', 'indexed_gzip')):
+def set_all_loggers(verbose, list_exclude=('matplotlib', 'indexed_gzip', 'pydicom')):
     """ Set all loggers in the root manager to the verbosity level. Exclude any logger with the name in list_exclude
 
     Args:


### PR DESCRIPTION
## Description
Some DICOM files don't have acquisition numbers or series description (e.g.: DICOMDIR). These files would raise error if they were included in the input data. This PR finds these files and copies them into the root of the output directory.

Also add pydicom to the default list of excluded loggers