### PR TITLE
Add and refactor functions to change coordinate systems

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
@@ -352,12 +352,7 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
             if (fname_sph_constr is not None) and (slices == 'volume'):
                 write_updated_scanner_constraints(scanner_coil_order, manufacturer, coefs_coil, coil, path_output)
 
-            # If outputting in the gradient CS, it must be specific orders, it must be in the delta CS and Siemens
-            # The check has already been done earlier in the program to avoid processing and throw an error afterwards.
-            # Therefore, we can only check for the o_format_sph.
             if 'hrd' in o_format_sph:
-                logger.debug("Converting Siemens scanner coil from Shim CS (LAI) to Gradient CS")
-
                 coefs_coil = coefs_to_dict(coefs_coil, scanner_coil_order, manufacturer)
 
             else:
@@ -410,7 +405,7 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
 
 def _save_to_text_file(coil, coefs, list_slices, path_output, o_format, options, coil_number,
                        default_coefs=None, mean_pressure=None):
-    """o_format can either be 'slicewise-ch', 'slicewise-coil', 'chronological-ch', 'chronological-coil', 'gradient'"""
+    """o_format can either be 'slicewise-ch', 'slicewise-coil', 'chronological-ch', 'chronological-coil'"""
 
     logger.info(f"Saving to text file with format: {o_format}")
     is_outputting_fatsat_file = options['fatsat'] and o_format in ['chronological-ch', 'chronological-coil']
