### PR TITLE
Add missing default option from gaussian-filter option

### DIFF
--- a/shimming-toolbox/shimmingtoolbox/cli/prepare_fieldmap.py
+++ b/shimming-toolbox/shimmingtoolbox/cli/prepare_fieldmap.py
@@ -39,7 +39,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    "than the threshold are set to 0.")
 @click.option('--savemask', 'fname_save_mask', type=click.Path(),
               help="Filename of the mask calculated by the unwrapper")
-@click.option('--gaussian-filter', 'gaussian_filter', type=bool, show_default=True, help="Gaussian filter for B0 map")
+@click.option('--gaussian-filter', 'gaussian_filter', type=bool, default=False, show_default=True, help="Gaussian filter for B0 map")
 @click.option('--sigma', type=float, default=1, help="Standard deviation of gaussian filter. Used for: gaussian_filter")
 @click.option('--2d', 'process_in_2d', type=bool, show_default=True, default=False,
               help="Unwrap and filter slice by slice. Defaults to False, which unwraps the whole 3D volume at once.")


### PR DESCRIPTION
## Checklist

- [x] I've given this PR a concise, self-descriptive, and meaningful title
- [x] I've linked relevant issues in the PR body
- [x] I've applied the relevant labels to this PR. (You need to choose: the scope of the PR, 1 or more (pale brown), the main reason for the PR, only 1 (dark purple) and if applicable, the CLI affected (dark cyan))
- [x] I've added relevant tests for my contribution
- [x] I've updated the documentation and/or added correct docstrings
- [x] I've assigned a reviewer

<!--- For the title, please observe the following rules:
	- Provide a concise and self-descriptive title
	- Do not include the applicable issue number in the title, do it in the PR body
	- If the PR is not ready for review, convert it to a draft.
-->

## Description
<!-- describe what the PR is about. Explain the approach and possible drawbacks.It's ok to repeat some text from the related issue. -->
Adding the missing default value from the gaussian-filter option of the st_prepare_fieldmap command, so it shows up in the docs instead of Sentinel.UNSET.
## Linked issues
<!-- If the PR fixes any issues, indicate it here with issue-closing keywords: e.g. Resolves #XX, Fixes #XX, Addresses #XX. Note that if you want multiple issues to be autoclosed on PR merge, you must use the issue-closing verb before each relevant issue: e.g. Resolves #1, Resolves #2 -->
