### PR TITLE
Add ability to optimize in the gradient coordinate system

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
@@ -19,7 +19,7 @@ import logging
 import os
 from matplotlib.figure import Figure
 
-from coils.spher_harm_basis import get_flip_matrix
+from shimmingtoolbox.coils.spher_harm_basis import get_flip_matrix
 from shimmingtoolbox import __config_scanner_constraints__, __config_custom_coil_constraints__
 from shimmingtoolbox.coils.coil import Coil, ScannerCoil, get_scanner_constraints, OPT_CS, SHIM_CS
 from shimmingtoolbox.coils.scanner_shim_settings import ScannerShimSettings, concatenate_shim_settings
@@ -454,7 +454,8 @@ def _save_to_text_file(coil, coefs, list_slices, path_output, o_format, options,
     is_outputting_fatsat_file = options['fatsat'] and o_format in ['chronological-ch', 'chronological-coil']
 
     # Convert -0 coefficients to 0.0
-    coefs += 0.0
+    if isinstance(coefs, np.ndarray):
+        coefs += 0.0
 
     n_channels = coil.dim[3]
     list_fname_output = []
@@ -1029,8 +1030,10 @@ def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_sli
                           options, coil_number, channel_start, default_st_coefs=None):
     """o_format can either be 'chronological-ch', 'chronological-coil'. gradient is implemented but deprecated. Use -hrd instead"""
     # Convert -0 coefficients to 0.0
-    currents_static += 0.0
-    currents_riro += 0.0
+    if isinstance(currents_static, np.ndarray):
+        currents_static += 0.0
+    if isinstance(currents_riro, np.ndarray):
+        currents_riro += 0.0
 
     list_fname_output = []
     if currents_riro is not None:

--- a/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
@@ -19,9 +19,8 @@ import logging
 import os
 from matplotlib.figure import Figure
 
-from shimmingtoolbox.coils.spher_harm_basis import get_flip_matrix
 from shimmingtoolbox import __config_scanner_constraints__, __config_custom_coil_constraints__
-from shimmingtoolbox.coils.coil import Coil, ScannerCoil, get_scanner_constraints, OPT_CS, SHIM_CS
+from shimmingtoolbox.coils.coil import Coil, ScannerCoil, get_scanner_constraints, OPT_CS
 from shimmingtoolbox.coils.scanner_shim_settings import ScannerShimSettings, concatenate_shim_settings
 from shimmingtoolbox.coils.spher_harm_basis import channels_per_order, reorder_shim_to_scaling_ge
 from shimmingtoolbox.pmu import PmuResp
@@ -29,7 +28,7 @@ from shimmingtoolbox.shim.sequencer import ShimSequencer, RealTimeSequencer
 from shimmingtoolbox.shim.sequencer import shim_max_intensity, define_slices
 from shimmingtoolbox.shim.sequencer import parse_slices
 from shimmingtoolbox.utils import create_output_dir, set_all_loggers, timeit
-from shimmingtoolbox.shim.shim_utils import gradient_to_phys_cs
+from shimmingtoolbox.shim.shim_utils import gradient_to_phys_cs, SHIM_CS, get_flip_matrix
 
 from shimmingtoolbox.files.NiftiTarget import NiftiTarget
 from shimmingtoolbox.files.NiftiFieldMap import NiftiFieldMap

--- a/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
@@ -310,16 +310,11 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
     if not np.all(np.isclose(nif_fmap.get_isocenter(), nif_target.get_isocenter())):
         raise ValueError("Table position in the field map and target image are not the same.")
 
-    # Read the current shim settings from the scanner
-    scanner_shim_settings = ScannerShimSettings(nif_fmap, orders=scanner_coil_order)
-    options = {'scanner_shim': scanner_shim_settings.shim_settings}
-
     # Load the coils
     list_coils = load_coils(coils,
                             scanner_coil_order,
                             fname_sph_constr,
                             nif_fmap,
-                            options['scanner_shim'],
                             off_channels=off_channels,
                             off_channels_values=off_channels_values,
                             opt_cs=opt_cs,
@@ -329,7 +324,8 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
     if slices == 'auto':
         list_slices = parse_slices(fname_target)
     else:
-        list_slices = define_slices(n_slices, slice_factor, slices, nif_fmap.get_json_info('SoftwareVersions', required=False))
+        list_slices = define_slices(n_slices, slice_factor, slices, nif_fmap.get_json_info('SoftwareVersions',
+                                                                                           required=False))
     logger.info(f"The slices to shim are:\n{list_slices}")
     # Get shimming coefficients
     # 1 ) Create the Shimming sequencer object
@@ -351,7 +347,7 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
     coefs = sequencer.shim()
     # Output
     # Load output options
-    options['fatsat'] = nif_target.get_fat_sat_option() if fatsat == 'auto' else fatsat == 'yes'
+    options = {'fatsat': nif_target.get_fat_sat_option() if fatsat == 'auto' else fatsat == 'yes'}
 
     list_fname_output = []
     end_channel = 0
@@ -373,12 +369,13 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
                 logger.debug(f"Shim coefficients in gradient coordinate system: {coefs_coil}")
                 # Convert shim coefficients from gradients back to xyz
                 if 1 not in scanner_coil_order:
-                    raise ValueError(f"Cannot convert shim coefficients from gradient to xyz coordinate system if 1st order is not used. ")
+                    raise ValueError(f"Cannot convert shim coefficients from gradient to xyz coordinate "
+                                     f"system if 1st order is not used. ")
                 coefs_coil_dict = coefs_to_dict(coefs_coil, scanner_coil_order, manufacturer)
                 coefs_order1_phys = gradient_to_phys_cs(coefs_coil_dict[1][:, 0],
-                                                      coefs_coil_dict[1][:, 1],
-                                                      coefs_coil_dict[1][:, 2],
-                                                      fname_target)
+                                                        coefs_coil_dict[1][:, 1],
+                                                        coefs_coil_dict[1][:, 2],
+                                                        fname_target)
                 coefs_phys = copy.deepcopy(coefs_coil)
                 offset_channel = 1 if 0 in scanner_coil_order else 0
                 # Convert from physical RAS to the manufacturer's shim CS (eg: Siemens is LAI)
@@ -388,6 +385,10 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
                 coefs_phys[:, 2 + offset_channel] = flip[2] * coefs_order1_phys[2]
 
                 coefs_coil = coefs_phys
+
+            # Save the field map's JSON file with the potentially updated coefficients
+            if sequencer.path_output is not None:
+                sequencer.save_calc_fmap_json(coefs_coil)
 
             # If it's a volume shim, we can update the input constraints
             # There is a check if fname_sph_constr is provided because if it is not, we can write the updated shim
