### PR TITLE
Allow using relative paths without ./

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/utils.py
+++ b/shimming-toolbox/shimmingtoolbox/utils.py
@@ -160,15 +160,16 @@ def create_output_dir(path_output, is_file=False, output_folder_name="output"):
     """Given a path, create the directory if it doesn't exist.
 
     Args:
-        path_output (str): Full path to either a folder or a file.
+        path_output (str): Path, preferably a full path to either a folder or a file. Relative paths will be expanded using current working directory.
         is_file (bool): True if the ``path_output`` is for a file, else False.
         output_folder_name (str): Name of sub-folder.
     """
+    path_output = os.path.expanduser(path_output)
 
     if is_file:
-        path_output_folder = os.path.dirname(path_output)
+        path_output_folder = os.path.dirname(os.path.abspath(path_output))
     else:
-        path_output_folder = path_output
+        path_output_folder = os.path.abspath(path_output)
     if not os.path.exists(path_output_folder):
         os.makedirs(path_output_folder)
 

--- a/shimming-toolbox/shimmingtoolbox/utils.py
+++ b/shimming-toolbox/shimmingtoolbox/utils.py
@@ -160,7 +160,7 @@ def create_output_dir(path_output, is_file=False, output_folder_name="output"):
     """Given a path, create the directory if it doesn't exist.
 
     Args:
-        path_output (str): Path, preferably a full path to either a folder or a file. Relative paths will be expanded using current working directory.
+        path_output (str): Path to either a folder or a file. Relative paths will be expanded using current working directory.
         is_file (bool): True if the ``path_output`` is for a file, else False.
         output_folder_name (str): Name of sub-folder.
     """

--- a/shimming-toolbox/test/cli/test_cli_mask.py
+++ b/shimming-toolbox/test/cli/test_cli_mask.py
@@ -106,11 +106,10 @@ def test_cli_mask_threshold():
 
 
 def test_cli_mask_rel_path():
-    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
-        runner = CliRunner()
-
-        os.chdir(tmp)
-        shutil.copy(os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz'), tmp)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        path_cwd = os.getcwd()
+        shutil.copy(os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz'), path_cwd)
         fname_input = 'sub-fieldmap_magnitude1.nii.gz'
         fname_out = 'mask.nii.gz'
         thr = 780
@@ -118,7 +117,7 @@ def test_cli_mask_rel_path():
                                catch_exceptions=False)
 
         assert result.exit_code == 0
-        assert os.path.isfile(os.path.join(tmp, fname_out))
+        assert os.path.isfile(os.path.join(path_cwd, fname_out))
 
 
 

--- a/shimming-toolbox/test/cli/test_cli_mask.py
+++ b/shimming-toolbox/test/cli/test_cli_mask.py
@@ -120,7 +120,6 @@ def test_cli_mask_rel_path():
         assert os.path.isfile(os.path.join(path_cwd, fname_out))
 
 
-
 def test_cli_mask_threshold_scaled():
     with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
         runner = CliRunner()

--- a/shimming-toolbox/test/cli/test_cli_mask.py
+++ b/shimming-toolbox/test/cli/test_cli_mask.py
@@ -6,10 +6,10 @@ import tempfile
 import os
 import nibabel as nib
 import pytest
+import shutil
 
 from click.testing import CliRunner
 from shimmingtoolbox.cli.mask import mask_cli
-from shimmingtoolbox.utils import run_subprocess
 from shimmingtoolbox import __dir_testing__
 
 inp = os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz')
@@ -103,6 +103,23 @@ def test_cli_mask_threshold():
 
         assert result.exit_code == 0
         assert np.all(mask[58:62, 28:31, 7:9] == expected)
+
+
+def test_cli_mask_rel_path():
+    with tempfile.TemporaryDirectory(prefix='st_' + pathlib.Path(__file__).stem) as tmp:
+        runner = CliRunner()
+
+        os.chdir(tmp)
+        shutil.copy(os.path.join(__dir_testing__, 'ds_b0', 'sub-fieldmap', 'fmap', 'sub-fieldmap_magnitude1.nii.gz'), tmp)
+        fname_input = 'sub-fieldmap_magnitude1.nii.gz'
+        fname_out = 'mask.nii.gz'
+        thr = 780
+        result = runner.invoke(mask_cli, ['threshold', '--input', fname_input, '--output', fname_out, '--thr', thr],
+                               catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert os.path.isfile(os.path.join(tmp, fname_out))
+
 
 
 def test_cli_mask_threshold_scaled():


### PR DESCRIPTION
## Description
There was a bug where relative paths could not be used as output files (e.g.: `path_output.nii`). This PR fixes that issue.

## Linked issues
Fixes #674 