@@ -770,8 +765,6 @@ def realtime_dynamic(fname_fmap, fname_target, fname_mask_target_static, fname_m
         # If no mask is provided, shim the whole target volume
         nif_mask_target_riro = copy.deepcopy(nif_mask_target_static)
 
-    # Error out for unsupported inputs. If file format is in gradient CS, it must be 1st order and the output format be
-    # delta.
     if 'hrd' in o_format_sph:
         if output_value_format == 'absolute':
             raise ValueError(f"Unsupported output value format: {output_value_format} for output file format: "
@@ -881,8 +874,6 @@ def realtime_dynamic(fname_fmap, fname_target, fname_mask_target_static, fname_m
         # If it's a scanner
         if type(coil) == ScannerCoil:
             if 'hrd' in o_format_sph:
-                logger.debug("Converting Siemens scanner coil from Shim CS (LAI) to Gradient CS")
-
                 coefs_coil_static = coefs_to_dict(coefs_static, scanner_coil_order_static,
                                                   nif_target.get_json_info('Manufacturer'))
                 coefs_coil_riro = coefs_to_dict(coefs_riro, scanner_coil_order_riro,
@@ -990,7 +981,7 @@ def realtime_dynamic(fname_fmap, fname_target, fname_mask_target_static, fname_m
 
 def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_slices, path_output, o_format,
                           options, coil_number, channel_start, default_st_coefs=None):
-    """o_format can either be 'chronological-ch', 'chronological-coil', 'gradient'"""
+    """o_format can either be 'chronological-ch', 'chronological-coil'. gradient is implemented but deprecated. Use -hrd instead"""
 
     list_fname_output = []
     if currents_riro is not None:

--- a/shimming-toolbox/shimmingtoolbox/coils/coordinates.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/coordinates.py
@@ -99,9 +99,9 @@ def phys_to_vox_coefs(x_coefs, y_coefs, z_coefs, affine):
     e.g: If world coordinates are RAS and voxel coordinates are LSP, then transform from RAS to LSP image coordinates.
 
     Args:
-        x_coefs (numpy.ndarray): matrix containing the coefs along the x direction in the patient coordinate system
-        y_coefs (numpy.ndarray): matrix containing the coefs along the y direction in the patient coordinate system
-        z_coefs (numpy.ndarray): matrix containing the coefs along the z direction in the patient coordinate system
+        x_coefs (numpy.ndarray): matrix containing the coefs along the x direction in the world coordinate system
+        y_coefs (numpy.ndarray): matrix containing the coefs along the y direction in the world coordinate system
+        z_coefs (numpy.ndarray): matrix containing the coefs along the z direction in the world coordinate system
         affine (numpy.ndarray): 4x4 array containing affine transformation
 
     Returns:
@@ -140,9 +140,9 @@ def vox_to_phys_coefs(ax1_coefs, ax2_coefs, ax3_coefs, affine):
     e.g: If world coordinates are RAS and voxel coordinates are LSP, then transform from LSP to RAS world coordinates.
 
     Args:
-        ax1_coefs (numpy.ndarray): matrix containing the coefs along the 1st axis direction in the patient coordinate system
-        ax2_coefs (numpy.ndarray): matrix containing the coefs along the 2nd axis direction in the patient coordinate system
-        ax3_coefs (numpy.ndarray): matrix containing the coefs along the 3rd axis direction in the patient coordinate system
+        ax1_coefs (numpy.ndarray): matrix containing the coefs along the 1st axis direction in the image coordinate system
+        ax2_coefs (numpy.ndarray): matrix containing the coefs along the 2nd axis direction in the image coordinate system
+        ax3_coefs (numpy.ndarray): matrix containing the coefs along the 3rd axis direction in the image coordinate system
         affine (numpy.ndarray): 4x4 array containing affine transformation
 
     Returns:

--- a/shimming-toolbox/shimmingtoolbox/coils/coordinates.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/coordinates.py
@@ -95,7 +95,7 @@ def phys_gradient(data, affine):
 
 def phys_to_vox_coefs(x_coefs, y_coefs, z_coefs, affine):
     """
-    Compute the coefficient from world coordinate to image orientation defined by the axis codes of the affine.
+    Compute the coefficients from world coordinate to image orientation defined by the axis codes of the affine.
     e.g: If world coordinates are RAS and voxel coordinates are LSP, then transform from RAS to LSP image coordinates.
 
     Args:
@@ -136,7 +136,7 @@ def phys_to_vox_coefs(x_coefs, y_coefs, z_coefs, affine):
 
 def vox_to_phys_coefs(ax1_coefs, ax2_coefs, ax3_coefs, affine):
     """
-    Compute the coefficient from image coordinates orientation to world orientation defined by the axis codes of the affine.
+    Compute the coefficients from image coordinates orientation to world orientation defined by the axis codes of the affine.
     e.g: If world coordinates are RAS and voxel coordinates are LSP, then transform from LSP to RAS world coordinates.
 
     Args:

--- a/shimming-toolbox/shimmingtoolbox/coils/coordinates.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/coordinates.py
@@ -93,21 +93,21 @@ def phys_gradient(data, affine):
     return x_gradient, y_gradient, z_gradient
 
 
-def phys_to_vox_coefs(gx, gy, gz, affine):
+def phys_to_vox_coefs(x_coefs, y_coefs, z_coefs, affine):
     """
-    Calculate the vector sum along the image coordinates defined by ``affine`` with coefficients in the patient
-    coordinate system.
+    Compute the coefficient from world coordinate to image orientation defined by the axis codes of the affine.
+    e.g: If world coordinates are RAS and voxel coordinates are LSP, then transform from RAS to LSP image coordinates.
 
     Args:
-        gx (numpy.ndarray): 3D matrix containing the coefs along the x direction in the patient coordinate system
-        gy (numpy.ndarray): 3D matrix containing the coefs along the y direction in the patient coordinate system
-        gz (numpy.ndarray): 3D matrix containing the coefs along the z direction in the patient coordinate system
+        x_coefs (numpy.ndarray): matrix containing the coefs along the x direction in the patient coordinate system
+        y_coefs (numpy.ndarray): matrix containing the coefs along the y direction in the patient coordinate system
+        z_coefs (numpy.ndarray): matrix containing the coefs along the z direction in the patient coordinate system
         affine (numpy.ndarray): 4x4 array containing affine transformation
 
     Returns:
-        numpy.ndarray: 3D matrix containing the coefs along the x direction in the image coordinate system
-        numpy.ndarray: 3D matrix containing the coefs along the y direction in the image coordinate system
-        numpy.ndarray: 3D matrix containing the coefs along the z direction in the image coordinate system
+        numpy.ndarray: matrix containing the coefs along the x direction in the image coordinate system
+        numpy.ndarray: matrix containing the coefs along the y direction in the image coordinate system
+        numpy.ndarray: matrix containing the coefs along the z direction in the image coordinate system
     """
 
     x_vox = 0
@@ -121,17 +121,57 @@ def phys_to_vox_coefs(gx, gy, gz, affine):
 
     inv_affine = np.linalg.inv(affine[:3, :3])
 
-    gx_vox = (gx * inv_affine[0, x_vox] * x_vox_spacing) + \
-             (gy * inv_affine[0, y_vox] * x_vox_spacing) + \
-             (gz * inv_affine[0, z_vox] * x_vox_spacing)
-    gy_vox = (gx * inv_affine[1, x_vox] * y_vox_spacing) + \
-             (gy * inv_affine[1, y_vox] * y_vox_spacing) + \
-             (gz * inv_affine[1, z_vox] * y_vox_spacing)
-    gz_vox = (gx * inv_affine[2, x_vox] * z_vox_spacing) + \
-             (gy * inv_affine[2, y_vox] * z_vox_spacing) + \
-             (gz * inv_affine[2, z_vox] * z_vox_spacing)
+    ax1_coefs = (x_coefs * inv_affine[0, x_vox] * x_vox_spacing) + \
+               (y_coefs * inv_affine[0, y_vox] * x_vox_spacing) + \
+               (z_coefs * inv_affine[0, z_vox] * x_vox_spacing)
+    ax2_coefs = (x_coefs * inv_affine[1, x_vox] * y_vox_spacing) + \
+               (y_coefs * inv_affine[1, y_vox] * y_vox_spacing) + \
+               (z_coefs * inv_affine[1, z_vox] * y_vox_spacing)
+    ax3_coefs = (x_coefs * inv_affine[2, x_vox] * z_vox_spacing) + \
+               (y_coefs * inv_affine[2, y_vox] * z_vox_spacing) + \
+               (z_coefs * inv_affine[2, z_vox] * z_vox_spacing)
 
-    return gx_vox, gy_vox, gz_vox
+    return ax1_coefs, ax2_coefs, ax3_coefs
+
+
+def vox_to_phys_coefs(ax1_coefs, ax2_coefs, ax3_coefs, affine):
+    """
+    Compute the coefficient from image coordinates orientation to world orientation defined by the axis codes of the affine.
+    e.g: If world coordinates are RAS and voxel coordinates are LSP, then transform from LSP to RAS world coordinates.
+
+    Args:
+        ax1_coefs (numpy.ndarray): matrix containing the coefs along the 1st axis direction in the patient coordinate system
+        ax2_coefs (numpy.ndarray): matrix containing the coefs along the 2nd axis direction in the patient coordinate system
+        ax3_coefs (numpy.ndarray): matrix containing the coefs along the 3rd axis direction in the patient coordinate system
+        affine (numpy.ndarray): 4x4 array containing affine transformation
+
+    Returns:
+        numpy.ndarray: matrix containing the coefs along the x direction in the world coordinate system
+        numpy.ndarray: matrix containing the coefs along the y direction in the world coordinate system
+        numpy.ndarray: matrix containing the coefs along the z direction in the world coordinate system
+    """
+
+    x_vox = 0
+    y_vox = 1
+    z_vox = 2
+
+    # Calculate the spacing along the different voxel axis
+    x_vox_spacing = math.sqrt((affine[0, x_vox] ** 2) + (affine[1, x_vox] ** 2) + (affine[2, x_vox] ** 2))
+    y_vox_spacing = math.sqrt((affine[0, y_vox] ** 2) + (affine[1, y_vox] ** 2) + (affine[2, y_vox] ** 2))
+    z_vox_spacing = math.sqrt((affine[0, z_vox] ** 2) + (affine[1, z_vox] ** 2) + (affine[2, z_vox] ** 2))
+
+    x_coefs = (ax1_coefs * affine[0, x_vox] * x_vox_spacing) + \
+             (ax2_coefs * affine[0, y_vox] * x_vox_spacing) + \
+             (ax3_coefs * affine[0, z_vox] * x_vox_spacing)
+    y_coefs = (ax1_coefs * affine[1, x_vox] * y_vox_spacing) + \
+             (ax2_coefs * affine[1, y_vox] * y_vox_spacing) + \
+             (ax3_coefs * affine[1, z_vox] * y_vox_spacing)
+    z_coefs = (ax1_coefs * affine[2, x_vox] * z_vox_spacing) + \
+             (ax2_coefs * affine[2, y_vox] * z_vox_spacing) + \
+             (ax3_coefs * affine[2, z_vox] * z_vox_spacing)
+
+    return x_coefs, y_coefs, z_coefs
+
 
 
 def resample_from_to(nii_from_img, nii_to_vox_map, order=2, mode='nearest', cval=0., out_class=nib.Nifti1Image):

--- a/shimming-toolbox/shimmingtoolbox/shim/shim_utils.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/shim_utils.py
@@ -71,33 +71,35 @@ def phys_to_gradient_cs(coefs_x, coefs_y, coefs_z, fname_target):
             * numpy.ndarray: Array containing the data in the gradient CS (slice)
 
     Notes:
+
         This function transforms the affine to create an image coordinate system that is in line with the
         Gradient coordinate system on Siemens.
 
         The previous way to do this was flawed if the affine was different than what dcm2niix would output for the
         different orientations (TRA: LAS, SAG: PSR, COR: LSP).
+        ::
 
-        scanner_coil_coef_vox = phys_to_vox_coefs(coefs_x, coefs_y, coefs_z, nii_target.affine)
-        # TRA: RAS -> LAS  # Assumption that voxel coordinate system is LAS
-        # SAG: RAS -> PSR
-        # COR: RAS -> LSP
+            scanner_coil_coef_vox = phys_to_vox_coefs(coefs_x, coefs_y, coefs_z, nii_target.affine)
+            # TRA: RAS -> LAS  # Assumption that voxel coordinate system is LAS
+            # SAG: RAS -> PSR
+            # COR: RAS -> LSP
 
-        # Convert from image to frequency, phase, slice encoding direction
-        dim_info = nii_target.header.get_dim_info()
-        coefs_freq, coefs_phase, coefs_slice = [scanner_coil_coef_vox[dim] for dim in dim_info]
-        # TRA: LAS -> LAS, # SAG: PSR -> SPR, # COR: LSP -> SLP
+            # Convert from image to frequency, phase, slice encoding direction
+            dim_info = nii_target.header.get_dim_info()
+            coefs_freq, coefs_phase, coefs_slice = [scanner_coil_coef_vox[dim] for dim in dim_info]
+            # TRA: LAS -> LAS, # SAG: PSR -> SPR, # COR: LSP -> SLP
 
-        if orientation == 'SAG':
-            coefs_slice = -coefs_slice
-        elif orientation == 'COR':
-            coefs_freq = -coefs_freq
-        # TRA: LAS -> LAS, # SAG: SPR -> SPL, # COR: SLP -> ILP
+            if orientation == 'SAG':
+                coefs_slice = -coefs_slice
+            elif orientation == 'COR':
+                coefs_freq = -coefs_freq
+            # TRA: LAS -> LAS, # SAG: SPR -> SPL, # COR: SLP -> ILP
 
-        if not phase_encode_is_positive:
-            coefs_freq = -coefs_freq
-            coefs_phase = -coefs_phase
-        # PE +: # TRA: LAS, # SAG: SPL, # COR: ILP
-        # PE -: # TRA: LAS -> RPS, # SAG: SPL -> IAL, # COR: ILP -> SRP
+            if not phase_encode_is_positive:
+                coefs_freq = -coefs_freq
+                coefs_phase = -coefs_phase
+            # PE +: # TRA: LAS, # SAG: SPL, # COR: ILP
+            # PE -: # TRA: LAS -> RPS, # SAG: SPL -> IAL, # COR: ILP -> SRP
     """
 
     fname_target_json = fname_target.rsplit('.nii', 1)[0] + '.json'

--- a/shimming-toolbox/shimmingtoolbox/shim/shim_utils.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/shim_utils.py
@@ -10,7 +10,7 @@ import logging
 from nibabel.affines import apply_affine
 
 from shimmingtoolbox.coils.coil import SCANNER_CONSTRAINTS, SCANNER_CONSTRAINTS_DAC
-from shimmingtoolbox.coils.coordinates import phys_to_vox_coefs, get_main_orientation
+from shimmingtoolbox.coils.coordinates import phys_to_vox_coefs, vox_to_phys_coefs, get_main_orientation
 from shimmingtoolbox.coils.spher_harm_basis import get_flip_matrix, SHIM_CS, channels_per_order
 
 logger = logging.getLogger(__name__)
@@ -56,12 +56,12 @@ def get_phase_encode_direction_sign(fname_nii):
 
 
 def phys_to_gradient_cs(coefs_x, coefs_y, coefs_z, fname_target):
-    """ Converts physical coefficients (x, y, z from RAS Coordinate System) to Siemens Gradient Coordinate System
+    """ Converts physical coefficients (x, y, z from RAS World Coordinate System) to Siemens Gradient Coordinate System (RO, PE, SL)
 
     Args:
-        coefs_x (numpy.ndarray): Array containing x coefficients in the physical coordinate system RAS
-        coefs_y (numpy.ndarray): Array containing y coefficients in the physical coordinate system RAS
-        coefs_z (numpy.ndarray): Array containing z coefficients in the physical coordinate system RAS
+        coefs_x (numpy.ndarray): Array containing x coefficients in the World coordinate system RAS
+        coefs_y (numpy.ndarray): Array containing y coefficients in the World coordinate system RAS
+        coefs_z (numpy.ndarray): Array containing z coefficients in the World coordinate system RAS
         fname_target (str): Filename of the NIfTI file to convert the data to that Gradient CS
 
     Returns:
@@ -70,26 +70,49 @@ def phys_to_gradient_cs(coefs_x, coefs_y, coefs_z, fname_target):
             * numpy.ndarray: Array containing the data in the gradient CS (phase)
             * numpy.ndarray: Array containing the data in the gradient CS (slice)
 
+    Notes:
+        This function transforms the affine to create an image coordinate system that is in line with the
+        Gradient coordinate system on Siemens.
+
+        The previous way to do this was flawed if the affine was different than what dcm2niix would output for the
+        different orientations (TRA: LAS, SAG: PSR, COR: LSP).
+
+        scanner_coil_coef_vox = phys_to_vox_coefs(coefs_x, coefs_y, coefs_z, nii_target.affine)
+        # TRA: RAS -> LAS  # Assumption that voxel coordinate system is LAS
+        # SAG: RAS -> PSR
+        # COR: RAS -> LSP
+
+        # Convert from image to frequency, phase, slice encoding direction
+        dim_info = nii_target.header.get_dim_info()
+        coefs_freq, coefs_phase, coefs_slice = [scanner_coil_coef_vox[dim] for dim in dim_info]
+        # TRA: LAS -> LAS, # SAG: PSR -> SPR, # COR: LSP -> SLP
+
+        if orientation == 'SAG':
+            coefs_slice = -coefs_slice
+        elif orientation == 'COR':
+            coefs_freq = -coefs_freq
+        # TRA: LAS -> LAS, # SAG: SPR -> SPL, # COR: SLP -> ILP
+
+        if not phase_encode_is_positive:
+            coefs_freq = -coefs_freq
+            coefs_phase = -coefs_phase
+        # PE +: # TRA: LAS, # SAG: SPL, # COR: ILP
+        # PE -: # TRA: LAS -> RPS, # SAG: SPL -> IAL, # COR: ILP -> SRP
     """
-    # Load target
-    nii_target = nib.load(fname_target)
 
-    # Convert from patient coordinates to image coordinates
-    scanner_coil_coef_vox = phys_to_vox_coefs(coefs_x, coefs_y, coefs_z, nii_target.affine)
-    # scanner_coil_coef_vox[0]  # NIfTI dim1, etc
-
-    # Convert from image to freq, phase, slice encoding direction
-    dim_info = nii_target.header.get_dim_info()
-    coefs_freq, coefs_phase, coefs_slice = [scanner_coil_coef_vox[dim] for dim in dim_info]
-
-    # To output to the gradient coord system, axes need some inversions. The gradient coordinate system is
-    # defined by the frequency, phase and slice encode directions.
-    # TODO: More tests, validated for TRA, SAG, COR, no-flip/flipped PE, no rotation
-
-    # Load target json
     fname_target_json = fname_target.rsplit('.nii', 1)[0] + '.json'
     with open(fname_target_json) as json_file:
         json_target_data = json.load(json_file)
+
+    if 'Manufacturer' not in json_target_data:
+        raise ValueError("Manufacturer not found in the json file.")
+    if json_target_data['Manufacturer'] != 'Siemens':
+        raise NotImplementedError(f"Manufacturer {json_target_data['Manufacturer']} not supported. Only Siemens supported.")
+
+    if 'PatientPosition' not in json_target_data:
+        raise ValueError("PatientPosition not found in json file.")
+    if json_target_data['PatientPosition'] != 'HFS':
+        raise NotImplementedError(f"PatientPosition {json_target_data['PatientPosition']} is not supported. Only HFS is implemented")
 
     if 'ImageOrientationText' in json_target_data:
         # Tag in private dicom header (0051,100E) indicates the slice orientation, if it exists, it will appear
@@ -101,20 +124,102 @@ def phys_to_gradient_cs(coefs_x, coefs_y, coefs_z, fname_target):
         # if there are 2 highest cosines. It will raise an exception if there is a problem
         orientation = get_main_orientation(json_target_data['ImageOrientationPatientDICOM'])
 
-    if orientation == 'SAG':
-        coefs_slice = -coefs_slice
+    phase_encode_is_positive = get_phase_encode_direction_sign(fname_target)
+
+    if orientation == 'TRA':
+        if phase_encode_is_positive:
+            target_ornt = nib.orientations.axcodes2ornt(('L', 'A', 'S'))
+        else:
+            target_ornt = nib.orientations.axcodes2ornt(('R', 'P', 'S'))
+    elif orientation == 'SAG':
+        if phase_encode_is_positive:
+            target_ornt = nib.orientations.axcodes2ornt(('S', 'P', 'L'))
+        else:
+            target_ornt = nib.orientations.axcodes2ornt(('I', 'A', 'L'))
     elif orientation == 'COR':
-        coefs_freq = -coefs_freq
+        if phase_encode_is_positive:
+            target_ornt = nib.orientations.axcodes2ornt(('I', 'L', 'P'))
+        else:
+            target_ornt = nib.orientations.axcodes2ornt(('S', 'R', 'P'))
     else:
-        # TRA
-        pass
+        raise RuntimeError(f"Unexpected value for orientation: {orientation}")
+
+    nii_target = nib.load(fname_target)
+    start_ornt = nib.orientations.axcodes2ornt(nib.aff2axcodes(nii_target.affine))
+    transform_ornt = nib.orientations.ornt_transform(start_ornt, target_ornt)
+    new_affine = nii_target.affine @ nib.orientations.inv_ornt_aff(transform_ornt, nii_target.shape)
+    coefs_freq, coefs_phase, coefs_slice = phys_to_vox_coefs(coefs_x, coefs_y, coefs_z, new_affine)
+    return coefs_freq, coefs_phase, coefs_slice
+
+
+def gradient_to_phys_cs(coefs_freq, coefs_phase, coefs_slice, fname_target):
+    """ Converts Siemens Gradient Coordinate System (RO, PE, SL) to physical coordinates (x, y, z from RAS World Coordinate System)
+    See phys_to_gradient_cs for more details. This is the inverse of that function
+
+    Args:
+        coefs_freq (numpy.ndarray): Array containing RO coefficients in the Siemens Gradient Coordinate System
+        coefs_phase (numpy.ndarray): Array containing PE coefficients in the Siemens Gradient Coordinate System
+        coefs_slice (numpy.ndarray): Array containing SL coefficients in the Siemens Gradient Coordinate System
+        fname_target (str): Filename of the NIfTI file to convert the data to RAS World Coordinate System
+
+    Returns:
+        (tuple): tuple containing:
+            * numpy.ndarray: Array containing the data in the x
+            * numpy.ndarray: Array containing the data in the y
+            * numpy.ndarray: Array containing the data in the z
+    """
+    fname_target_json = fname_target.rsplit('.nii', 1)[0] + '.json'
+    with open(fname_target_json) as json_file:
+        json_target_data = json.load(json_file)
+
+    if 'Manufacturer' not in json_target_data:
+        raise ValueError("Manufacturer not found in the json file.")
+    if json_target_data['Manufacturer'] != 'Siemens':
+        raise NotImplementedError(
+            f"Manufacturer {json_target_data['Manufacturer']} not supported. Only Siemens supported.")
+
+    if 'PatientPosition' not in json_target_data:
+        raise ValueError("PatientPosition not found in json file.")
+    if json_target_data['PatientPosition'] != 'HFS':
+        raise NotImplementedError(
+            f"PatientPosition {json_target_data['PatientPosition']} is not supported. Only HFS is implemented")
+
+    if 'ImageOrientationText' in json_target_data:
+        # Tag in private dicom header (0051,100E) indicates the slice orientation, if it exists, it will appear
+        # in the json under 'ImageOrientationText' tag
+        orientation_text = json_target_data['ImageOrientationText']
+        orientation = orientation_text[:3].upper()
+    else:
+        # Find orientation with the ImageOrientationPatientDICOM tag, this is less reliable since it can fail
+        # if there are 2 highest cosines. It will raise an exception if there is a problem
+        orientation = get_main_orientation(json_target_data['ImageOrientationPatientDICOM'])
 
     phase_encode_is_positive = get_phase_encode_direction_sign(fname_target)
-    if not phase_encode_is_positive:
-        coefs_freq = -coefs_freq
-        coefs_phase = -coefs_phase
 
-    return coefs_freq, coefs_phase, coefs_slice
+    if orientation == 'TRA':
+        if phase_encode_is_positive:
+            target_ornt = nib.orientations.axcodes2ornt(('L', 'A', 'S'))
+        else:
+            target_ornt = nib.orientations.axcodes2ornt(('R', 'P', 'S'))
+    elif orientation == 'SAG':
+        if phase_encode_is_positive:
+            target_ornt = nib.orientations.axcodes2ornt(('S', 'P', 'L'))
+        else:
+            target_ornt = nib.orientations.axcodes2ornt(('I', 'A', 'L'))
+    elif orientation == 'COR':
+        if phase_encode_is_positive:
+            target_ornt = nib.orientations.axcodes2ornt(('I', 'L', 'P'))
+        else:
+            target_ornt = nib.orientations.axcodes2ornt(('S', 'R', 'P'))
+    else:
+        raise RuntimeError(f"Unexpected value for orientation: {orientation}")
+
+    nii_target = nib.load(fname_target)
+    start_ornt = nib.orientations.axcodes2ornt(nib.aff2axcodes(nii_target.affine))
+    transform_ornt = nib.orientations.ornt_transform(start_ornt, target_ornt)
+    new_affine = nii_target.affine @ nib.orientations.inv_ornt_aff(transform_ornt, nii_target.shape)
+    coefs_x, coefs_y, coefs_z = vox_to_phys_coefs(coefs_freq, coefs_phase, coefs_slice, new_affine)
+    return coefs_x, coefs_y, coefs_z
 
 
 def calculate_metric_within_mask(array, mask, metric, axis=None):

--- a/shimming-toolbox/test/shim/test_shim_utils.py
+++ b/shimming-toolbox/test/shim/test_shim_utils.py
@@ -1,11 +1,17 @@
 #!usr/bin/env python3
 # -*- coding: utf-8
 
+import json
 import logging
+import nibabel as nib
 import numpy as np
+import os
 import pytest
 
-from shimmingtoolbox.shim.shim_utils import dac_to_shim_units, phys_to_shim_cs, shim_to_phys_cs, calculate_metric_within_mask, logger
+from shimmingtoolbox.shim.shim_utils import (dac_to_shim_units, phys_to_shim_cs, shim_to_phys_cs,
+                                             calculate_metric_within_mask, logger, phys_to_gradient_cs,
+                                             gradient_to_phys_cs)
+from shimmingtoolbox.coils.coordinates import get_main_orientation
 
 
 class TestDacToShimUnits:
@@ -122,3 +128,76 @@ class TestCalculateMetricWithinMask:
 
         with pytest.raises(NotImplementedError, match="Metric 'invalid' not implemented. Available metrics:"):
             calculate_metric_within_mask(array, mask, metric='invalid')
+
+
+
+@pytest.mark.parametrize("input_coefs, orientation, phase_encode_dir, expected_coefs", [
+    ([1, 2, 3], "TRA", "-", [1, -2, 3]),  # PE: AP
+    ([1, 2, 3], "TRA", "", [-1, 2, 3]),  # PE: PA
+    ([1, 2, 3], "SAG", "", [3, -2, -1]),  # PE: AP
+    ([1, 2, 3], "SAG", "-", [-3, 2, -1]),  # PE: PA
+    ([1, 2, 3], "COR", "", [-3, -1, -2]),  # PE: RL
+    ([1, 2, 3], "COR", "-", [3, 1, -2])  # PE: LR
+])
+def test_phys_to_gradient_cs(input_coefs, orientation, phase_encode_dir, expected_coefs, tmpdir):
+    fname_target = create_nifti(orientation, phase_encode_dir, tmpdir)
+    output_coefs = phys_to_gradient_cs(*input_coefs, fname_target)
+    assert np.allclose(output_coefs, expected_coefs)
+
+
+@pytest.mark.parametrize("expected_coefs, orientation, phase_encode_dir, input_coefs", [
+    ([1, 2, 3], "TRA", "-", [1, -2, 3]),  # PE: AP
+    ([1, 2, 3], "TRA", "", [-1, 2, 3]),  # PE: PA
+    ([1, 2, 3], "SAG", "", [3, -2, -1]),  # PE: AP
+    ([1, 2, 3], "SAG", "-", [-3, 2, -1]),  # PE: PA
+    ([1, 2, 3], "COR", "", [-3, -1, -2]),  # PE: RL
+    ([1, 2, 3], "COR", "-", [3, 1, -2])  # PE: LR
+])
+def test_gradient_to_phys_cs(input_coefs, orientation, phase_encode_dir, expected_coefs, tmpdir):
+    fname_target = create_nifti(orientation, phase_encode_dir, tmpdir)
+    output_coefs = gradient_to_phys_cs(*input_coefs, fname_target)
+    assert np.allclose(output_coefs, expected_coefs)
+
+
+def create_nifti(orientation, phase_encode_dir, path_output):
+    if not os.path.exists(path_output):
+        os.makedirs(path_output)
+
+    data = np.zeros((5, 5, 5))
+    if orientation == "TRA":
+        affine = np.array([[-1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+        dim_info = (0, 1, 2)
+        pe_letter = "j"
+    elif orientation == "SAG":
+        affine = np.array([[0, 0, 1, 0], [-1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+        dim_info = (1, 0, 2)
+        pe_letter = "i"
+    elif orientation == "COR":
+        affine = np.array([[-1, 0, 0, 0], [0, 0, -1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+        dim_info = (1, 0, 2)
+        pe_letter = "i"
+    else:
+        raise ValueError(f"Unknown orientation: {orientation}")
+    nii = nib.Nifti1Image(data, affine)
+    nii.header.set_dim_info(*dim_info)
+    fname_nii = os.path.join(path_output, f"target_{orientation}_pe{phase_encode_dir}.nii.gz")
+    nii.to_filename(fname_nii)
+    nii2 = nib.as_closest_canonical(nii)  # Make sure the target is in canonical orientation (RAS)
+    nii2.to_filename(fname_nii.replace(".nii.gz", "canon.nii.gz"))
+
+    fname_json = fname_nii.replace(".nii.gz", ".json")
+    image_orientation = {
+        "TRA": [1, 0, 0, 0, 1, 0],
+        "SAG": [0, 1, 0, 0, 0, -1],
+        "COR": [1, 0, 0, 0, 0, -1]
+    }[orientation]
+    assert get_main_orientation(image_orientation) == orientation
+    data_json = {
+        "Manufacturer": "Siemens",
+        "PatientPosition": "HFS",
+        "ImageOrientationPatientDICOM": image_orientation,
+        "PhaseEncodingDirection": f"{pe_letter}{phase_encode_dir}"
+    }
+    with open(fname_json, "w") as f:
+        json.dump(data_json, f)
+    return fname_nii


### PR DESCRIPTION
## Description
Refactor `phys_to_vox_coefs` and add complimentary `vox_to_phys_coefs` function. These function are useful to change from coefficients in world coordinate system (RAS+) to Siemens gradient coordinate system and vice-versa. The gradient CS (frequency, phase, slice) has the same orientation as image space but depending on if the acquisition is TRA, SAG or COR, the axes 1, 2 and 3 (voxel space) mapping to frequency, phase, slice changes. The polarity of the axis also change.

We implement this to allow easy conversion between world and gradient CS.

Related to #322 