@@ -831,16 +832,9 @@ def realtime_dynamic(fname_fmap, fname_target, fname_mask_target_static, fname_m
     if not np.all(np.isclose(nif_fmap.get_isocenter(), nif_target.get_isocenter())):
         raise ValueError("Table position in the field map and target image are not the same.")
 
-    # Read the current shim settings from the scanner
-    all_scanner_orders = set(scanner_coil_order_static).union(set(scanner_coil_order_riro))
-    scanner_shim_settings = ScannerShimSettings(nif_fmap, orders=all_scanner_orders)
-    options = {'scanner_shim': scanner_shim_settings.shim_settings}
-
     # Load the coils
-    list_coils_static = load_coils(coils_static, scanner_coil_order_static, fname_sph_constr, nif_fmap,
-                                   options['scanner_shim'])
-    list_coils_riro = load_coils(coils_riro, scanner_coil_order_riro, fname_sph_constr, nif_fmap,
-                                 options['scanner_shim'])
+    list_coils_static = load_coils(coils_static, scanner_coil_order_static, fname_sph_constr, nif_fmap)
+    list_coils_riro = load_coils(coils_riro, scanner_coil_order_riro, fname_sph_constr, nif_fmap)
 
     if logger.level <= getattr(logging, 'DEBUG'):
         # Save inputs
@@ -881,7 +875,7 @@ def realtime_dynamic(fname_fmap, fname_target, fname_mask_target_static, fname_m
 
     # Output
     # Load output options
-    options['fatsat'] = nif_target.get_fat_sat_option() if fatsat == 'auto' else fatsat == 'yes'
+    options = {'fatsat': nif_target.get_fat_sat_option() if fatsat == 'auto' else fatsat == 'yes'}
 
     # Get common coils between static and riro // Comparison based on coil name
     coil_static_only = [coil for coil in list_coils_static if coil not in list_coils_riro]
@@ -1198,7 +1192,7 @@ def parse_channels_off(opt_channels: str) -> list[int]:
         return [int(ch) for ch in opt_channels.split(',')]
 
 
-def load_coils(coils, orders, fname_constraints, nif_fmap, scanner_shim_settings, off_channels=(),
+def load_coils(coils, orders, fname_constraints, nif_fmap, off_channels=(),
                off_channels_values=None, opt_cs="shim-cs", fname_target=None):
     """ Loads the Coil objects from filenames
 
@@ -1207,7 +1201,6 @@ def load_coils(coils, orders, fname_constraints, nif_fmap, scanner_shim_settings
         orders (list): Orders of the scanner coils (0 or 1 or 2)
         fname_constraints (str): Filename of the constraints of the scanner coils
         nif_fmap (NiftiFieldMap): Field map
-        scanner_shim_settings (dict): Dictionary containing the shim settings of the scanner ('0', '1', '2')
         json_fm_data (dict): BIDS JSON sidecar as a dictionary
         off_channels (tuple): Tuple of channels to turn off.
         off_channels_values (np.array): (n_slices x n_off_channels) array of values to set for the channels that are
@@ -1271,17 +1264,20 @@ def load_coils(coils, orders, fname_constraints, nif_fmap, scanner_shim_settings
 
     # Create the spherical harmonic coil profiles of the scanner
     if -1 not in orders:
+        # Read the current shim settings from the scanner
+        scanner_shim_settings = ScannerShimSettings(nif_fmap, orders=orders)
+
         if fname_constraints is not None and os.path.isfile(fname_constraints):
             with open(fname_constraints) as json_file:
                 external_contraints = json.load(json_file)
         else:
             external_contraints = None
 
-        scanner_contraints = get_scanner_constraints(manufacturers_model_name,
+        scanner_constraints = get_scanner_constraints(manufacturers_model_name,
                                                      orders,
                                                      manufacturer,
                                                      device_serial_number,
-                                                     scanner_shim_settings,
+                                                     scanner_shim_settings.shim_settings,
                                                      external_contraints)
 
         n_channels = np.array([channels_per_order(order, manufacturer) for order in orders]).sum()
@@ -1291,7 +1287,7 @@ def load_coils(coils, orders, fname_constraints, nif_fmap, scanner_shim_settings
         isocenter = nif_fmap.get_isocenter()
         scanner_coil = ScannerCoil(nif_fmap.extended_shape[:3],
                                    nif_fmap.extended_affine,
-                                   scanner_contraints,
+                                   scanner_constraints,
                                    orders,
                                    manufacturer=manufacturer,
                                    isocenter=isocenter,

--- a/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/b0shim.py
@@ -10,7 +10,7 @@ the gradient method in a st_shim CLI with the argument being:
 
 import click
 from cloup import command, option, option_group, group
-from cloup.constraints import RequireAtLeast, mutually_exclusive, all_or_none, constraint
+from cloup.constraints import mutually_exclusive, constraint
 import copy
 import json
 import nibabel as nib
@@ -19,15 +19,18 @@ import logging
 import os
 from matplotlib.figure import Figure
 
+from coils.spher_harm_basis import get_flip_matrix
 from shimmingtoolbox import __config_scanner_constraints__, __config_custom_coil_constraints__
-from shimmingtoolbox.coils.coil import Coil, ScannerCoil, get_scanner_constraints
+from shimmingtoolbox.coils.coil import Coil, ScannerCoil, get_scanner_constraints, OPT_CS, SHIM_CS
+from shimmingtoolbox.coils.scanner_shim_settings import ScannerShimSettings, concatenate_shim_settings
 from shimmingtoolbox.coils.spher_harm_basis import channels_per_order, reorder_shim_to_scaling_ge
 from shimmingtoolbox.pmu import PmuResp
 from shimmingtoolbox.shim.sequencer import ShimSequencer, RealTimeSequencer
 from shimmingtoolbox.shim.sequencer import shim_max_intensity, define_slices
-from shimmingtoolbox.shim.sequencer import extend_fmap_to_kernel_size, parse_slices
+from shimmingtoolbox.shim.sequencer import parse_slices
 from shimmingtoolbox.utils import create_output_dir, set_all_loggers, timeit
-from shimmingtoolbox.shim.shim_utils import ScannerShimSettings, concatenate_shim_settings
+from shimmingtoolbox.shim.shim_utils import gradient_to_phys_cs
+
 from shimmingtoolbox.files.NiftiTarget import NiftiTarget
 from shimmingtoolbox.files.NiftiFieldMap import NiftiFieldMap
 from shimmingtoolbox.files.NiftiMask import NiftiMask
@@ -87,6 +90,14 @@ def b0shim_cli():
                 "'--output-value-format delta'. For example, if you have 2 channels turned off, "
                 "the text file should have 2 columns (one for each channel) and the # of slices (NIfTI indexed) as "
                 "rows."),
+    option("--opt-cs", type=click.Choice(OPT_CS), default='shim-cs', show_default=True,
+           help="Coordinate system to use when optimizing for the scanner's coil. "
+                "Allows optimizing for the encoding directions (freq, phase, slice) or the world coordinates (x,y,z)."
+                "Useful in conjunction with --off-channels to turn off specific channels (e.g: freq encoding direction)."
+                "shim-cs: Use the physical x, y and z axes."
+                "gradient-cs: Use the freq, phase and slice encoding directions."
+                "gradient-cs has limitations: --scanner-coil-order needs to be '1' or '0,1', it is only implemented "
+                "for Siemens, the output coefficients will still be in the shim-cs."),
     option('--output-file-format-scanner', 'o_format_sph',
            type=click.Choice(['slicewise-ch', 'slicewise-coil', 'chronological-ch', 'chronological-coil',
                                  'slicewise-hrd', 'chronological-hrd']),
@@ -194,7 +205,7 @@ def b0shim_cli():
 def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, slices, slice_factor, coils,
             dilation_kernel_size, scanner_coil_order, fname_sph_constr, fatsat, path_output, o_format_coil,
             o_format_sph, output_value_format, reg_factor, w_signal_loss, w_signal_loss_xy, off_channels,
-            fname_off_channels_values, verbose):
+            fname_off_channels_values, opt_cs, verbose):
     """ Static shim by fitting a fieldmap. Use the option --optimizer-method to change the shimming algorithm used to
     optimize. Use the options --slices and --slice-factor to change the shimming order/size of the slices.
 
@@ -212,6 +223,11 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
     # Output a warning if not shimming with the optimal shim orders ("0", "0,1", "0,1,2")
     if scanner_coil_order not in [[-1], [0], [0, 1], [0, 1, 2], [0, 1, 2, 3]]:
         logger.warning(f"You are not shimming with the optimal shim orders: {scanner_coil_order}. Consider using '0', '0,1', '0,1,2' or '0,1,2,3'.")
+
+    LIST_SUPPORTED_ORDERS_GRADIENT_CS = [[0, 1], [1]]
+    if opt_cs == 'gradient-cs' and scanner_coil_order not in LIST_SUPPORTED_ORDERS_GRADIENT_CS:
+        raise ValueError(f"--opt-cs {opt_cs} is not supported with scanner coil order {scanner_coil_order}."
+                         f"(Must be in {LIST_SUPPORTED_ORDERS_GRADIENT_CS})")
 
     # Parse the channels to turn off
     off_channels = parse_channels_off(off_channels)
@@ -305,7 +321,9 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
                             nif_fmap,
                             options['scanner_shim'],
                             off_channels=off_channels,
-                            off_channels_values=off_channels_values)
+                            off_channels_values=off_channels_values,
+                            opt_cs=opt_cs,
+                            fname_target=fname_target)
 
     # Get the shim slice ordering
     if slices == 'auto':
@@ -350,6 +368,26 @@ def dynamic(fname_fmap, fname_target, fname_mask_target, method, opt_criteria, s
         # If it's a scanner
         if type(coil) == ScannerCoil:
             manufacturer = nif_target.get_json_info('Manufacturer')
+
+            if opt_cs == 'gradient-cs':
+                logger.debug(f"Shim coefficients in gradient coordinate system: {coefs_coil}")
+                # Convert shim coefficients from gradients back to xyz
+                if 1 not in scanner_coil_order:
+                    raise ValueError(f"Cannot convert shim coefficients from gradient to xyz coordinate system if 1st order is not used. ")
+                coefs_coil_dict = coefs_to_dict(coefs_coil, scanner_coil_order, manufacturer)
+                coefs_order1_phys = gradient_to_phys_cs(coefs_coil_dict[1][:, 0],
+                                                      coefs_coil_dict[1][:, 1],
+                                                      coefs_coil_dict[1][:, 2],
+                                                      fname_target)
+                coefs_phys = copy.deepcopy(coefs_coil)
+                offset_channel = 1 if 0 in scanner_coil_order else 0
+                # Convert from physical RAS to the manufacturer's shim CS (eg: Siemens is LAI)
+                flip = get_flip_matrix(SHIM_CS[manufacturer.upper()], manufacturer, [1,])
+                coefs_phys[:, 0 + offset_channel] = flip[0] * coefs_order1_phys[0]
+                coefs_phys[:, 1 + offset_channel] = flip[1] * coefs_order1_phys[1]
+                coefs_phys[:, 2 + offset_channel] = flip[2] * coefs_order1_phys[2]
+
+                coefs_coil = coefs_phys
 
             # If it's a volume shim, we can update the input constraints
             # There is a check if fname_sph_constr is provided because if it is not, we can write the updated shim
@@ -414,6 +452,9 @@ def _save_to_text_file(coil, coefs, list_slices, path_output, o_format, options,
 
     logger.info(f"Saving to text file with format: {o_format}")
     is_outputting_fatsat_file = options['fatsat'] and o_format in ['chronological-ch', 'chronological-coil']
+
+    # Convert -0 coefficients to 0.0
+    coefs += 0.0
 
     n_channels = coil.dim[3]
     list_fname_output = []
@@ -987,6 +1028,9 @@ def realtime_dynamic(fname_fmap, fname_target, fname_mask_target_static, fname_m
 def _save_to_text_file_rt(coil, currents_static, currents_riro, mean_p, list_slices, path_output, o_format,
                           options, coil_number, channel_start, default_st_coefs=None):
     """o_format can either be 'chronological-ch', 'chronological-coil'. gradient is implemented but deprecated. Use -hrd instead"""
+    # Convert -0 coefficients to 0.0
+    currents_static += 0.0
+    currents_riro += 0.0
 
     list_fname_output = []
     if currents_riro is not None:
@@ -1152,7 +1196,7 @@ def parse_channels_off(opt_channels: str) -> list[int]:
 
 
 def load_coils(coils, orders, fname_constraints, nif_fmap, scanner_shim_settings, off_channels=(),
-               off_channels_values=None):
+               off_channels_values=None, opt_cs="shim-cs", fname_target=None):
     """ Loads the Coil objects from filenames
 
     Args:
@@ -1165,6 +1209,8 @@ def load_coils(coils, orders, fname_constraints, nif_fmap, scanner_shim_settings
         off_channels (tuple): Tuple of channels to turn off.
         off_channels_values (np.array): (n_slices x n_off_channels) array of values to set for the channels that are
                                         off.
+        opt_cs (str): Coordinate system of the shim coefficients. Either 'shim-cs' or 'gradient-cs'.
+        fname_target (str): Filename of the target image. Relevant for opt_cs.
 
     Returns:
         list: List of Coil objects containing the custom coils followed by the scanner coil if requested
@@ -1247,7 +1293,9 @@ def load_coils(coils, orders, fname_constraints, nif_fmap, scanner_shim_settings
                                    manufacturer=manufacturer,
                                    isocenter=isocenter,
                                    channels_onoff=channels_onoff,
-                                   channels_off_values=off_channels_values_coil)
+                                   channels_off_values=off_channels_values_coil,
+                                   opt_cs=opt_cs,
+                                   fname_target=fname_target)
         list_coils.append(scanner_coil)
 
     if off_channels and np.any(off_channels >= channel_start):

--- a/shimming-toolbox/shimmingtoolbox/coils/coil.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/coil.py
@@ -6,9 +6,8 @@ import logging
 import numpy as np
 from typing import Tuple
 
-from coils.spher_harm_basis import get_flip_matrix
 from shimmingtoolbox.coils.spher_harm_basis import (sh_basis, siemens_basis, ge_basis, philips_basis, SHIM_CS,
-                                                    channels_per_order)
+                                                    channels_per_order, get_flip_matrix)
 from shimmingtoolbox.coils.coordinates import generate_meshgrid
 from shimmingtoolbox.shim.shim_utils import phys_to_gradient_cs
 from shimmingtoolbox import __config_scanner_constraints__

--- a/shimming-toolbox/shimmingtoolbox/coils/coil.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/coil.py
@@ -369,8 +369,8 @@ class ScannerCoil(Coil):
 
         if opt_cs == "gradient-cs" and self.fname_target is None:
             raise ValueError("fname_target cannot be None for gradient-cs")
-        if opt_cs == "shim-cs" and manufacturer is not "SIEMENS":
-            raise ValueError("gradient-cs not implemented for manufacturer {manufacturer}. Only implemented for SIEMENS.")
+        if opt_cs == "gradient-cs" and manufacturer != "SIEMENS":
+            raise ValueError(f"gradient-cs not implemented for manufacturer {manufacturer}. Only implemented for SIEMENS.")
 
         # Change the affine offset so that the origin is at isocenter
         affine_origin_iso = copy.deepcopy(self.affine)

--- a/shimming-toolbox/shimmingtoolbox/coils/coil.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/coil.py
@@ -372,7 +372,7 @@ class ScannerCoil(Coil):
         if opt_cs == "gradient-cs" and self.manufacturer != "SIEMENS":
             raise ValueError(f"gradient-cs not implemented for manufacturer {self.manufacturer}. Only implemented for SIEMENS.")
         if opt_cs == "gradient-cs" and self.orders not in [[1,], [0, 1]]:
-            raise ValueError("Order 1 is required for gradient-cs")
+            raise ValueError("Accepted orders for gradient-cs: [1,], [0, 1]")
 
         # Change the affine offset so that the origin is at isocenter
         affine_origin_iso = copy.deepcopy(self.affine)

--- a/shimming-toolbox/shimmingtoolbox/coils/coil.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/coil.py
@@ -6,6 +6,7 @@ import logging
 import numpy as np
 from typing import Tuple
 
+from coils.spher_harm_basis import get_flip_matrix
 from shimmingtoolbox.coils.spher_harm_basis import (sh_basis, siemens_basis, ge_basis, philips_basis, SHIM_CS,
                                                     channels_per_order)
 from shimmingtoolbox.coils.coordinates import generate_meshgrid
@@ -347,6 +348,7 @@ class ScannerCoil(Coil):
             else:
                 self.coord_system = shim_cs
 
+        self.manufacturer = manufacturer
         self.affine = affine
         self.isocenter = isocenter
         self.opt_cs = opt_cs
@@ -355,28 +357,28 @@ class ScannerCoil(Coil):
         self.fname_target = fname_target
 
         # Create the spherical harmonics with the correct order, dim and affine
-        sph_coil_profile = self._create_coil_profile(dim_volume, manufacturer, opt_cs)
+        sph_coil_profile = self._create_coil_profile(dim_volume, opt_cs)
         # Restricts the constraints to the specified order
         if 'coef_channel_minmax' in constraints.keys():
-            constraints['coef_channel_minmax'] = restrict_to_orders(constraints['coef_channel_minmax'],
-                                                                          self.orders)
+            constraints['coef_channel_minmax'] = restrict_to_orders(constraints['coef_channel_minmax'], self.orders)
         if 'coefs_used' in constraints.keys():
             constraints['coefs_used'] = restrict_to_orders(constraints['coefs_used'], self.orders)
         super().__init__(sph_coil_profile, affine, constraints, channels_onoff, channels_off_values)
+        self._update_constraints_to_cs()
 
-    def _create_coil_profile(self, dim, manufacturer=None, opt_cs='shim-cs'):
+    def _create_coil_profile(self, dim, opt_cs='shim-cs'):
         # Create spherical harmonics coil profiles
 
         if opt_cs == "gradient-cs" and self.fname_target is None:
             raise ValueError("fname_target cannot be None for gradient-cs")
-        if opt_cs == "gradient-cs" and manufacturer != "SIEMENS":
-            raise ValueError(f"gradient-cs not implemented for manufacturer {manufacturer}. Only implemented for SIEMENS.")
+        if opt_cs == "gradient-cs" and self.manufacturer != "SIEMENS":
+            raise ValueError(f"gradient-cs not implemented for manufacturer {self.manufacturer}. Only implemented for SIEMENS.")
 
         # Change the affine offset so that the origin is at isocenter
         affine_origin_iso = copy.deepcopy(self.affine)
         affine_origin_iso[:3, 3] -= self.isocenter
         mesh1, mesh2, mesh3 = generate_meshgrid(dim, affine_origin_iso)
-        if manufacturer == 'SIEMENS':
+        if self.manufacturer == 'SIEMENS':
             if opt_cs == 'shim-cs':
                 sph_coil_profile = siemens_basis(mesh1, mesh2, mesh3, orders=tuple(self.orders))
             elif opt_cs == 'gradient-cs':
@@ -384,16 +386,71 @@ class ScannerCoil(Coil):
                 sph_coil_profile = siemens_basis(mesh1_freq, mesh2_phase, mesh3_slice, orders=tuple(self.orders), shim_cs='RAS')
             else:
                 raise ValueError(f"Unknown opt_cs: {opt_cs}")
-        elif manufacturer == 'GE':
+        elif self.manufacturer == 'GE':
             sph_coil_profile = ge_basis(mesh1, mesh2, mesh3, orders=tuple(self.orders))
-        elif manufacturer == 'PHILIPS':
+        elif self.manufacturer == 'PHILIPS':
             sph_coil_profile = philips_basis(mesh1, mesh2, mesh3, orders=tuple(self.orders))
         else:
-            logger.warning(f"{manufacturer} manufacturer not implemented. Outputting in Hz, uT/m, uT/m^2, uT/m^3 for "
+            logger.warning(f"{self.manufacturer} manufacturer not implemented. Outputting in Hz, uT/m, uT/m^2, uT/m^3 for "
                            "order 0, 1, 2 and 3 respectively")
             sph_coil_profile = sh_basis(mesh1, mesh2, mesh3, orders=tuple(self.orders), shim_cs=self.coord_system)
 
         return sph_coil_profile
+
+    def _update_constraints_to_cs(self):
+        # Constraints are in the shim cs
+        if self.opt_cs == 'gradient-cs':
+            if 1 not in self.orders:
+                raise ValueError("Order 1 needs to be selected to update to gradient-cs")
+            # Convert from shim coordinate system to RAS
+            flip = get_flip_matrix(self.coord_system, self.manufacturer, [1, ])
+            if flip[0] < 0:
+                min_x = -self.coef_channel_minmax['1'][0][1]
+                max_x = -self.coef_channel_minmax['1'][0][0]
+            else:
+                min_x = self.coef_channel_minmax['1'][0][0]
+                max_x = self.coef_channel_minmax['1'][0][1]
+            if flip[1] < 0:
+                min_y = -self.coef_channel_minmax['1'][1][1]
+                max_y = -self.coef_channel_minmax['1'][1][0]
+            else:
+                min_y = self.coef_channel_minmax['1'][1][0]
+                max_y = self.coef_channel_minmax['1'][1][1]
+            if flip[2] < 0:
+                min_z = -self.coef_channel_minmax['1'][2][1]
+                max_z = -self.coef_channel_minmax['1'][2][0]
+            else:
+                min_z = self.coef_channel_minmax['1'][2][0]
+                max_z = self.coef_channel_minmax['1'][2][1]
+
+            # Find bounds for freq, phase and slice encoding direction
+            min_freq = np.inf
+            max_freq = -np.inf
+            min_phase = np.inf
+            max_phase = -np.inf
+            min_slice = np.inf
+            max_slice = -np.inf
+
+            for x_coef in [min_x, max_x]:
+                for y_coef in [min_y, max_y]:
+                    for z_coef in [min_z, max_z]:
+                        # Convert from World RAS to gradient CS
+                        freq, phase, slice = phys_to_gradient_cs(x_coef, y_coef, z_coef, self.fname_target)
+                        if freq < min_freq:
+                            min_freq = freq
+                        if freq > max_freq:
+                            max_freq = freq
+                        if phase < min_phase:
+                            min_phase = phase
+                        if phase > max_phase:
+                            max_phase = phase
+                        if slice < min_slice:
+                            min_slice = slice
+                        if slice > max_slice:
+                            max_slice = slice
+
+                        logger.debug(f"Freq, phase, slice: {freq}, {phase}, {slice}")
+            self.coef_channel_minmax['1'] = [[min_freq, max_freq], [min_phase, max_phase], [min_slice, max_slice]]
 
     def __hash__(self):
         return hash(self.name)

--- a/shimming-toolbox/shimmingtoolbox/coils/coil.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/coil.py
@@ -9,6 +9,7 @@ from typing import Tuple
 from shimmingtoolbox.coils.spher_harm_basis import (sh_basis, siemens_basis, ge_basis, philips_basis, SHIM_CS,
                                                     channels_per_order)
 from shimmingtoolbox.coils.coordinates import generate_meshgrid
+from shimmingtoolbox.shim.shim_utils import phys_to_gradient_cs
 from shimmingtoolbox import __config_scanner_constraints__
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,7 @@ SCANNER_CONSTRAINTS_DAC = {
     }
 }
 
+OPT_CS = ['shim-cs', 'gradient-cs']
 
 class Coil(object):
     """
@@ -306,7 +308,7 @@ class ScannerCoil(Coil):
     """Coil class for scanner coils as they require extra arguments"""
 
     def __init__(self, dim_volume, affine, constraints, orders, manufacturer="", shim_cs=None,
-                 isocenter=np.array([0, 0, 0]), channels_onoff=None, channels_off_values=None):
+                 isocenter=np.array([0, 0, 0]), channels_onoff=None, channels_off_values=None, opt_cs="shim-cs", fname_target=None):
         """
         Args:
             dim_volume (tuple): x, y and z dimensions.
@@ -329,6 +331,9 @@ class ScannerCoil(Coil):
                                    If not specified, all channels are on. (Optional)
             channels_off_values (np.ndarray): (n_slices x n_off_channels) array of values to set for the channels that are
                                              off.
+            opt_cs (str): Coordinate system of the coil profiles. If gradient-cs, only order 1 is supported.
+            fname_target (str): Filename of the target NIfTI file.
+
         """
         self.orders = orders
 
@@ -344,9 +349,13 @@ class ScannerCoil(Coil):
 
         self.affine = affine
         self.isocenter = isocenter
+        self.opt_cs = opt_cs
+        if opt_cs not in OPT_CS:
+            raise ValueError(f"Unknown option {opt_cs}. Available options are: {OPT_CS}")
+        self.fname_target = fname_target
 
         # Create the spherical harmonics with the correct order, dim and affine
-        sph_coil_profile = self._create_coil_profile(dim_volume, manufacturer)
+        sph_coil_profile = self._create_coil_profile(dim_volume, manufacturer, opt_cs)
         # Restricts the constraints to the specified order
         if 'coef_channel_minmax' in constraints.keys():
             constraints['coef_channel_minmax'] = restrict_to_orders(constraints['coef_channel_minmax'],
@@ -355,14 +364,26 @@ class ScannerCoil(Coil):
             constraints['coefs_used'] = restrict_to_orders(constraints['coefs_used'], self.orders)
         super().__init__(sph_coil_profile, affine, constraints, channels_onoff, channels_off_values)
 
-    def _create_coil_profile(self, dim, manufacturer=None):
+    def _create_coil_profile(self, dim, manufacturer=None, opt_cs='shim-cs'):
         # Create spherical harmonics coil profiles
+
+        if opt_cs == "gradient-cs" and self.fname_target is None:
+            raise ValueError("fname_target cannot be None for gradient-cs")
+        if opt_cs == "shim-cs" and manufacturer is not "SIEMENS":
+            raise ValueError("gradient-cs not implemented for manufacturer {manufacturer}. Only implemented for SIEMENS.")
+
         # Change the affine offset so that the origin is at isocenter
         affine_origin_iso = copy.deepcopy(self.affine)
         affine_origin_iso[:3, 3] -= self.isocenter
         mesh1, mesh2, mesh3 = generate_meshgrid(dim, affine_origin_iso)
         if manufacturer == 'SIEMENS':
-            sph_coil_profile = siemens_basis(mesh1, mesh2, mesh3, orders=tuple(self.orders))
+            if opt_cs == 'shim-cs':
+                sph_coil_profile = siemens_basis(mesh1, mesh2, mesh3, orders=tuple(self.orders))
+            elif opt_cs == 'gradient-cs':
+                mesh1_freq, mesh2_phase, mesh3_slice = phys_to_gradient_cs(mesh1, mesh2, mesh3, self.fname_target)
+                sph_coil_profile = siemens_basis(mesh1_freq, mesh2_phase, mesh3_slice, orders=tuple(self.orders), shim_cs='RAS')
+            else:
+                raise ValueError(f"Unknown opt_cs: {opt_cs}")
         elif manufacturer == 'GE':
             sph_coil_profile = ge_basis(mesh1, mesh2, mesh3, orders=tuple(self.orders))
         elif manufacturer == 'PHILIPS':

--- a/shimming-toolbox/shimmingtoolbox/coils/coil.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/coil.py
@@ -6,10 +6,9 @@ import logging
 import numpy as np
 from typing import Tuple
 
-from shimmingtoolbox.coils.spher_harm_basis import (sh_basis, siemens_basis, ge_basis, philips_basis, SHIM_CS,
-                                                    channels_per_order, get_flip_matrix)
+from shimmingtoolbox.coils.spher_harm_basis import sh_basis, siemens_basis, ge_basis, philips_basis, channels_per_order
 from shimmingtoolbox.coils.coordinates import generate_meshgrid
-from shimmingtoolbox.shim.shim_utils import phys_to_gradient_cs
+from shimmingtoolbox.shim.shim_utils import phys_to_gradient_cs, SHIM_CS, get_flip_matrix
 from shimmingtoolbox import __config_scanner_constraints__
 
 logger = logging.getLogger(__name__)
@@ -372,19 +371,15 @@ class ScannerCoil(Coil):
             raise ValueError("fname_target cannot be None for gradient-cs")
         if opt_cs == "gradient-cs" and self.manufacturer != "SIEMENS":
             raise ValueError(f"gradient-cs not implemented for manufacturer {self.manufacturer}. Only implemented for SIEMENS.")
+        if opt_cs == "gradient-cs" and self.orders not in [[1,], [0, 1]]:
+            raise ValueError("Order 1 is required for gradient-cs")
 
         # Change the affine offset so that the origin is at isocenter
         affine_origin_iso = copy.deepcopy(self.affine)
         affine_origin_iso[:3, 3] -= self.isocenter
         mesh1, mesh2, mesh3 = generate_meshgrid(dim, affine_origin_iso)
         if self.manufacturer == 'SIEMENS':
-            if opt_cs == 'shim-cs':
-                sph_coil_profile = siemens_basis(mesh1, mesh2, mesh3, orders=tuple(self.orders))
-            elif opt_cs == 'gradient-cs':
-                mesh1_freq, mesh2_phase, mesh3_slice = phys_to_gradient_cs(mesh1, mesh2, mesh3, self.fname_target)
-                sph_coil_profile = siemens_basis(mesh1_freq, mesh2_phase, mesh3_slice, orders=tuple(self.orders), shim_cs='RAS')
-            else:
-                raise ValueError(f"Unknown opt_cs: {opt_cs}")
+            sph_coil_profile = siemens_basis(mesh1, mesh2, mesh3, orders=tuple(self.orders), cs=opt_cs, fname_target=self.fname_target)
         elif self.manufacturer == 'GE':
             sph_coil_profile = ge_basis(mesh1, mesh2, mesh3, orders=tuple(self.orders))
         elif self.manufacturer == 'PHILIPS':
@@ -403,24 +398,9 @@ class ScannerCoil(Coil):
                 raise ValueError("Order 1 needs to be selected to update to gradient-cs")
             # Convert from shim coordinate system to RAS
             flip = get_flip_matrix(self.coord_system, self.manufacturer, [1, ])
-            if flip[0] < 0:
-                min_x = -self.coef_channel_minmax['1'][0][1]
-                max_x = -self.coef_channel_minmax['1'][0][0]
-            else:
-                min_x = self.coef_channel_minmax['1'][0][0]
-                max_x = self.coef_channel_minmax['1'][0][1]
-            if flip[1] < 0:
-                min_y = -self.coef_channel_minmax['1'][1][1]
-                max_y = -self.coef_channel_minmax['1'][1][0]
-            else:
-                min_y = self.coef_channel_minmax['1'][1][0]
-                max_y = self.coef_channel_minmax['1'][1][1]
-            if flip[2] < 0:
-                min_z = -self.coef_channel_minmax['1'][2][1]
-                max_z = -self.coef_channel_minmax['1'][2][0]
-            else:
-                min_z = self.coef_channel_minmax['1'][2][0]
-                max_z = self.coef_channel_minmax['1'][2][1]
+            min_x, max_x = sorted([flip[0] * coef for coef in self.coef_channel_minmax['1'][0]])
+            min_y, max_y = sorted([flip[1] * coef for coef in self.coef_channel_minmax['1'][1]])
+            min_z, max_z = sorted([flip[2] * coef for coef in self.coef_channel_minmax['1'][2]])
 
             # Find bounds for freq, phase and slice encoding direction
             min_freq = np.inf

--- a/shimming-toolbox/shimmingtoolbox/coils/coordinates.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/coordinates.py
@@ -160,15 +160,15 @@ def vox_to_phys_coefs(ax1_coefs, ax2_coefs, ax3_coefs, affine):
     y_vox_spacing = math.sqrt((affine[0, y_vox] ** 2) + (affine[1, y_vox] ** 2) + (affine[2, y_vox] ** 2))
     z_vox_spacing = math.sqrt((affine[0, z_vox] ** 2) + (affine[1, z_vox] ** 2) + (affine[2, z_vox] ** 2))
 
-    x_coefs = (ax1_coefs * affine[0, x_vox] * x_vox_spacing) + \
-             (ax2_coefs * affine[0, y_vox] * x_vox_spacing) + \
-             (ax3_coefs * affine[0, z_vox] * x_vox_spacing)
-    y_coefs = (ax1_coefs * affine[1, x_vox] * y_vox_spacing) + \
-             (ax2_coefs * affine[1, y_vox] * y_vox_spacing) + \
-             (ax3_coefs * affine[1, z_vox] * y_vox_spacing)
-    z_coefs = (ax1_coefs * affine[2, x_vox] * z_vox_spacing) + \
-             (ax2_coefs * affine[2, y_vox] * z_vox_spacing) + \
-             (ax3_coefs * affine[2, z_vox] * z_vox_spacing)
+    x_coefs = (ax1_coefs * affine[0, x_vox] / x_vox_spacing) + \
+             (ax2_coefs * affine[0, y_vox] / y_vox_spacing) + \
+             (ax3_coefs * affine[0, z_vox] / z_vox_spacing)
+    y_coefs = (ax1_coefs * affine[1, x_vox] / x_vox_spacing) + \
+             (ax2_coefs * affine[1, y_vox] / y_vox_spacing) + \
+             (ax3_coefs * affine[1, z_vox] / z_vox_spacing)
+    z_coefs = (ax1_coefs * affine[2, x_vox] / x_vox_spacing) + \
+             (ax2_coefs * affine[2, y_vox] / y_vox_spacing) + \
+             (ax3_coefs * affine[2, z_vox] / z_vox_spacing)
 
     return x_coefs, y_coefs, z_coefs
 

--- a/shimming-toolbox/shimmingtoolbox/coils/scanner_shim_settings.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/scanner_shim_settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-This file includes functions a classes useful to extract scanner's shim settings
+This file includes functions and classes useful to extract scanner's shim settings
 """
 import copy
 import logging

--- a/shimming-toolbox/shimmingtoolbox/coils/scanner_shim_settings.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/scanner_shim_settings.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""
+This file includes functions a classes useful to extract scanner's shim settings
+"""
+import copy
+import logging
+import numpy as np
+
+from shimmingtoolbox.coils.coil import SCANNER_CONSTRAINTS, SCANNER_CONSTRAINTS_DAC
+from shimmingtoolbox.coils.spher_harm_basis import channels_per_order
+
+logger = logging.getLogger(__name__)
+
+
+class ScannerShimSettings:
+    """ Class to handle the scanner shim settings from a NIfTI fieldmap file.
+    """
+    def __init__(self, nif_fmap, orders=None):
+
+        shim_settings_dac = nif_fmap.get_scanner_shim_settings(orders=orders)
+        manufacturers_model_name = nif_fmap.get_manufacturers_model_name()
+        manufacturer = nif_fmap.get_json_info('Manufacturer')
+        device_serial_number = nif_fmap.get_json_info('DeviceSerialNumber')
+
+        self.shim_settings = dac_to_shim_units(manufacturer,
+                                               manufacturers_model_name,
+                                               device_serial_number,
+                                               shim_settings_dac)
+
+    def concatenate_shim_settings(self, orders=[2]):
+        return concatenate_shim_settings(self.shim_settings, orders=orders)
+
+
+def concatenate_shim_settings(shim_settings, orders=[2]):
+    """
+
+    Args:
+        shim_settings (dict): Dictionary of shimSettings.
+        orders (list): List of orders to concatenate.
+
+    Returns:
+        list: List of coefficients concatenated in the order of the orders. If an order is not available,
+              it will be filled with zeros.
+    """
+    coefs = []
+
+    if any(order >= 0 for order in orders):
+        for order in sorted(orders):
+            if shim_settings.get(str(order)) is not None:
+                # Concatenate 2 lists
+                coefs.extend(shim_settings.get(str(order)))
+            else:
+                n_coefs = channels_per_order(order)
+                coefs.extend([0] * n_coefs)
+
+    return coefs
+
+
+def dac_to_shim_units(manufacturer, manufacturers_model_name, device_serial_number, shim_settings):
+    """ Converts the ShimSettings tag from the json BIDS sidecar to the ui units.
+        (i.e. For the Prisma fit DAC --> uT/m, uT/m^2 (1st order, 2nd order))
+
+    Args:
+        manufacturer (str): Manufacturer of the scanner. "SIEMENS", "GE" or "PHILIPS".
+        manufacturers_model_name (str): Name of the model of the scanner. Found in the json BIDS sidecar under
+                                        'ManufacturersModelName'. Supported names: 'Prisma_fit'.
+        device_serial_number (str): Serial number of the scanner. Found in the json BIDS sidecar under
+                                    DeviceSerialNumber.
+        shim_settings (dict): Dictionary with keys: '1', '2'. Found in the json BIDS sidecar under 'ShimSetting'. '2' is
+                       a list of 5 coefficients.
+
+    Returns:
+        dict: Same dictionary as the shim_settings input with coefficients of the first, second and third order
+              converted according to the appropriate manufacturer model.
+    """
+    scanner_shim_mp = copy.deepcopy(shim_settings)
+
+    scanner_id = f"{manufacturers_model_name}_{device_serial_number}"
+
+    # Check if the manufacturer is implemented
+    if manufacturer not in SCANNER_CONSTRAINTS_DAC.keys():
+        logger.warning(f"{manufacturer} not implemented or does not include enough metadata information")
+
+    # Check if the scanner_id is implemented
+    elif scanner_id in SCANNER_CONSTRAINTS_DAC[manufacturer].keys():
+        scanner_constraints_dac = SCANNER_CONSTRAINTS_DAC[manufacturer][scanner_id]
+        scanner_constraints = SCANNER_CONSTRAINTS[manufacturer][scanner_id]
+
+        # Do all the orders except f0
+        for order in ['0', '1', '2', '3']:
+            # Make sure the order is available in the metadata
+            if shim_settings.get(order) and shim_settings[order] is not None:
+
+                # No conversion necessary for f0
+                if order == '0':
+                    # F0 is in Hz, no conversion necessary, just check that the current frequency fits within the bounds
+                    max_0 = scanner_constraints[order][0][1]
+                    min_0 = scanner_constraints[order][0][0]
+                    tolerance = 0.001 * (max_0 - min_0)
+                    if (shim_settings[order][0] > (max_0 + tolerance)) or (
+                            shim_settings[order][0] < (min_0 - tolerance)):
+                        raise ValueError(f"Current f0 frequency {shim_settings[order][0]} exceeds known system limits.")
+                    continue
+                # Check if unit conversion for the order is implemented
+                elif not scanner_constraints_dac.get(order):
+                    logger.warning(f"Order {order} conversion of {scanner_id} not implemented.")
+                    scanner_shim_mp[order] = None
+                    continue
+
+                # Convert the shim settings to ui units
+                scanner_shim_mp[order] = _convert_to_ui_units(shim_settings[order],
+                                                              scanner_constraints[order],
+                                                              scanner_constraints_dac[order])
+
+    else:
+        logger.debug(f"Manufacturer model {scanner_id} not implemented, "
+                     f"could not convert shim settings")
+
+    return scanner_shim_mp
+
+
+def _convert_to_ui_units(shim_settings_coefs, scanner_constraints, scanner_constraints_dac):
+    # Convert to ui units
+    coefs_dac = shim_settings_coefs
+    max_coefs_ui = np.array([cst[1] for cst in scanner_constraints])
+    min_coefs_ui = np.array([cst[0] for cst in scanner_constraints])
+    coefs_ui = (np.array(coefs_dac) * (max_coefs_ui - min_coefs_ui) / (2 * np.array(scanner_constraints_dac)))
+    tolerance = 0.001 * (max_coefs_ui - min_coefs_ui)
+    if np.any(coefs_ui > (max_coefs_ui + tolerance)) or np.any(coefs_ui < (min_coefs_ui - tolerance)):
+        raise ValueError("Current shim settings exceed known system limits.")
+
+    return coefs_ui

--- a/shimming-toolbox/shimmingtoolbox/coils/spher_harm_basis.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/spher_harm_basis.py
@@ -7,13 +7,10 @@ import numpy as np
 from shimmingtoolbox.coils.spherical_harmonics import spherical_harmonics
 from shimmingtoolbox.conversion import (hz_per_cm_to_micro_tesla_per_m, hz_per_cm2_to_micro_tesla_per_m2,
                                         metric_unit_to_metric_unit, tesla_to_hz)
+from shimmingtoolbox.shim.shim_utils import phys_to_gradient_cs, SHIM_CS, get_flip_matrix, reorder_to_manufacturer
 
 logger = logging.getLogger(__name__)
 
-MANUFACTURERS = ('SIEMENS', 'GE', 'PHILIPS')
-SHIM_CS = {'SIEMENS': 'LAI',
-           'GE': 'LPI',
-           'PHILIPS': 'RPI'}
 SPH_HARMONICS_TITLES = \
     {'SIEMENS': ['X', 'Y', 'Z', 'Z2', 'ZX', 'ZY', 'X2-Y2', 'XY', 'Z3', 'Z2X', 'Z2Y', 'Z(X2 - Y2)'],
      'GE':      ['X', 'Y', 'Z', 'XY', 'ZY', 'ZX', 'X2-Y2', 'Z2'],
@@ -71,7 +68,7 @@ def sh_basis(x, y, z, orders=(1, 2), shim_cs="RAS"):
     return output
 
 
-def siemens_basis(x, y, z, orders=(1, 2), shim_cs=SHIM_CS['SIEMENS']):
+def siemens_basis(x, y, z, orders=(1, 2), cs='shim-cs', fname_target=None):
     """
     The function first wraps ``shimmingtoolbox.coils.spherical_harmonics`` to generate the specified order
     spherical harmonic ``basis`` fields at the grid positions given by arrays ``x,y,z``. *Following Siemens convention*,
@@ -100,6 +97,8 @@ def siemens_basis(x, y, z, orders=(1, 2), shim_cs=SHIM_CS['SIEMENS']):
                            the patient coordinate system (i.e. NIfTI reference, units of mm)
         orders (tuple): Degrees of the desired terms in the series expansion, specified as a vector of non-negative
                         integers (``(0:1:n)`` yields harmonics up to n-th order, implemented 1st, 2nd and 3rd order)
+        cs (str): Coordinate system of the profiles. ['shim-cs', 'gradient-cs']
+        fname_target (str): Path to the target image. This option is required if cs is 'gradient-cs'.
 
     Returns:
         numpy.ndarray: 4-D array of spherical harmonic basis fields
@@ -109,6 +108,14 @@ def siemens_basis(x, y, z, orders=(1, 2), shim_cs=SHIM_CS['SIEMENS']):
     _check_basis_inputs(x, y, z, orders)
 
     # Create spherical harmonics
+    if cs == 'shim-cs':
+        shim_cs = SHIM_CS['SIEMENS']
+    elif cs == 'gradient-cs':
+        x, y, z = phys_to_gradient_cs(x, y, z, fname_target)
+        shim_cs = 'RAS'
+    else:
+        raise ValueError("Invalid value of coordinate system")
+
     flip = get_flip_matrix(shim_cs, manufacturer='SIEMENS', orders=[1, ])
     spher_harm = scaled_spher_harm(x * flip[0], y * flip[1], z * flip[2], orders)
 
@@ -396,82 +403,6 @@ def convert_spher_harm_to_array(spher_harm_dict):
     return spher_harm
 
 
-def reorder_to_manufacturer(spher_harm, manufacturer):
-    """
-    Reorder 1st - 2nd - 3rd order coefficients, if specified. From
-
-    Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2, Y(X2 - Y2), XYZ, Z2Y, Z3, Z2X, Z(X2 - Y2), X(X2 - Y2)
-    (output by shimmingtoolbox.coils.spherical_harmonics.spherical_harmonics), to
-
-    X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY, Z3, Z2X, Z2Y, Z(X2 - Y2) (in line with Siemens shims) or
-
-    X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY (in line with GE shims) or
-
-    X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY, Z3, Z2X, Z2Y, Z(X2 - Y2), XYZ, X(X2 - Y2), Y(X2 - Y2) (in line with Philips shims)
-
-    Args:
-        spher_harm (dict): 3D array of spherical harmonics coefficients with key corresponding to the order
-        manufacturer (str): Manufacturer of the scanner
-
-    Returns:
-        dict: Coefficients ordered following the manufacturer's convention
-    """
-    if manufacturer not in MANUFACTURERS:
-        # Do not reorder if the manufacturer is not in the implemented manufacturers
-        return spher_harm
-
-    def _reorder_order0(sph, manuf):
-        if sph.shape[-1] != 1:
-            raise ValueError("Input arrays should have 4th dimension's shape equal to 1")
-        return sph[..., [0]]
-
-    def _reorder_order1(sph, manuf):
-        if sph.shape[-1] != 3:
-            raise ValueError("Input arrays should have 4th dimension's shape equal to 3")
-        if manuf in ['SIEMENS', 'GE', 'PHILIPS']:
-            return sph[..., [2, 0, 1]]
-        else:
-            logger.warning(f"1st order spherical harmonics not implemented for: {manuf}")
-            return sph
-
-    def _reorder_order2(sph, manuf):
-        if sph.shape[-1] != 5:
-            raise ValueError("Input arrays should have 4th dimension's shape equal to 5")
-
-        if manuf in ['SIEMENS', 'PHILIPS', 'GE']:
-            return sph[..., [2, 3, 1, 4, 0]]
-        else:
-            logger.warning(f"2nd order spherical harmonics not implemented for: {manuf}")
-            return sph
-
-    def _reorder_order3(sph, manuf):
-        if sph.shape[-1] != 7:
-            raise ValueError("Input arrays should have 4th dimension's shape equal to 7")
-        if manufacturer == 'SIEMENS':
-            return sph[..., [3, 4, 2, 5]]
-        elif manufacturer == 'PHILIPS':
-            # Y(X2 - Y2), XYZ, Z2Y, Z3, Z2X, Z(X2 - Y2), X(X2 - Y2)
-            # Z3, Z2X, Z2Y, Z(X2 - Y2), XYZ, X(X2 - Y2), Y(X2 - Y2)
-            return sph[..., [3, 4, 2, 5, 1, 6, 0]]
-
-        else:
-            logger.warning(f"3rd order spherical harmonics not implemented for: {manuf}")
-            return sph
-
-    reorder = {0: _reorder_order0,
-               1: _reorder_order1,
-               2: _reorder_order2,
-               3: _reorder_order3}
-
-    reordered = {}
-    for order in spher_harm.keys():
-        if order not in reorder.keys():
-            logger.warning(f"Ordering for order {order} spherical harmonics not implemented")
-        reordered[order] = reorder[order](spher_harm[order], manuf=manufacturer)
-
-    return reordered
-
-
 def reorder_shim_to_scaling_ge(coefs):
     # Reorder 2nd order terms
     # 1. * Z2, ZX, ZY, X2 - Y2, XY * (in line with GE shims)
@@ -596,64 +527,3 @@ def channels_per_order(order, manufacturer=None):
     if manufacturer == 'SIEMENS' and order == 3:
         return 4
     return 2 * order + 1
-
-
-def get_flip_matrix(shim_cs='RAS', manufacturer=None, orders=None):
-    f"""
-    Return a matrix to flip the spherical harmonics basis set from RAS to the desired coordinate system.
-
-    Args:
-        shim_cs (str): Coordinate system of the shim basis set. Default is RAS.
-        orders (list): List of orders of the spherical harmonics. Default to None (all orders)
-        manufacturer (str): Manufacturer of the scanner. The flipping matrix order is different for each manufacturer.
-                            If None is selected, it will output according to
-                            ``shimmingtoolbox.coils.spherical_harmonics``. Possible values: {MANUFACTURERS}.
-
-    Returns:
-        numpy.ndarray: Matrix (len: 8) to flip the spherical harmonics basis set from ras to the desired coordinate
-                       system. Output is a 1D vector of ``flip_matrix`` for the following:
-                       Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2, Y(X2 - Y2), XYZ, YZ2, Z3, XZ^2, Z(X2 - Y2), X(X2 - Y2).
-                       If xyz is True, output X, Y, Z only in this order.
-    """
-    if orders is None:
-        orders = [1, 2, 3]
-
-    xyz_cs = [1, 1, 1]
-
-    shim_cs = shim_cs.upper()
-    if (len(shim_cs) != 3) or \
-            (shim_cs[0] not in ['R', 'L']) or (shim_cs[1] not in ['A', 'P']) or (shim_cs[2] not in ['S', 'I']):
-        raise ValueError(f"Unknown coordinate system: {shim_cs}")
-
-    if shim_cs[0] == 'L':
-        xyz_cs[0] = -1
-    if shim_cs[1] == 'P':
-        xyz_cs[1] = -1
-    if shim_cs[2] == 'I':
-        xyz_cs[2] = -1
-
-    # Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2, Y(X2 - Y2), XYZ, Z2Y, Z3, Z2X, Z(X2 - Y2), X(X2 - Y2)
-    out_dict = {}
-    for order in orders:
-        if order == 1:
-            out_dict[1] = np.array([xyz_cs[1], xyz_cs[2], xyz_cs[0]])
-        if order == 2:
-            out_dict[2] = np.array([xyz_cs[0] * xyz_cs[1], xyz_cs[2] * xyz_cs[1], 1, xyz_cs[2] * xyz_cs[0], 1])
-        if order == 3:
-            out_dict[3] = np.array([xyz_cs[1], xyz_cs[0] * xyz_cs[1] * xyz_cs[2], xyz_cs[1], xyz_cs[2], xyz_cs[0],
-                                    xyz_cs[2], xyz_cs[0]])
-
-    if manufacturer is not None:
-        manufacturer = manufacturer.upper()
-
-    out_dict = reorder_to_manufacturer(out_dict, manufacturer)
-
-    out_list = []
-    for i_order in sorted(orders):
-        out_list += out_dict[i_order].tolist()
-
-    # None: Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2, Y(X2 - Y2), XYZ, Z2Y, Z3, Z2X, Z(X2 - Y2), X(X2 - Y2)
-    # GE: x, y, z, xy, zy, zx, X2 - Y2, z2, 3rd order not implemented
-    # Siemens: X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY, Z3,  XZ2, YZ2, Z(X2 - Y2)
-    # Philips: X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY, 3rd order not implemented
-    return out_list

--- a/shimming-toolbox/shimmingtoolbox/coils/spher_harm_basis.py
+++ b/shimming-toolbox/shimmingtoolbox/coils/spher_harm_basis.py
@@ -71,7 +71,7 @@ def sh_basis(x, y, z, orders=(1, 2), shim_cs="RAS"):
     return output
 
 
-def siemens_basis(x, y, z, orders=(1, 2)):
+def siemens_basis(x, y, z, orders=(1, 2), shim_cs=SHIM_CS['SIEMENS']):
     """
     The function first wraps ``shimmingtoolbox.coils.spherical_harmonics`` to generate the specified order
     spherical harmonic ``basis`` fields at the grid positions given by arrays ``x,y,z``. *Following Siemens convention*,
@@ -109,7 +109,7 @@ def siemens_basis(x, y, z, orders=(1, 2)):
     _check_basis_inputs(x, y, z, orders)
 
     # Create spherical harmonics
-    flip = get_flip_matrix(SHIM_CS['SIEMENS'], manufacturer='SIEMENS', orders=[1, ])
+    flip = get_flip_matrix(shim_cs, manufacturer='SIEMENS', orders=[1, ])
     spher_harm = scaled_spher_harm(x * flip[0], y * flip[1], z * flip[2], orders)
 
     # Reorder according to siemens convention: X, Y, Z, Z2, ZX, ZY, X2-Y2, XY, Z3, Z2X, Z2Y, Z(X2 - Y2)
@@ -605,7 +605,7 @@ def get_flip_matrix(shim_cs='RAS', manufacturer=None, orders=None):
     Args:
         shim_cs (str): Coordinate system of the shim basis set. Default is RAS.
         orders (list): List of orders of the spherical harmonics. Default to None (all orders)
-        manufacturer (str): Manufacturer of the scanner. The flipping matrix is different for each manufacturer.
+        manufacturer (str): Manufacturer of the scanner. The flipping matrix order is different for each manufacturer.
                             If None is selected, it will output according to
                             ``shimmingtoolbox.coils.spherical_harmonics``. Possible values: {MANUFACTURERS}.
 

--- a/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
@@ -353,8 +353,8 @@ class ShimSequencer(Sequencer):
                 fname_shimmed_fmap = os.path.join(self.path_output, 'fieldmap_calculated_shim.nii.gz')
                 nib.save(nii_shimmed_fmap, fname_shimmed_fmap)
 
-            # Output JSON file
-            self.save_calc_fmap_json(coefs)
+            # We don't save the field maps' JSON file here because the coefficients might not be in the correct CS
+            # The function save_calc_fmap_json should be called separately to save the JSON file (in b0shim).
 
             # TODO: Add units if possible
             # TODO: Add in target space?
@@ -699,19 +699,26 @@ class ShimSequencer(Sequencer):
         nib.save(nii_shimmed_target_orient, fname_shimmed_target_orient)
 
     def save_calc_fmap_json(self, coefs):
+        """ Save the shim coefficients for the scanner in the JSON sidecar. coefs must only include the Scanner coefs
+        in the shim CS. Only writes the coefficents if it's volume shim.
+
+        Args:
+            coefs (np.ndarray): Array with the shim coefficients:
+        """
+        if self.path_output is None:
+            raise RuntimeError("Path output is None")
+
         json_shimmed = copy.deepcopy(self.nif_fieldmap.json)
         # If volume shim
         if len(self.slices) == 1:
-            # i keeps track of the index of the concatenated shim coefficients
-            i = 0
             for coil in self.coils:
-                # j keeps track of the index of the order
-                j = 0
                 if isinstance(coil, ScannerCoil):
                     # If its volume shim (len(slices == 1)) and a scanner coil
+                    # j keeps track of the index of the order
+                    j = 0
                     # Dump the shim coefficients as ShimSettingsCurrent + calculated shimmed coefs
                     if 0 in coil.orders:
-                        json_shimmed['ImagingFrequency'] = int(coil.coefs_used['0'][0] + coefs[0, i]) / 1e6
+                        json_shimmed['ImagingFrequency'] = int(coil.coefs_used['0'][0] + coefs[0, 0]) / 1e6
                         j += 1
                     shim_settings_output = []
                     for order in (1, 2, 3):
@@ -720,8 +727,7 @@ class ShimSequencer(Sequencer):
                             n_channels = channels_per_order(order, manufacturer)
                             for i_channel in range(n_channels):
                                 if coil.coefs_used[str(order)] is not None and coil.coefs_used[str(order)][i_channel] is not None:
-                                    shim_settings_tmp = (coil.coefs_used[str(order)][i_channel] +
-                                                         coefs[0, i + j + i_channel])
+                                    shim_settings_tmp = coil.coefs_used[str(order)][i_channel] + coefs[0, j + i_channel]
                                     manufacturers_model_name = self.nif_fieldmap.get_manufacturers_model_name()
                                     device_serial_number = self.nif_fieldmap.get_json_info('DeviceSerialNumber')
                                     scanner_id = f"{manufacturers_model_name}_{device_serial_number}"
@@ -763,8 +769,7 @@ class ShimSequencer(Sequencer):
                         else:
                             formatted_shim_settings.append(None)
                     json_shimmed['ShimSetting'] = formatted_shim_settings
-
-                i += coil.dim[3]
+                    break
 
         with open(os.path.join(self.path_output, "fieldmap_calculated_shim.json"), "w") as outfile:
             json.dump(json_shimmed, outfile, indent=4)

--- a/shimming-toolbox/shimmingtoolbox/shim/shim_utils.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/shim_utils.py
@@ -2,16 +2,14 @@
 """
 This file includes utility functions useful for the shimming module
 """
-import copy
 import nibabel as nib
 import json
 import numpy as np
 import logging
 from nibabel.affines import apply_affine
 
-from shimmingtoolbox.coils.coil import SCANNER_CONSTRAINTS, SCANNER_CONSTRAINTS_DAC
 from shimmingtoolbox.coils.coordinates import phys_to_vox_coefs, vox_to_phys_coefs, get_main_orientation
-from shimmingtoolbox.coils.spher_harm_basis import get_flip_matrix, SHIM_CS, channels_per_order
+from shimmingtoolbox.coils.spher_harm_basis import get_flip_matrix, SHIM_CS
 
 logger = logging.getLogger(__name__)
 
@@ -108,13 +106,11 @@ def phys_to_gradient_cs(coefs_x, coefs_y, coefs_z, fname_target):
 
     if 'Manufacturer' not in json_target_data:
         raise ValueError("Manufacturer not found in the json file.")
-    if json_target_data['Manufacturer'] != 'Siemens':
-        raise NotImplementedError(f"Manufacturer {json_target_data['Manufacturer']} not supported. Only Siemens supported.")
+    manufacturer = json_target_data['Manufacturer']
 
     if 'PatientPosition' not in json_target_data:
         raise ValueError("PatientPosition not found in json file.")
-    if json_target_data['PatientPosition'] != 'HFS':
-        raise NotImplementedError(f"PatientPosition {json_target_data['PatientPosition']} is not supported. Only HFS is implemented")
+    patient_position = json_target_data['PatientPosition']
 
     if 'ImageOrientationText' in json_target_data:
         # Tag in private dicom header (0051,100E) indicates the slice orientation, if it exists, it will appear
@@ -128,29 +124,16 @@ def phys_to_gradient_cs(coefs_x, coefs_y, coefs_z, fname_target):
 
     phase_encode_is_positive = get_phase_encode_direction_sign(fname_target)
 
-    if orientation == 'TRA':
-        if phase_encode_is_positive:
-            target_ornt = nib.orientations.axcodes2ornt(('L', 'A', 'S'))
-        else:
-            target_ornt = nib.orientations.axcodes2ornt(('R', 'P', 'S'))
-    elif orientation == 'SAG':
-        if phase_encode_is_positive:
-            target_ornt = nib.orientations.axcodes2ornt(('S', 'P', 'L'))
-        else:
-            target_ornt = nib.orientations.axcodes2ornt(('I', 'A', 'L'))
-    elif orientation == 'COR':
-        if phase_encode_is_positive:
-            target_ornt = nib.orientations.axcodes2ornt(('I', 'L', 'P'))
-        else:
-            target_ornt = nib.orientations.axcodes2ornt(('S', 'R', 'P'))
-    else:
-        raise RuntimeError(f"Unexpected value for orientation: {orientation}")
-
     nii_target = nib.load(fname_target)
-    start_ornt = nib.orientations.axcodes2ornt(nib.aff2axcodes(nii_target.affine))
-    transform_ornt = nib.orientations.ornt_transform(start_ornt, target_ornt)
-    new_affine = nii_target.affine @ nib.orientations.inv_ornt_aff(transform_ornt, nii_target.shape)
+    new_affine = convert_affine_to_gradient_cs(manufacturer,
+                                               patient_position,
+                                               orientation,
+                                               phase_encode_is_positive,
+                                               nii_target.affine,
+                                               nii_target.shape)
+
     coefs_freq, coefs_phase, coefs_slice = phys_to_vox_coefs(coefs_x, coefs_y, coefs_z, new_affine)
+
     return coefs_freq, coefs_phase, coefs_slice
 
 
@@ -176,15 +159,11 @@ def gradient_to_phys_cs(coefs_freq, coefs_phase, coefs_slice, fname_target):
 
     if 'Manufacturer' not in json_target_data:
         raise ValueError("Manufacturer not found in the json file.")
-    if json_target_data['Manufacturer'] != 'Siemens':
-        raise NotImplementedError(
-            f"Manufacturer {json_target_data['Manufacturer']} not supported. Only Siemens supported.")
+    manufacturer = json_target_data['Manufacturer']
 
     if 'PatientPosition' not in json_target_data:
         raise ValueError("PatientPosition not found in json file.")
-    if json_target_data['PatientPosition'] != 'HFS':
-        raise NotImplementedError(
-            f"PatientPosition {json_target_data['PatientPosition']} is not supported. Only HFS is implemented")
+    patient_position = json_target_data['PatientPosition']
 
     if 'ImageOrientationText' in json_target_data:
         # Tag in private dicom header (0051,100E) indicates the slice orientation, if it exists, it will appear
@@ -197,6 +176,38 @@ def gradient_to_phys_cs(coefs_freq, coefs_phase, coefs_slice, fname_target):
         orientation = get_main_orientation(json_target_data['ImageOrientationPatientDICOM'])
 
     phase_encode_is_positive = get_phase_encode_direction_sign(fname_target)
+
+    nii_target = nib.load(fname_target)
+    new_affine = convert_affine_to_gradient_cs(manufacturer,
+                                               patient_position,
+                                               orientation,
+                                               phase_encode_is_positive,
+                                               nii_target.affine,
+                                               nii_target.shape)
+
+    coefs_x, coefs_y, coefs_z = vox_to_phys_coefs(coefs_freq, coefs_phase, coefs_slice, new_affine)
+    return coefs_x, coefs_y, coefs_z
+
+
+def convert_affine_to_gradient_cs(manufacturer: str, patient_position: str, orientation: str,
+                                  phase_encode_is_positive: bool, affine, shape):
+    """ Output the affine matrix to transform from the gradient CS to RAS World Coordinate System.
+
+    Args:
+        manufacturer (str): Manufacturer
+        patient_position (str): Only HFS is supported
+        orientation (str): TRA or SAG or COR
+        phase_encode_is_positive (bool): Whether the phase encoding is positive or negative
+        affine (np.ndarray): Affine matrix
+        shape (np.ndarray): Dimensions of the image
+
+    Returns:
+        np.ndarray: New affine matrix to transform from the gradient CS to RAS World Coordinate System
+    """
+    if manufacturer != 'Siemens':
+        raise NotImplementedError(f"Manufacturer {manufacturer} not supported. Only Siemens supported.")
+    if patient_position != 'HFS':
+        raise NotImplementedError(f"PatientPosition {patient_position} is not supported. Only HFS is implemented")
 
     if orientation == 'TRA':
         if phase_encode_is_positive:
@@ -216,12 +227,10 @@ def gradient_to_phys_cs(coefs_freq, coefs_phase, coefs_slice, fname_target):
     else:
         raise RuntimeError(f"Unexpected value for orientation: {orientation}")
 
-    nii_target = nib.load(fname_target)
-    start_ornt = nib.orientations.axcodes2ornt(nib.aff2axcodes(nii_target.affine))
+    start_ornt = nib.orientations.axcodes2ornt(nib.aff2axcodes(affine))
     transform_ornt = nib.orientations.ornt_transform(start_ornt, target_ornt)
-    new_affine = nii_target.affine @ nib.orientations.inv_ornt_aff(transform_ornt, nii_target.shape)
-    coefs_x, coefs_y, coefs_z = vox_to_phys_coefs(coefs_freq, coefs_phase, coefs_slice, new_affine)
-    return coefs_x, coefs_y, coefs_z
+    new_affine = affine @ nib.orientations.inv_ornt_aff(transform_ornt, shape)
+    return new_affine
 
 
 def calculate_metric_within_mask(array, mask, metric, axis=None):
@@ -334,82 +343,6 @@ def shim_to_phys_cs(coefs, manufacturer, orders):
     coefs = phys_to_shim_cs(coefs, manufacturer, orders)
 
     return coefs
-
-
-def dac_to_shim_units(manufacturer, manufacturers_model_name, device_serial_number, shim_settings):
-    """ Converts the ShimSettings tag from the json BIDS sidecar to the ui units.
-        (i.e. For the Prisma fit DAC --> uT/m, uT/m^2 (1st order, 2nd order))
-
-    Args:
-        manufacturer (str): Manufacturer of the scanner. "SIEMENS", "GE" or "PHILIPS".
-        manufacturers_model_name (str): Name of the model of the scanner. Found in the json BIDS sidecar under
-                                        ManufacturersModelName'. Supported names: 'Prisma_fit'.
-        device_serial_number (str): Serial number of the scanner. Found in the json BIDS sidecar under
-                                    DeviceSerialNumber.
-        shim_settings (dict): Dictionary with keys: '1', '2'. Found in the json BIDS sidecar under 'ShimSetting'. '2' is
-                       a list of 5 coefficients.
-
-    Returns:
-        dict: Same dictionary as the shim_settings input with coefficients of the first, second and third order
-              converted according to the appropriate manufacturer model.
-    """
-    scanner_shim_mp = copy.deepcopy(shim_settings)
-
-    scanner_id = f"{manufacturers_model_name}_{device_serial_number}"
-
-    # Check if the manufacturer is implemented
-    if manufacturer not in SCANNER_CONSTRAINTS_DAC.keys():
-        logger.warning(f"{manufacturer} not implemented or does not include enough metadata information")
-
-    # Check if the scanner_id is implemented
-    elif scanner_id in SCANNER_CONSTRAINTS_DAC[manufacturer].keys():
-        scanner_constraints_dac = SCANNER_CONSTRAINTS_DAC[manufacturer][scanner_id]
-        scanner_constraints = SCANNER_CONSTRAINTS[manufacturer][scanner_id]
-
-        # Do all the orders except f0
-        for order in ['0', '1', '2', '3']:
-            # Make sure the order is available in the metadata
-            if shim_settings.get(order) and shim_settings[order] is not None:
-
-                # No conversion necessary for f0
-                if order == '0':
-                    # F0 is in Hz, no conversion necessary, just check that the current frequency fits within the bounds
-                    max_0 = scanner_constraints[order][0][1]
-                    min_0 = scanner_constraints[order][0][0]
-                    tolerance = 0.001 * (max_0 - min_0)
-                    if (shim_settings[order][0] > (max_0 + tolerance)) or (
-                            shim_settings[order][0] < (min_0 - tolerance)):
-                        raise ValueError(f"Current f0 frequency {shim_settings[order][0]} exceeds known system limits.")
-                    continue
-                # Check if unit conversion for the order is implemented
-                elif not scanner_constraints_dac.get(order):
-                    logger.warning(f"Order {order} conversion of {scanner_id} not implemented.")
-                    scanner_shim_mp[order] = None
-                    continue
-
-                # Convert the shim settings to ui units
-                scanner_shim_mp[order] = _convert_to_ui_units(shim_settings[order],
-                                                              scanner_constraints[order],
-                                                              scanner_constraints_dac[order])
-
-    else:
-        logger.debug(f"Manufacturer model {scanner_id} not implemented, "
-                     f"could not convert shim settings")
-
-    return scanner_shim_mp
-
-
-def _convert_to_ui_units(shim_settings_coefs, scanner_constraints, scanner_constraints_dac):
-    # Convert to ui units
-    coefs_dac = shim_settings_coefs
-    max_coefs_ui = np.array([cst[1] for cst in scanner_constraints])
-    min_coefs_ui = np.array([cst[0] for cst in scanner_constraints])
-    coefs_ui = (np.array(coefs_dac) * (max_coefs_ui - min_coefs_ui) / (2 * np.array(scanner_constraints_dac)))
-    tolerance = 0.001 * (max_coefs_ui - min_coefs_ui)
-    if np.any(coefs_ui > (max_coefs_ui + tolerance)) or np.any(coefs_ui < (min_coefs_ui - tolerance)):
-        raise ValueError("Current shim settings exceed known system limits.")
-
-    return coefs_ui
 
 
 def convert_to_dac_units(shim_settings_coefs_ui, scanner_constraints, scanner_constraints_dac):
@@ -538,47 +471,3 @@ def update_affine_for_ap_slices(affine, n_slices=1, axis=2):
     new_affine[:3, 3] = affine[:3, 3] - spacing
 
     return new_affine
-
-
-class ScannerShimSettings:
-    """ Class to handle the scanner shim settings from a NIfTI fieldmap file.
-    """
-    def __init__(self, nif_fmap, orders=None):
-
-        shim_settings_dac = nif_fmap.get_scanner_shim_settings(orders=orders)
-        manufacturers_model_name = nif_fmap.get_manufacturers_model_name()
-        manufacturer = nif_fmap.get_json_info('Manufacturer')
-        device_serial_number = nif_fmap.get_json_info('DeviceSerialNumber')
-
-        self.shim_settings = dac_to_shim_units(manufacturer,
-                                               manufacturers_model_name,
-                                               device_serial_number,
-                                               shim_settings_dac)
-
-    def concatenate_shim_settings(self, orders=[2]):
-        return concatenate_shim_settings(self.shim_settings, orders=orders)
-
-
-def concatenate_shim_settings(shim_settings, orders=[2]):
-    """
-
-    Args:
-        shim_settings (dict): Dictionary of shimSettings.
-        orders (list): List of orders to concatenate.
-
-    Returns:
-        list: List of coefficients concatenated in the order of the orders. If an order is not available,
-              it will be filled with zeros.
-    """
-    coefs = []
-
-    if any(order >= 0 for order in orders):
-        for order in sorted(orders):
-            if shim_settings.get(str(order)) is not None:
-                # Concatenate 2 lists
-                coefs.extend(shim_settings.get(str(order)))
-            else:
-                n_coefs = channels_per_order(order)
-                coefs.extend([0] * n_coefs)
-
-    return coefs

--- a/shimming-toolbox/shimmingtoolbox/shim/shim_utils.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/shim_utils.py
@@ -9,10 +9,13 @@ import logging
 from nibabel.affines import apply_affine
 
 from shimmingtoolbox.coils.coordinates import phys_to_vox_coefs, vox_to_phys_coefs, get_main_orientation
-from shimmingtoolbox.coils.spher_harm_basis import get_flip_matrix, SHIM_CS
 
 logger = logging.getLogger(__name__)
 
+MANUFACTURERS = ('SIEMENS', 'GE', 'PHILIPS')
+SHIM_CS = {'SIEMENS': 'LAI',
+           'GE': 'LPI',
+           'PHILIPS': 'RPI'}
 
 def get_phase_encode_direction_sign(fname_nii):
     """ Returns the phase encode direction sign
@@ -471,3 +474,140 @@ def update_affine_for_ap_slices(affine, n_slices=1, axis=2):
     new_affine[:3, 3] = affine[:3, 3] - spacing
 
     return new_affine
+
+
+def get_flip_matrix(shim_cs='RAS', manufacturer=None, orders=None):
+    f"""
+    Return a matrix to flip the spherical harmonics basis set from RAS to the desired coordinate system.
+
+    Args:
+        shim_cs (str): Coordinate system of the shim basis set. Default is RAS.
+        orders (list): List of orders of the spherical harmonics. Default to None (all orders)
+        manufacturer (str): Manufacturer of the scanner. The flipping matrix order is different for each manufacturer.
+                            If None is selected, it will output according to
+                            ``shimmingtoolbox.coils.spherical_harmonics``. Possible values: {MANUFACTURERS}.
+
+    Returns:
+        numpy.ndarray: Matrix (len: 8) to flip the spherical harmonics basis set from ras to the desired coordinate
+                       system. Output is a 1D vector of ``flip_matrix`` for the following:
+                       Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2, Y(X2 - Y2), XYZ, YZ2, Z3, XZ^2, Z(X2 - Y2), X(X2 - Y2).
+                       If xyz is True, output X, Y, Z only in this order.
+    """
+    if orders is None:
+        orders = [1, 2, 3]
+
+    xyz_cs = [1, 1, 1]
+
+    shim_cs = shim_cs.upper()
+    if (len(shim_cs) != 3) or \
+            (shim_cs[0] not in ['R', 'L']) or (shim_cs[1] not in ['A', 'P']) or (shim_cs[2] not in ['S', 'I']):
+        raise ValueError(f"Unknown coordinate system: {shim_cs}")
+
+    if shim_cs[0] == 'L':
+        xyz_cs[0] = -1
+    if shim_cs[1] == 'P':
+        xyz_cs[1] = -1
+    if shim_cs[2] == 'I':
+        xyz_cs[2] = -1
+
+    # Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2, Y(X2 - Y2), XYZ, Z2Y, Z3, Z2X, Z(X2 - Y2), X(X2 - Y2)
+    out_dict = {}
+    for order in orders:
+        if order == 1:
+            out_dict[1] = np.array([xyz_cs[1], xyz_cs[2], xyz_cs[0]])
+        if order == 2:
+            out_dict[2] = np.array([xyz_cs[0] * xyz_cs[1], xyz_cs[2] * xyz_cs[1], 1, xyz_cs[2] * xyz_cs[0], 1])
+        if order == 3:
+            out_dict[3] = np.array([xyz_cs[1], xyz_cs[0] * xyz_cs[1] * xyz_cs[2], xyz_cs[1], xyz_cs[2], xyz_cs[0],
+                                    xyz_cs[2], xyz_cs[0]])
+
+    if manufacturer is not None:
+        manufacturer = manufacturer.upper()
+
+    out_dict = reorder_to_manufacturer(out_dict, manufacturer)
+
+    out_list = []
+    for i_order in sorted(orders):
+        out_list += out_dict[i_order].tolist()
+
+    # None: Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2, Y(X2 - Y2), XYZ, Z2Y, Z3, Z2X, Z(X2 - Y2), X(X2 - Y2)
+    # GE: x, y, z, xy, zy, zx, X2 - Y2, z2, 3rd order not implemented
+    # Siemens: X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY, Z3,  XZ2, YZ2, Z(X2 - Y2)
+    # Philips: X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY, 3rd order not implemented
+    return out_list
+
+
+def reorder_to_manufacturer(spher_harm, manufacturer):
+    """
+    Reorder 1st - 2nd - 3rd order coefficients, if specified. From
+
+    Y, Z, X, XY, ZY, Z2, ZX, X2 - Y2, Y(X2 - Y2), XYZ, Z2Y, Z3, Z2X, Z(X2 - Y2), X(X2 - Y2)
+    (output by shimmingtoolbox.coils.spherical_harmonics.spherical_harmonics), to
+
+    X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY, Z3, Z2X, Z2Y, Z(X2 - Y2) (in line with Siemens shims) or
+
+    X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY (in line with GE shims) or
+
+    X, Y, Z, Z2, ZX, ZY, X2 - Y2, XY, Z3, Z2X, Z2Y, Z(X2 - Y2), XYZ, X(X2 - Y2), Y(X2 - Y2) (in line with Philips shims)
+
+    Args:
+        spher_harm (dict): 3D array of spherical harmonics coefficients with key corresponding to the order
+        manufacturer (str): Manufacturer of the scanner
+
+    Returns:
+        dict: Coefficients ordered following the manufacturer's convention
+    """
+    if manufacturer not in MANUFACTURERS:
+        # Do not reorder if the manufacturer is not in the implemented manufacturers
+        return spher_harm
+
+    def _reorder_order0(sph, manuf):
+        if sph.shape[-1] != 1:
+            raise ValueError("Input arrays should have 4th dimension's shape equal to 1")
+        return sph[..., [0]]
+
+    def _reorder_order1(sph, manuf):
+        if sph.shape[-1] != 3:
+            raise ValueError("Input arrays should have 4th dimension's shape equal to 3")
+        if manuf in ['SIEMENS', 'GE', 'PHILIPS']:
+            return sph[..., [2, 0, 1]]
+        else:
+            logger.warning(f"1st order spherical harmonics not implemented for: {manuf}")
+            return sph
+
+    def _reorder_order2(sph, manuf):
+        if sph.shape[-1] != 5:
+            raise ValueError("Input arrays should have 4th dimension's shape equal to 5")
+
+        if manuf in ['SIEMENS', 'PHILIPS', 'GE']:
+            return sph[..., [2, 3, 1, 4, 0]]
+        else:
+            logger.warning(f"2nd order spherical harmonics not implemented for: {manuf}")
+            return sph
+
+    def _reorder_order3(sph, manuf):
+        if sph.shape[-1] != 7:
+            raise ValueError("Input arrays should have 4th dimension's shape equal to 7")
+        if manufacturer == 'SIEMENS':
+            return sph[..., [3, 4, 2, 5]]
+        elif manufacturer == 'PHILIPS':
+            # Y(X2 - Y2), XYZ, Z2Y, Z3, Z2X, Z(X2 - Y2), X(X2 - Y2)
+            # Z3, Z2X, Z2Y, Z(X2 - Y2), XYZ, X(X2 - Y2), Y(X2 - Y2)
+            return sph[..., [3, 4, 2, 5, 1, 6, 0]]
+
+        else:
+            logger.warning(f"3rd order spherical harmonics not implemented for: {manuf}")
+            return sph
+
+    reorder = {0: _reorder_order0,
+               1: _reorder_order1,
+               2: _reorder_order2,
+               3: _reorder_order3}
+
+    reordered = {}
+    for order in spher_harm.keys():
+        if order not in reorder.keys():
+            logger.warning(f"Ordering for order {order} spherical harmonics not implemented")
+        reordered[order] = reorder[order](spher_harm[order], manuf=manufacturer)
+
+    return reordered

--- a/shimming-toolbox/test/cli/test_cli_b0shim.py
+++ b/shimming-toolbox/test/cli/test_cli_b0shim.py
@@ -1222,11 +1222,9 @@ class TestCliDynamic(object):
                                 catch_exceptions=False)
             assert res.exit_code == 0
             # Read both txt files and make sure they are the same
-            with(open(os.path.join(tmp_shimcs, "coefs_coil0_Prisma_fit_167006.txt"), 'r')) as f:
-                shim_cs_coefs = f.read()
-            with(open(os.path.join(tmp_gradcs, "coefs_coil0_Prisma_fit_167006.txt"), 'r')) as f:
-                grad_cs_coefs = f.read()
-            assert shim_cs_coefs == grad_cs_coefs
+            shim_cs_coefs = read_txt_file(os.path.join(tmp_shimcs, "coefs_coil0_Prisma_fit_167006.txt"))
+            grad_cs_coefs = read_txt_file(os.path.join(tmp_gradcs, "coefs_coil0_Prisma_fit_167006.txt"))
+            assert np.allclose(shim_cs_coefs, grad_cs_coefs, atol=1e-6), "The coefficients from gradient-cs and shim-cs should be the same."
 
     def test_cli_dynamic_no_coil(self, nii_fmap, nii_target, nii_mask, nii_softmask, fm_data, target_data):
         """Test cli with scanner coil profiles of order 1 with default constraints"""

--- a/shimming-toolbox/test/cli/test_cli_b0shim.py
+++ b/shimming-toolbox/test/cli/test_cli_b0shim.py
@@ -1072,6 +1072,7 @@ class TestCliDynamic(object):
                                              '--mask', fname_mask,
                                              '--scanner-coil-order', '1',
                                              '-v', 'debug',
+                                             '--opt-cs', 'gradient-cs',
                                              '--output', tmp],
                                 catch_exceptions=False)
 
@@ -1147,6 +1148,85 @@ class TestCliDynamic(object):
                                              '--output', tmp],
                                 catch_exceptions=False)
             assert res.exit_code == 0
+
+    def test_cli_dynamic_opt_cs_gradient_offchannels(self, nii_fmap, nii_target, nii_mask, nii_softmask, fm_data, target_data):
+        """ Test the gradient-cs --opt-cs. When using pseudo inverse, the results should be the same as shim-cs. """
+        with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+            # Save the inputs to the new directory
+            fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
+            fname_fm_json = os.path.join(tmp, 'fmap.json')
+            fname_mask = os.path.join(tmp, 'mask.nii.gz')
+            fname_softmask = os.path.join(tmp, 'softmask.nii.gz')
+            fname_target = os.path.join(tmp, 'target.nii.gz')
+            fname_target_json = os.path.join(tmp, 'target.json')
+            nii_fmap = nib.Nifti1Image(nii_fmap.get_fdata()[..., 0], nii_fmap.affine, header=nii_fmap.header)
+            _save_inputs(nii_fmap=nii_fmap, fname_fmap=fname_fmap,
+                         nii_target=nii_target, fname_target=fname_target,
+                         nii_mask=nii_mask, fname_mask=fname_mask,
+                         nii_softmask=nii_softmask, fname_softmask=fname_softmask,
+                         fm_data=fm_data, fname_fm_json=fname_fm_json,
+                         target_data=target_data, fname_target_json=fname_target_json)
+
+            runner = CliRunner()
+            res = runner.invoke(b0shim_cli, ['dynamic',
+                                             '--fmap', fname_fmap,
+                                             '--mask', fname_mask,
+                                             '--target', fname_target,
+                                             '--optimizer-method', 'pseudo_inverse',
+                                             '--scanner-coil-order', '0,1',
+                                             '--off-channels', '0,1,2',
+                                             '--opt-cs', 'gradient-cs',
+                                             '--output', tmp],
+                                catch_exceptions=False)
+            assert res.exit_code == 0
+
+    def test_cli_dynamic_opt_cs_gradient_same_shim_cs(self, nii_fmap, nii_target, nii_mask, nii_softmask, fm_data, target_data):
+        """ Test the gradient-cs --opt-cs. When using pseudo inverse, the results should be the same as shim-cs. """
+        with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+            # Save the inputs to the new directory
+            fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
+            fname_fm_json = os.path.join(tmp, 'fmap.json')
+            fname_mask = os.path.join(tmp, 'mask.nii.gz')
+            fname_softmask = os.path.join(tmp, 'softmask.nii.gz')
+            fname_target = os.path.join(tmp, 'target.nii.gz')
+            fname_target_json = os.path.join(tmp, 'target.json')
+            nii_fmap = nib.Nifti1Image(nii_fmap.get_fdata()[..., 0], nii_fmap.affine, header=nii_fmap.header)
+            _save_inputs(nii_fmap=nii_fmap, fname_fmap=fname_fmap,
+                         nii_target=nii_target, fname_target=fname_target,
+                         nii_mask=nii_mask, fname_mask=fname_mask,
+                         nii_softmask=nii_softmask, fname_softmask=fname_softmask,
+                         fm_data=fm_data, fname_fm_json=fname_fm_json,
+                         target_data=target_data, fname_target_json=fname_target_json)
+            tmp_gradcs = os.path.join(tmp, 'grad_cs')
+            runner = CliRunner()
+            res = runner.invoke(b0shim_cli, ['dynamic',
+                                             '--fmap', fname_fmap,
+                                             '--mask', fname_mask,
+                                             '--target', fname_target,
+                                             '--optimizer-method', 'pseudo_inverse',
+                                             '--scanner-coil-order', '0,1',
+                                             '--opt-cs', 'gradient-cs',
+                                             '--output', tmp_gradcs],
+                                catch_exceptions=False)
+            assert res.exit_code == 0
+            tmp_shimcs = os.path.join(tmp, 'shim_cs')
+            runner = CliRunner()
+            res = runner.invoke(b0shim_cli, ['dynamic',
+                                             '--fmap', fname_fmap,
+                                             '--mask', fname_mask,
+                                             '--target', fname_target,
+                                             '--optimizer-method', 'pseudo_inverse',
+                                             '--scanner-coil-order', '0,1',
+                                             '--opt-cs', 'shim-cs',
+                                             '--output', tmp_shimcs],
+                                catch_exceptions=False)
+            assert res.exit_code == 0
+            # Read both txt files and make sure they are the same
+            with(open(os.path.join(tmp_shimcs, "coefs_coil0_Prisma_fit_167006.txt"), 'r')) as f:
+                shim_cs_coefs = f.read()
+            with(open(os.path.join(tmp_gradcs, "coefs_coil0_Prisma_fit_167006.txt"), 'r')) as f:
+                grad_cs_coefs = f.read()
+            assert shim_cs_coefs == grad_cs_coefs
 
     def test_cli_dynamic_no_coil(self, nii_fmap, nii_target, nii_mask, nii_softmask, fm_data, target_data):
         """Test cli with scanner coil profiles of order 1 with default constraints"""

--- a/shimming-toolbox/test/cli/test_cli_b0shim.py
+++ b/shimming-toolbox/test/cli/test_cli_b0shim.py
@@ -1148,6 +1148,7 @@ class TestCliDynamic(object):
                                              '--output', tmp],
                                 catch_exceptions=False)
             assert res.exit_code == 0
+            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_Prisma_fit_167006.txt"))
 
     def test_cli_dynamic_opt_cs_gradient_offchannels(self, nii_fmap, nii_target, nii_mask, nii_softmask, fm_data, target_data):
         """ Test the gradient-cs --opt-cs. When using pseudo inverse, the results should be the same as shim-cs. """
@@ -1179,6 +1180,44 @@ class TestCliDynamic(object):
                                              '--output', tmp],
                                 catch_exceptions=False)
             assert res.exit_code == 0
+            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_Prisma_fit_167006.txt"))
+
+    def test_cli_dynamic_opt_cs_gradient_volume(self, nii_fmap, nii_target, nii_mask, nii_softmask, fm_data, target_data):
+        """ Test the gradient-cs --opt-cs. When using pseudo inverse, the results should be the same as shim-cs. """
+        with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+            # Save the inputs to the new directory
+            fname_fmap = os.path.join(tmp, 'fmap.nii.gz')
+            fname_fm_json = os.path.join(tmp, 'fmap.json')
+            fname_mask = os.path.join(tmp, 'mask.nii.gz')
+            fname_softmask = os.path.join(tmp, 'softmask.nii.gz')
+            fname_target = os.path.join(tmp, 'target.nii.gz')
+            fname_target_json = os.path.join(tmp, 'target.json')
+            nii_fmap = nib.Nifti1Image(nii_fmap.get_fdata()[..., 0], nii_fmap.affine, header=nii_fmap.header)
+            _save_inputs(nii_fmap=nii_fmap, fname_fmap=fname_fmap,
+                         nii_target=nii_target, fname_target=fname_target,
+                         nii_mask=nii_mask, fname_mask=fname_mask,
+                         nii_softmask=nii_softmask, fname_softmask=fname_softmask,
+                         fm_data=fm_data, fname_fm_json=fname_fm_json,
+                         target_data=target_data, fname_target_json=fname_target_json)
+
+            runner = CliRunner()
+            res = runner.invoke(b0shim_cli, ['dynamic',
+                                             '--fmap', fname_fmap,
+                                             '--mask', fname_mask,
+                                             '--target', fname_target,
+                                             '--optimizer-method', 'pseudo_inverse',
+                                             '--slices', 'volume',
+                                             '--scanner-coil-order', '0,1',
+                                             '--opt-cs', 'gradient-cs',
+                                             '--output', tmp],
+                                catch_exceptions=False)
+            assert res.exit_code == 0
+            assert os.path.isfile(os.path.join(tmp, "coefs_coil0_Prisma_fit_167006.txt"))
+            # Read json sidecar and look at the calues
+            with open(os.path.join(tmp, 'fieldmap_calculated_shim.json'), 'r') as f:
+                data = json.load(f)
+            assert data['ImagingFrequency'] == 123.258971
+            assert np.allclose(data['ShimSetting'], [665.0, -7442.95, -9991.09], atol=1e-6)
 
     def test_cli_dynamic_opt_cs_gradient_same_shim_cs(self, nii_fmap, nii_target, nii_mask, nii_softmask, fm_data, target_data):
         """ Test the gradient-cs --opt-cs. When using pseudo inverse, the results should be the same as shim-cs. """

--- a/shimming-toolbox/test/shim/test_scanner_shim_settings.py
+++ b/shimming-toolbox/test/shim/test_scanner_shim_settings.py
@@ -1,0 +1,55 @@
+#!usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import logging
+import numpy as np
+import pytest
+
+from shimmingtoolbox.coils.scanner_shim_settings import dac_to_shim_units, logger
+
+
+class TestDacToShimUnits:
+
+    def test_dac_to_shim_units_prisma_fit(self):
+        dac_units = {'1': [14436, 14265, 14045], '2': [9998, 9998, 9998, 9998, 9998],
+                     'order1_is_valid': True, 'order2_is_valid': True}
+        ui_units = dac_to_shim_units('Siemens', 'Prisma_fit', '167006', dac_units)
+        assert np.all(np.isclose(ui_units['1'], [2300, 2300, 2300]))
+        assert np.all(np.isclose(ui_units['2'], [4959.01, 3551.29, 3503.299, 3551.29, 3487.302]))
+
+    def test_dac_to_shim_units_investigational_device_7t(self):
+        dac_units = {'1': [62479, 62264, 54082], '2': [18000, 18000, 18000, 18000, 18000],
+                     'order1_is_valid': True, 'order2_is_valid': True}
+        ui_units = dac_to_shim_units('Siemens', 'Investigational_Device_7T', '18923', dac_units)
+        assert np.all(np.isclose(ui_units['1'], [4999.976, 4999.980, 4999.957]))
+        assert np.all(np.isclose(ui_units['2'], [6163.200, 2592.000, 2592.000, 2476.800, 2476.800]))
+
+    def test_dac_to_shim_units_terra(self):
+        dac_units = {'1': [17729, 18009, 17872], '2': [12500.0] * 5,
+                     'order1_is_valid': True, 'order2_is_valid': True}
+        ui_units = dac_to_shim_units('Siemens', 'Terra', '79121', dac_units)
+        assert np.all(np.isclose(ui_units['1'], [3000] * 3))
+        assert np.all(np.isclose(ui_units['2'], [9360.0, 4680.0, 4620.0, 4620.0, 4560.0]))
+
+    def test_dac_to_shim_units_0(self):
+        dac_units = {'1': [0, 0, 0], '2': [0, 0, 0, 0, 0],
+                     'order1_is_valid': True, 'order2_is_valid': True}
+        ui_units = dac_to_shim_units('Siemens', 'Prisma_fit', '167006', dac_units)
+        assert np.all(np.isclose(ui_units['1'], [0, 0, 0]))
+        assert np.all(np.isclose(ui_units['2'], [0, 0, 0, 0, 0]))
+
+    def test_dac_to_shim_units_unknown_scanner(self, caplog):
+        dac_units = {'1': [14436, 14265, 14045], '2': [9998, 9998, 9998, 9998, 9998],
+                     'order1_is_valid': True, 'order2_is_valid': True}
+
+        with caplog.at_level(logging.DEBUG, logger.name):
+            dac_to_shim_units('Unknown', 'Unknown', '167006', dac_units)
+
+        assert "Unknown not implemented or does not include enough metadata information" in caplog.text
+
+    def test_dac_to_shim_units_outside_bounds(self):
+        dac_units = {'1': [20000, 14265, 14045], '2': [9998, 9998, 9998, 9998, 9998],
+                     'order1_is_valid': True, 'order2_is_valid': True}
+
+        with pytest.raises(ValueError, match="Current shim settings exceed known system limits."):
+            dac_to_shim_units('Siemens', 'Prisma_fit', '167006', dac_units)

--- a/shimming-toolbox/test/shim/test_shim_utils.py
+++ b/shimming-toolbox/test/shim/test_shim_utils.py
@@ -2,63 +2,15 @@
 # -*- coding: utf-8
 
 import json
-import logging
 import nibabel as nib
 import numpy as np
 import os
 import pytest
 
-from shimmingtoolbox.shim.shim_utils import (dac_to_shim_units, phys_to_shim_cs, shim_to_phys_cs,
-                                             calculate_metric_within_mask, logger, phys_to_gradient_cs,
+from shimmingtoolbox.shim.shim_utils import (phys_to_shim_cs, shim_to_phys_cs,
+                                             calculate_metric_within_mask, phys_to_gradient_cs,
                                              gradient_to_phys_cs)
 from shimmingtoolbox.coils.coordinates import get_main_orientation
-
-
-class TestDacToShimUnits:
-
-    def test_dac_to_shim_units_prisma_fit(self):
-        dac_units = {'1': [14436, 14265, 14045], '2': [9998, 9998, 9998, 9998, 9998],
-                     'order1_is_valid': True, 'order2_is_valid': True}
-        ui_units = dac_to_shim_units('Siemens', 'Prisma_fit', '167006', dac_units)
-        assert np.all(np.isclose(ui_units['1'], [2300, 2300, 2300]))
-        assert np.all(np.isclose(ui_units['2'], [4959.01, 3551.29, 3503.299, 3551.29, 3487.302]))
-
-    def test_dac_to_shim_units_investigational_device_7t(self):
-        dac_units = {'1': [62479, 62264, 54082], '2': [18000, 18000, 18000, 18000, 18000],
-                     'order1_is_valid': True, 'order2_is_valid': True}
-        ui_units = dac_to_shim_units('Siemens', 'Investigational_Device_7T', '18923', dac_units)
-        assert np.all(np.isclose(ui_units['1'], [4999.976, 4999.980, 4999.957]))
-        assert np.all(np.isclose(ui_units['2'], [6163.200, 2592.000, 2592.000, 2476.800, 2476.800]))
-
-    def test_dac_to_shim_units_terra(self):
-        dac_units = {'1': [17729, 18009, 17872], '2': [12500.0] * 5,
-                     'order1_is_valid': True, 'order2_is_valid': True}
-        ui_units = dac_to_shim_units('Siemens', 'Terra', '79121', dac_units)
-        assert np.all(np.isclose(ui_units['1'], [3000] * 3))
-        assert np.all(np.isclose(ui_units['2'], [9360.0, 4680.0, 4620.0, 4620.0, 4560.0]))
-
-    def test_dac_to_shim_units_0(self):
-        dac_units = {'1': [0, 0, 0], '2': [0, 0, 0, 0, 0],
-                     'order1_is_valid': True, 'order2_is_valid': True}
-        ui_units = dac_to_shim_units('Siemens', 'Prisma_fit', '167006', dac_units)
-        assert np.all(np.isclose(ui_units['1'], [0, 0, 0]))
-        assert np.all(np.isclose(ui_units['2'], [0, 0, 0, 0, 0]))
-
-    def test_dac_to_shim_units_unknown_scanner(self, caplog):
-        dac_units = {'1': [14436, 14265, 14045], '2': [9998, 9998, 9998, 9998, 9998],
-                     'order1_is_valid': True, 'order2_is_valid': True}
-
-        with caplog.at_level(logging.DEBUG, logger.name):
-            dac_to_shim_units('Unknown', 'Unknown', '167006', dac_units)
-
-        assert "Unknown not implemented or does not include enough metadata information" in caplog.text
-
-    def test_dac_to_shim_units_outside_bounds(self):
-        dac_units = {'1': [20000, 14265, 14045], '2': [9998, 9998, 9998, 9998, 9998],
-                     'order1_is_valid': True, 'order2_is_valid': True}
-
-        with pytest.raises(ValueError, match="Current shim settings exceed known system limits."):
-            dac_to_shim_units('Siemens', 'Prisma_fit', '167006', dac_units)
 
 
 def test_phys_to_shim_cs():

--- a/shimming-toolbox/test/shim/test_shim_utils.py
+++ b/shimming-toolbox/test/shim/test_shim_utils.py
@@ -9,7 +9,7 @@ import pytest
 
 from shimmingtoolbox.shim.shim_utils import (phys_to_shim_cs, shim_to_phys_cs,
                                              calculate_metric_within_mask, phys_to_gradient_cs,
-                                             gradient_to_phys_cs)
+                                             gradient_to_phys_cs, get_flip_matrix)
 from shimmingtoolbox.coils.coordinates import get_main_orientation
 
 
@@ -153,3 +153,38 @@ def create_nifti(orientation, phase_encode_dir, path_output):
     with open(fname_json, "w") as f:
         json.dump(data_json, f)
     return fname_nii
+
+
+class TestGetFlipMatrix:
+    def test_flip_cs(self):
+        out = get_flip_matrix('RAS', orders=[1, ])
+        assert np.all(out == [1, 1, 1])
+
+    def test_flip_cs_lpi(self):
+        out = get_flip_matrix('LPI', orders=[1, ])
+        assert np.all(out == [-1, -1, -1])
+
+    def test_flip_cs_order2(self):
+        out = get_flip_matrix('LAI', orders=[1, 2])
+        assert np.all(out == [1, -1, -1, -1, -1, 1, 1, 1])
+
+    def test_flip_cs_len4(self):
+        with pytest.raises(ValueError, match="Unknown coordinate system"):
+            get_flip_matrix('LAIS')
+
+    def test_flip_cs_lap(self):
+        with pytest.raises(ValueError, match="Unknown coordinate system"):
+            get_flip_matrix('LAP')
+
+    def test_flip_siemens(self):
+        out = get_flip_matrix('LAI', orders=[1, 2, 3], manufacturer='Siemens')
+        # TODO: Verify 3rd order
+        assert np.all(out == [-1, 1, -1, 1, 1, -1, 1, -1, -1, -1, 1, -1])
+
+    def test_flip_ge(self):
+        out = get_flip_matrix('LPI', orders=[1, 2], manufacturer='GE')
+        assert np.all(out == [-1, -1, -1, 1, 1, 1, 1, 1])
+
+    def test_flip_philips(self):
+        out = get_flip_matrix('RPI', orders=[1, 2], manufacturer='PHILIPS')
+        assert np.all(out == [1, -1, -1, 1, -1, 1, 1, -1])

--- a/shimming-toolbox/test/test_coil.py
+++ b/shimming-toolbox/test/test_coil.py
@@ -1,13 +1,14 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-import copy
 
-import numpy as np
+import copy
 import json
+import numpy as np
+import os
 
 from shimmingtoolbox.coils.coil import Coil, ScannerCoil, get_scanner_constraints, SCANNER_CONSTRAINTS
 from shimmingtoolbox.coils.spher_harm_basis import siemens_basis
-from shimmingtoolbox import __config_scanner_constraints__
+from shimmingtoolbox import __config_scanner_constraints__, __dir_testing__
 
 shim_settings = {
     '0': [1],
@@ -133,7 +134,7 @@ def test_create_scanner_coil_not_isocenter():
     scanner_coil = ScannerCoil((3, 3, 3), affine, sph_contraints, [0, 1, 2], 'SIEMENS',
                                isocenter=np.array([3, 4, 5]))
 
-    # assert np.all(scanner_coil.isocenter == [3, 4, 5])
+    assert np.allclose(scanner_coil.isocenter, [3, 4, 5])
     assert np.allclose(scanner_coil.profile[0, 0, 1, :], [-1,  1.70309914e-01, -2.12887393e-01,
                                                           2.12887393e-01, 1.91598653e-04,  1.70309914e-03,
                                                           -2.12887393e-03, -3.83197307e-04, -1.70309914e-03])
@@ -143,6 +144,34 @@ def test_create_scanner_coil_not_isocenter():
     assert np.allclose(scanner_coil.profile[1, 0, 0, :], [-1,  1.27732436e-01, -2.12887393e-01,
                                                           2.55464871e-01, 8.08972092e-04, 1.53278923e-03,
                                                           -2.55464871e-03, -6.81239656e-04, -1.27732436e-03])
+
+
+def test_create_scanner_coil_gradient_cs():
+    sph_contraints = json.load(open(__config_scanner_constraints__))
+    affine = np.array([[1, 0, 0, -1], [0, 1, 0, -1], [0, 0, 1, -1], [0, 0, 0, 1]])
+    fname_target = os.path.join(__dir_testing__, "ds_b0", "sub-fieldmap", "fmap", "sub-1_acq-gre_magnitude1.nii.gz")
+    scanner_coil = ScannerCoil((3, 3, 3), affine, sph_contraints, [0, 1], 'SIEMENS',
+                               isocenter=np.array([3, 4, 5]), opt_cs="gradient-cs", fname_target=fname_target)
+
+    assert np.allclose(scanner_coil.coef_channel_minmax['1'], [[-2300.0, 2300.0],
+                                                               [-2542.0446737374277, 2542.0446737374277],
+                                                               [-2542.0451880969194, 2542.0451880969194]])
+    assert np.allclose(scanner_coil.coef_channel_minmax['0'], [[123100100, 123265000]])
+    assert np.allclose(scanner_coil.profile[0, 0, 1, :], [-1, -0.17030991, 0.23529098, -0.18783028])
+    assert np.allclose(scanner_coil.profile[0, 1, 0, :], [-1, -0.17030991, 0.19772492, -0.23488849])
+    assert np.allclose(scanner_coil.profile[1, 0, 0, :], [-1, -0.12773244, 0.24003705, -0.23014241])
+    assert np.allclose(scanner_coil.profile[:, 0, 0, 0], [-1., -1., -1.])
+    # fname_target is not perfectly axial, field map is perfectly axial, therefore gradient axes x, y, z are in
+    # freq, phase, slice respectively
+    assert np.allclose(scanner_coil.profile[:, 0, 0, 1], [-0.17030991, -0.12773244, -0.08515496])
+    assert np.allclose(scanner_coil.profile[0, :, 0, 1], [-0.17030991, -0.17030991, -0.17030991])
+    assert np.allclose(scanner_coil.profile[0, 0, :, 1], [-0.17030991, -0.17030991, -0.17030991])
+    assert np.allclose(scanner_coil.profile[:, 0, 0, 2], [[0.24003705, 0.24003705, 0.24003705]])
+    assert np.allclose(scanner_coil.profile[0, :, 0, 2], [[0.24003705, 0.19772492, 0.15541278]])
+    assert np.allclose(scanner_coil.profile[0, 0, :, 2], [[0.24003705, 0.23529098, 0.23054492]])
+    assert np.allclose(scanner_coil.profile[:, 0, 0, 3], [[-0.23014241, -0.23014241, -0.23014241]])
+    assert np.allclose(scanner_coil.profile[0, :, 0, 3], [[-0.23014241, -0.23488849, -0.23963456]])
+    assert np.allclose(scanner_coil.profile[0, 0, :, 3], [[-0.23014241, -0.18783028, -0.14551815]])
 
 
 def test_create_scanner_coil_philips():

--- a/shimming-toolbox/test/test_spher_harm_basis.py
+++ b/shimming-toolbox/test/test_spher_harm_basis.py
@@ -6,7 +6,7 @@ import numpy as np
 import os
 import pytest
 
-from shimmingtoolbox.coils.spher_harm_basis import sh_basis, siemens_basis, ge_basis, philips_basis, get_flip_matrix
+from shimmingtoolbox.coils.spher_harm_basis import sh_basis, siemens_basis, ge_basis, philips_basis
 from shimmingtoolbox.coils.coordinates import generate_meshgrid
 from shimmingtoolbox import __dir_testing__
 
@@ -260,38 +260,3 @@ def test_siemens_basis_resample():
 
     nx, ny, nz = nii.get_fdata().shape
     assert (np.all(np.isclose(basis[int(nx / 2), int(ny / 2), int(nz / 2), :], expected, rtol=1e-05)))
-
-
-class TestGetFlipMatrix:
-    def test_flip_cs(self):
-        out = get_flip_matrix('RAS', orders=[1, ])
-        assert np.all(out == [1, 1, 1])
-
-    def test_flip_cs_lpi(self):
-        out = get_flip_matrix('LPI', orders=[1, ])
-        assert np.all(out == [-1, -1, -1])
-
-    def test_flip_cs_order2(self):
-        out = get_flip_matrix('LAI', orders=[1, 2])
-        assert np.all(out == [1, -1, -1, -1, -1, 1, 1, 1])
-
-    def test_flip_cs_len4(self):
-        with pytest.raises(ValueError, match="Unknown coordinate system"):
-            get_flip_matrix('LAIS')
-
-    def test_flip_cs_lap(self):
-        with pytest.raises(ValueError, match="Unknown coordinate system"):
-            get_flip_matrix('LAP')
-
-    def test_flip_siemens(self):
-        out = get_flip_matrix('LAI', orders=[1, 2, 3], manufacturer='Siemens')
-        # TODO: Verify 3rd order
-        assert np.all(out == [-1, 1, -1, 1, 1, -1, 1, -1, -1, -1, 1, -1])
-
-    def test_flip_ge(self):
-        out = get_flip_matrix('LPI', orders=[1, 2], manufacturer='GE')
-        assert np.all(out == [-1, -1, -1, 1, 1, 1, 1, 1])
-
-    def test_flip_philips(self):
-        out = get_flip_matrix('RPI', orders=[1, 2], manufacturer='PHILIPS')
-        assert np.all(out == [1, -1, -1, 1, -1, 1, 1, -1])


### PR DESCRIPTION
## Description
This PR adds the ability to optimize in the gradient coordinate system. In conjunction with `--off-channels` this allow to turn off the frequency encoding direction for example whereas before we could only turn off specific world coordinate axes (x, y, z)

Todo:
- [x] Verify bounds are correct

## Linked issues
Fixes #670 