### PR TITLE
Support 4d field maps with singleton in the last dimension in st_b0shim dynamic

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/files/NiftiFieldMap.py
+++ b/shimming-toolbox/shimmingtoolbox/files/NiftiFieldMap.py
@@ -49,18 +49,23 @@ class NiftiFieldMap(NiftiFile):
             numpy.array : The extended NIfTI image if the field map was extended, otherwise the original NIfTI image.
         """
         self.extended = False
+
+        # If realtime, fmap must be 4d
+        if self.is_realtime and self.ndim != 4:
+            raise ValueError("Fieldmap must be 4d for realtime processing")
+
+        # If not realtime, ndim should be 2 or 3 unless last dimension has 1 volume
+        if not self.is_realtime and self.ndim == 4 and self.shape[3] == 1:
+            super().set_nii(nib.Nifti1Image(self.data[..., 0], self.affine, header=self.header))
+
         if self.ndim != 3 and not self.is_realtime:
             if self.ndim == 2:
-                super().set_nii(nib.Nifti1Image(self.data[..., np.newaxis], self.affine,
-                                                header=self.header))
+                super().set_nii(nib.Nifti1Image(self.data[..., np.newaxis], self.affine, header=self.header))
                 extended_nii = self.extend_fmap_to_kernel_size(dilation_kernel_size)
                 self.extended = True
             else:
                 raise ValueError("Fieldmap must be 2d or 3d")
         else:
-            if self.is_realtime and self.ndim != 4:
-                raise ValueError("Fieldmap must be 4d for realtime processing")
-
             for i_axis in range(3):
                 if self.shape[i_axis] < dilation_kernel_size:
                     self.extended = True

--- a/shimming-toolbox/test/files/test_NiftiFieldMap.py
+++ b/shimming-toolbox/test/files/test_NiftiFieldMap.py
@@ -38,6 +38,17 @@ def test_niftifieldmap_init(temp_nifti_file):
     assert nifti.data.shape == (10, 10, 10)
 
 
+def test_niftifieldmap_static_4d_singleton(temp_nifti_file):
+    """Test NiftiFieldMap initialization with valid file."""
+    nifti = NiftiFieldMap(temp_nifti_file, 3)
+    new_data = np.ones((10, 10, 10, 1))
+    new_nii = nib.Nifti1Image(new_data, affine=np.eye(4))
+    nifti.set_nii(new_nii)
+    assert isinstance(nifti.nii, nib.Nifti1Image)
+    assert isinstance(nifti.data, np.ndarray)
+    assert nifti.data.shape == (10, 10, 10)
+
+
 def test_set_nii_wrong_dim(temp_nifti_file):
     """Test setting a new NIfTI image."""
     nifti = NiftiFieldMap(temp_nifti_file, 3)


### PR DESCRIPTION
## Description
It is possible to save 4D data in a NIfTI file with a singleton in the last dimension (e.g.: 64x64x20x1). ST flags it as 4D data which is unsupported by st_b0shim dynamic. However, this is effectively 3D data so we should support it. This PR fixes that.

## Linked issues
https://github.com/shimming-toolbox/shimming-toolbox/discussions/664#discussioncomment-17635493
