### PR TITLE
Don't display fig_currents if it's volume shim (only 1 set of currents)

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
+++ b/shimming-toolbox/shimmingtoolbox/shim/sequencer.py
@@ -652,6 +652,11 @@ class ShimSequencer(Sequencer):
         Args:
             static (np.ndarray): Array with the static coefficients
         """
+
+        # Cannot see the evolution of the currents through shims if there is only one
+        if len(self.slices) == 1:
+            return
+
         fig = Figure(figsize=(10, 10))
         ax = fig.add_subplot(111)
         n_channels = static.shape[1]


### PR DESCRIPTION
## Description
Skip generating the fig_currents figure if we do volume shim as there is only one to show.
